### PR TITLE
Upload and embed images in issue descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ issue-dev makes every GitHub issue a self-contained work order — enriched with
 
 | Command | What It Does |
 |---------|-------------|
-| `/issue-creator` | Scans your codebase, classifies the type, generates acceptance criteria, creates a structured issue |
+| `/issue-creator` | Scans your codebase, classifies the type, generates acceptance criteria, uploads screenshots, creates a structured issue |
 | `/issue-resolver N` | Fetches the issue, creates a branch, researches files, writes code + tests, opens a PR with "Closes #N" |
 | `/issue-triage` | Builds a dependency graph, detects stale issues, suggests priority and execution order |
 | `/init-gitissue` | Detects your language/framework/test runner and generates a `.gitissue.yml` config |
@@ -43,6 +43,7 @@ Every issue created or normalized by issue-dev includes:
 - **Acceptance criteria** derived from the problem description and codebase
 - **Technical notes** — architecture constraints, test coverage, breaking change risk
 - **Reporter's original text** preserved verbatim
+- **Embedded screenshots** — images uploaded to GitHub and embedded inline in the issue body
 
 ## How It Works
 
@@ -255,7 +256,7 @@ npx skills add https://github.com/luongnv89/idd
 | `/issue-creator <N> --force` | Force | Normalize even if issue has a security label |
 | `/issue-creator <multi-item text>` | Batch | Extract and create multiple issues from one input |
 
-**Create mode** scans the codebase for relevant files, classifies the issue type (bug/feature/improvement), generates acceptance criteria, and creates a structured issue via `gh issue create`.
+**Create mode** scans the codebase for relevant files, classifies the issue type (bug/feature/improvement), generates acceptance criteria, uploads any provided screenshots to GitHub (embedded inline in the issue body), and creates a structured issue via `gh issue create`.
 
 **Normalize mode** enriches an existing unstructured issue: preserves the original text in a Reporter Context blockquote, adds affected files with confidence levels, generates acceptance criteria, and posts a backup before editing.
 

--- a/skills/issue-creator/SKILL.md
+++ b/skills/issue-creator/SKILL.md
@@ -84,27 +84,21 @@ For each image path provided:
 
 2. **Upload via GitHub API** — use the repository contents API to commit the image to `.github/issue-assets/`:
    ```bash
-   # Base64-encode the image
-   base64_content=$(base64 < "{image_path}")
+   # Base64-encode the image (cross-platform: try Linux -w0 flag first, fall back to macOS)
+   base64_content=$(base64 -w0 < "{image_path}" 2>/dev/null || base64 < "{image_path}")
 
    # Generate a unique filename: timestamp + original name
    filename="$(date +%Y%m%d%H%M%S)-{original_filename}"
 
-   # Upload via gh api
-   gh api repos/{owner}/{repo}/contents/.github/issue-assets/{filename} \
-     --method PUT \
-     --field message="Upload image for issue: {filename}" \
-     --field content="$base64_content"
-   ```
-
-3. **Extract the URL** — the API response includes `download_url`. Use this for the markdown embed. Parse the response:
-   ```bash
-   gh api repos/{owner}/{repo}/contents/.github/issue-assets/{filename} \
+   # Upload via gh api and capture the download URL
+   download_url=$(gh api repos/{owner}/{repo}/contents/.github/issue-assets/{filename} \
      --method PUT \
      --field message="Upload image for issue: {filename}" \
      --field content="$base64_content" \
-     --jq '.content.download_url'
+     --jq '.content.download_url')
    ```
+
+3. **Extract the URL** — the upload command in Step 2 already captures `download_url` via `--jq`. Verify it is non-empty before proceeding. If empty, treat as an upload failure.
 
 4. **Build the markdown** — create an image embed for each uploaded file:
    ```markdown
@@ -244,8 +238,8 @@ Read the appropriate template from `templates/` (bug.md, feature.md, or improvem
 1. **Type** — classified type
 2. **Context** — affected files with confidence levels, current behavior (bugs), related components, related issues
 3. **Description** — synthesized from user input, enriched with codebase context
-4. **Screenshots** — embedded images (only if images were provided and uploaded successfully)
-5. **Reporter Context** — user's original text, verbatim, in a blockquote
+4. **Reporter Context** — user's original text, verbatim, in a blockquote
+5. **Screenshots** — embedded images (only if images were provided and uploaded successfully)
 6. **Acceptance Criteria** — 3-5 testable criteria based on the problem and codebase context
 7. **Technical Notes** — architecture constraints from reading affected files, test coverage status, breaking change risk
 8. **Metadata** — suggested priority, estimated effort (XS/S/M/L/XL), suggested labels with confidence levels

--- a/skills/issue-creator/SKILL.md
+++ b/skills/issue-creator/SKILL.md
@@ -21,7 +21,7 @@ Three modes: **Create** (new issue from text/image), **Normalize** (enrich exist
 
 Detect mode: if the argument is a number → Normalize. If the input contains multiple distinct items (numbered list, bullet points, multiple paragraphs describing different problems, or a planning document with several work items) → Batch. Otherwise → Create.
 
-**Image/screenshot input**: When the user provides an image path or screenshot, read the image with the Read tool to extract visual context, then treat extracted information as the input description. Combine visual observations with any accompanying text.
+**Image/screenshot input**: When the user provides an image path or screenshot, read the image with the Read tool to extract visual context, then treat extracted information as the input description. Combine visual observations with any accompanying text. Additionally, upload the image to GitHub and embed it in the issue body — see the **Image Upload** section below.
 
 ## Prerequisites
 
@@ -64,6 +64,98 @@ Load `.gitissue.yml` from the repo root once at skill start. If the file does no
 Defaults: `issue.auto_normalize: true`, `issue.template: "default"`, `issue.labels_auto_suggest: true`, `issue.normalize_comment: true`
 
 Do not re-read the config at each step.
+
+## Image Upload
+
+When the user provides one or more image paths (e.g., screenshots, photos, diagrams), upload each image to GitHub and embed it in the issue body. This happens **in addition to** reading the image for visual context extraction.
+
+### Supported formats
+
+PNG, JPG/JPEG, GIF, WEBP, SVG. Maximum file size: 10 MB per image (GitHub's limit).
+
+### Upload procedure
+
+For each image path provided:
+
+1. **Validate the file** — confirm it exists, is a supported format, and is under 10 MB:
+   ```bash
+   test -f "{image_path}" && stat -f%z "{image_path}" 2>/dev/null || stat -c%s "{image_path}" 2>/dev/null
+   ```
+
+2. **Upload via GitHub API** — use the repository contents API to commit the image to `.github/issue-assets/`:
+   ```bash
+   # Base64-encode the image
+   base64_content=$(base64 < "{image_path}")
+
+   # Generate a unique filename: timestamp + original name
+   filename="$(date +%Y%m%d%H%M%S)-{original_filename}"
+
+   # Upload via gh api
+   gh api repos/{owner}/{repo}/contents/.github/issue-assets/{filename} \
+     --method PUT \
+     --field message="Upload image for issue: {filename}" \
+     --field content="$base64_content"
+   ```
+
+3. **Extract the URL** — the API response includes `download_url`. Use this for the markdown embed. Parse the response:
+   ```bash
+   gh api repos/{owner}/{repo}/contents/.github/issue-assets/{filename} \
+     --method PUT \
+     --field message="Upload image for issue: {filename}" \
+     --field content="$base64_content" \
+     --jq '.content.download_url'
+   ```
+
+4. **Build the markdown** — create an image embed for each uploaded file:
+   ```markdown
+   ![{original_filename}]({download_url})
+   ```
+
+### Placement in issue body
+
+Embed uploaded images in a **Screenshots** section placed between the Description and Acceptance Criteria sections:
+
+```markdown
+## Screenshots
+
+![screenshot-1.png](https://raw.githubusercontent.com/owner/repo/main/.github/issue-assets/20260320120000-screenshot-1.png)
+
+![error-log.png](https://raw.githubusercontent.com/owner/repo/main/.github/issue-assets/20260320120001-error-log.png)
+```
+
+If no images are provided, omit the Screenshots section entirely.
+
+### Multiple images
+
+When multiple images are provided, upload each sequentially and embed all of them in the Screenshots section. Number them if the user did not provide descriptive filenames:
+
+```markdown
+## Screenshots
+
+![Screenshot 1](url1)
+
+![Screenshot 2](url2)
+```
+
+### Failure handling
+
+If an image upload fails, do **not** block issue creation. Create the issue with text context only and warn:
+
+```
+⚠ Image upload failed: {filename} — {reason}
+  Issue created without embedded image.
+  Tip: upload the image manually via GitHub's web UI.
+```
+
+Reasons include: file not found, unsupported format, file too large (>10 MB), API error, permission denied.
+
+If some images in a batch succeed and others fail, embed the successful ones and warn about the failures.
+
+### Normalization mode
+
+When normalizing an existing issue that mentions image paths or contains image URLs, preserve existing images. Do not re-upload images that are already embedded with `![...]()` syntax.
+
+---
 
 ## Confidence Scoring System
 
@@ -145,15 +237,18 @@ Compare the new issue's title and key terms against existing issues. If a potent
 
 ### Step 5 — Generate Issue Content
 
+If the user provided image paths, upload them now using the **Image Upload** procedure. Collect the resulting markdown embeds for inclusion in the issue body.
+
 Read the appropriate template from `templates/` (bug.md, feature.md, or improvement.md) and populate every section:
 
 1. **Type** — classified type
 2. **Context** — affected files with confidence levels, current behavior (bugs), related components, related issues
 3. **Description** — synthesized from user input, enriched with codebase context
-4. **Reporter Context** — user's original text, verbatim, in a blockquote
-5. **Acceptance Criteria** — 3-5 testable criteria based on the problem and codebase context
-6. **Technical Notes** — architecture constraints from reading affected files, test coverage status, breaking change risk
-7. **Metadata** — suggested priority, estimated effort (XS/S/M/L/XL), suggested labels with confidence levels
+4. **Screenshots** — embedded images (only if images were provided and uploaded successfully)
+5. **Reporter Context** — user's original text, verbatim, in a blockquote
+6. **Acceptance Criteria** — 3-5 testable criteria based on the problem and codebase context
+7. **Technical Notes** — architecture constraints from reading affected files, test coverage status, breaking change risk
+8. **Metadata** — suggested priority, estimated effort (XS/S/M/L/XL), suggested labels with confidence levels
 
 ### Step 6 — Preview and Confirm
 
@@ -166,11 +261,14 @@ Read the appropriate template from `templates/` (bug.md, feature.md, or improvem
   Type:     bug (high)
   Title:    Fix mobile auth redirect loop
   Files:    auth.py (high), middleware.py (high), config.py (medium)
+  Images:   2 uploaded ✓
   Labels:   bug (high), auth (medium), mobile (medium)
   Criteria: 3 acceptance criteria generated (medium)
 
 Create issue? [Y/n]
 ```
+
+The `Images:` line appears only when images were provided. Show count and upload status. If some failed: `Images: 1/2 uploaded (1 failed)`.
 
 Wait for confirmation. If declined, stop without creating.
 

--- a/skills/issue-creator/references/error-messages.md
+++ b/skills/issue-creator/references/error-messages.md
@@ -139,6 +139,53 @@ All errors follow the rich error format: what went wrong + fix command + docs li
 **Trigger:** Batch detection finds only one distinct item in the input. Falls through to single Create mode.
 **Note:** This is an informational message, not an error.
 
+## Image Upload
+
+### Image file not found
+```
+⚠ Image upload failed: {filename} — file not found
+  Issue created without embedded image.
+  Tip: upload the image manually via GitHub's web UI.
+```
+**Trigger:** The provided image path does not exist on disk.
+
+### Unsupported image format
+```
+⚠ Image upload failed: {filename} — unsupported format
+  Issue created without embedded image.
+  Supported: PNG, JPG, JPEG, GIF, WEBP, SVG
+  Tip: convert the image and retry, or upload manually via GitHub's web UI.
+```
+**Trigger:** The file extension is not in the supported list (png, jpg, jpeg, gif, webp, svg).
+
+### Image too large
+```
+⚠ Image upload failed: {filename} — file too large ({size} MB, max 10 MB)
+  Issue created without embedded image.
+  Tip: resize or compress the image, or upload manually via GitHub's web UI.
+```
+**Trigger:** The file size exceeds 10 MB (GitHub API limit for contents API).
+
+### Image upload API error
+```
+⚠ Image upload failed: {filename} — GitHub API error
+  Issue created without embedded image.
+  To fix:  check your permissions: gh api repos/{owner}/{repo}/contents
+  Tip: upload the image manually via GitHub's web UI.
+```
+**Trigger:** The `gh api` call to upload the image returns a non-success status (403, 404, 422, 500).
+
+### Partial image upload failure
+```
+⚠ {uploaded}/{total} images uploaded, {failed} failed
+
+  ✓ {success_filename} — embedded in issue
+  ✗ {failed_filename} — {reason}
+
+  Tip: upload failed images manually via GitHub's web UI.
+```
+**Trigger:** In a multi-image upload, some succeed and some fail. Issue is created with successfully uploaded images embedded.
+
 ## Empty States
 
 ### No files identified

--- a/skills/issue-creator/templates/bug.md
+++ b/skills/issue-creator/templates/bug.md
@@ -25,6 +25,10 @@ Bug
 > **Reporter Context**
 > {original_reporter_text}
 
+## Screenshots
+
+{screenshots}
+
 ## Acceptance Criteria
 
 - [ ] {criterion_1}

--- a/skills/issue-creator/templates/feature.md
+++ b/skills/issue-creator/templates/feature.md
@@ -22,6 +22,10 @@ Feature
 > **Reporter Context**
 > {original_reporter_text}
 
+## Screenshots
+
+{screenshots}
+
 ## Acceptance Criteria
 
 - [ ] {criterion_1}

--- a/skills/issue-creator/templates/improvement.md
+++ b/skills/issue-creator/templates/improvement.md
@@ -25,6 +25,10 @@ Improvement
 > **Reporter Context**
 > {original_reporter_text}
 
+## Screenshots
+
+{screenshots}
+
 ## Acceptance Criteria
 
 - [ ] {criterion_1}


### PR DESCRIPTION
Closes #9

## Summary

- Adds image upload capability to `/issue-creator` so that user-provided screenshots and images are uploaded to GitHub and embedded inline in the issue body
- Uses the GitHub contents API to commit images to `.github/issue-assets/` with timestamped filenames
- Adds a `## Screenshots` section to all three issue templates (bug, feature, improvement)
- Adds 5 new error messages for graceful image upload failure handling

## Changes

| File | Change |
|------|--------|
| `skills/issue-creator/SKILL.md` | Added Image Upload section with upload procedure, failure handling, normalization mode |
| `skills/issue-creator/references/error-messages.md` | Added 5 image upload error messages |
| `skills/issue-creator/templates/bug.md` | Added Screenshots section |
| `skills/issue-creator/templates/feature.md` | Added Screenshots section |
| `skills/issue-creator/templates/improvement.md` | Added Screenshots section |

## Pre-Landing Review

3 issues found and fixed:
- **[CRITICAL]** Double PUT in upload procedure — merged into single command that captures download_url directly
- **[INFO]** Section order mismatch between SKILL.md Step 5 list and templates — reordered to match
- **[INFO]** `base64` without `-w0` breaks on Linux — added cross-platform encoding with fallback

## TODOS

No TODO items completed in this PR. 1 P2 item remaining (predicted-vs-actual file tracking).

## Test plan

- [x] Pre-landing review completed (3 issues found and fixed)
- [x] All changes are skill markdown — no runtime code to test
- [x] Templates verified: Screenshots section correctly placed between Description/Reporter Context and Acceptance Criteria in all 3 templates
- [x] Upload procedure verified: single PUT command, cross-platform base64, proper URL extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)