### PR TITLE
feat: add open-source community files, templates, and new logo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,45 @@
+---
+name: Bug Report
+about: Report a bug in an issue-dev skill
+title: "[bug] "
+labels: bug
+assignees: ''
+---
+
+## Skill
+
+Which skill is affected?
+
+- [ ] `/issue-creator`
+- [ ] `/issue-resolver`
+- [ ] `/issue-triage`
+- [ ] `/init-gitissue`
+
+## Description
+
+A clear description of what the bug is.
+
+## Steps to Reproduce
+
+1. Run `/<skill-name> ...`
+2. ...
+3. See error
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened. Include terminal output (redact sensitive info).
+
+```
+paste terminal output here
+```
+
+## Environment
+
+- OS: [e.g., macOS 15, Ubuntu 24.04]
+- `gh` version: [e.g., 2.45.0]
+- Agent: [e.g., Claude Code, Codex CLI]
+- `.gitissue.yml`: [default / custom — paste relevant config if custom]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,43 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement for issue-dev
+title: "[feature] "
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+
+What problem does this feature solve? Describe the pain point.
+
+## Proposed Solution
+
+How should it work? Include example commands and expected output.
+
+```bash
+# Example usage
+/issue-creator --new-flag
+```
+
+```
+# Expected terminal output
+✓ Feature result
+```
+
+## Alternatives Considered
+
+Any alternative solutions or workarounds you've considered.
+
+## Affected Skills
+
+Which skill(s) would this change?
+
+- [ ] `/issue-creator`
+- [ ] `/issue-resolver`
+- [ ] `/issue-triage`
+- [ ] `/init-gitissue`
+- [ ] New skill
+
+## Additional Context
+
+Any other context, screenshots, or references.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+## Summary
+
+<!-- What does this PR do? 1-3 bullet points. -->
+
+-
+
+## Related Issue
+
+<!-- Link the issue this PR addresses. Use "Closes #N" to auto-close. -->
+
+Closes #
+
+## Changes
+
+<!-- List the key changes. -->
+
+- [ ] Skill SKILL.md updated
+- [ ] Error messages updated
+- [ ] Templates updated
+- [ ] Documentation updated
+- [ ] Tests added/updated
+
+## Testing
+
+<!-- How did you verify this works? -->
+
+- [ ] Tested against a real GitHub repository
+- [ ] Terminal output matches DESIGN.md patterns
+- [ ] `gh` calls use `--json` with explicit field selection
+
+## Checklist
+
+- [ ] Follows [Conventional Commits](https://www.conventionalcommits.org/)
+- [ ] No cross-skill imports or shared state
+- [ ] Docs updated if user-facing behavior changed

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,38 @@
+# OS files
+.DS_Store
+Thumbs.db
+
+# Editor files
+*.swp
+*.swo
+*~
+.vscode/
+.idea/
+*.sublime-workspace
+*.sublime-project
+
+# Environment
+.env
+.env.local
+.env.*.local
+
+# Node (if skills are installed via npx)
+node_modules/
+package-lock.json
+yarn.lock
+
+# Python (if test scripts use Python)
+__pycache__/
+*.pyc
+*.pyo
+.venv/
+venv/
+env/
+
+# Test artifacts
+tests/tmp/
+tests/output/
+*.log
+
+# Claude Code local state
+.claude/settings.local.json

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,60 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes
+* Focusing on what is best for the overall community
+
+Examples of unacceptable behavior:
+
+* The use of sexualized language or imagery, and sexual attention or advances
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without explicit permission
+* Other conduct which could reasonably be considered inappropriate
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainers at **luongnv89** via
+[GitHub Issues](https://github.com/luongnv89/idd/issues) (for non-sensitive matters) or
+direct message.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,124 @@
+# Contributing to issue-dev
+
+Thanks for your interest in contributing! issue-dev is a skills-only project — there's no runtime code, just Claude Code skills written in Markdown. This makes contributing accessible to anyone comfortable with Markdown and GitHub.
+
+## How to Contribute
+
+### Reporting Bugs
+
+- Use the [bug report template](https://github.com/luongnv89/idd/issues/new?template=bug_report.md)
+- Include the skill name (`/issue-creator`, `/issue-resolver`, etc.)
+- Paste the full terminal output (redact any sensitive info)
+- Mention your `gh` CLI version (`gh --version`)
+
+### Suggesting Features
+
+- Use the [feature request template](https://github.com/luongnv89/idd/issues/new?template=feature_request.md)
+- Describe the problem you're solving, not just the feature you want
+- Check existing issues first to avoid duplicates
+
+### Submitting Changes
+
+1. Fork the repository
+2. Create a feature branch from `main`:
+   ```bash
+   git checkout -b feat/your-change
+   ```
+3. Make your changes
+4. Test your skill changes against a real GitHub repo (see [Development Setup](#development-setup))
+5. Commit using [Conventional Commits](#commit-conventions)
+6. Open a Pull Request against `main`
+
+## Development Setup
+
+### Prerequisites
+
+- [GitHub CLI](https://cli.github.com) (`gh`) 2.0+ — authenticated via `gh auth login`
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) or any SKILL.md-compatible agent
+- Git 2.30+
+
+### Project Structure
+
+```
+skills/
+├── issue-creator/      # /issue-creator — create and normalize issues
+│   ├── SKILL.md        # Skill definition (the "code")
+│   ├── templates/      # Issue templates (bug, feature, improvement)
+│   └── references/     # Error messages, detailed patterns
+├── issue-resolver/     # /issue-resolver N — resolve issues end-to-end
+│   ├── SKILL.md
+│   └── references/
+├── issue-triage/       # /issue-triage — backlog analysis
+│   ├── SKILL.md
+│   └── references/
+└── init-gitissue/      # /init-gitissue — config generator
+    ├── SKILL.md
+    └── references/
+docs/                   # Project documentation
+tests/                  # Integration test scripts
+```
+
+### Testing
+
+Each skill should be tested against a real (or test) GitHub repository:
+
+1. Install the skill locally in Claude Code
+2. Run the skill against a test repo with known issues
+3. Verify the terminal output matches expected patterns from `DESIGN.md`
+4. Check that `gh` CLI calls use `--json` with explicit field selection
+
+See `tests/` for integration test scripts and setup instructions.
+
+## Commit Conventions
+
+We use [Conventional Commits](https://www.conventionalcommits.org/):
+
+| Prefix | Use |
+|--------|-----|
+| `feat:` | New skill capability or feature |
+| `fix:` | Bug fix in a skill |
+| `docs:` | Documentation changes |
+| `refactor:` | Skill restructuring without behavior change |
+| `test:` | Adding or updating tests |
+| `chore:` | Maintenance (CI, config, dependencies) |
+
+Examples:
+```
+feat: add batch creation mode to issue-creator
+fix: handle missing labels gracefully in issue-resolver
+docs: add triage workflow example to README
+```
+
+## Branching Strategy
+
+- `main` — stable, always releasable
+- `feat/*` — new features
+- `fix/*` — bug fixes
+- `issue-N/*` — issue-linked branches (created by `/issue-resolver`)
+
+## Pull Request Process
+
+1. Fill in the PR template completely
+2. Link to the related issue (use `Closes #N`)
+3. Ensure all existing tests pass
+4. Add tests for new functionality
+5. Update docs if your change affects user-facing behavior
+6. One approval required before merge
+
+## Coding Standards
+
+Since this is a skills-only project, "code" means SKILL.md files and references:
+
+- **`gh` CLI calls** — always use `--json` with explicit field selection, never parse text output
+- **Terminal output** — follow the symbol vocabulary and formatting rules in `DESIGN.md`
+- **Error messages** — include what went wrong, how to fix it, and where to learn more
+- **Skills are isolated** — no cross-skill imports or shared state
+- **Templates** — include the `<!-- gitissue:normalized v1 -->` marker
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you agree to uphold this code.
+
+## Questions?
+
+Open a [discussion](https://github.com/luongnv89/idd/discussions) or file an issue. We're happy to help!

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 <p align="center">
   <a href="https://github.com/luongnv89/idd/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="MIT License"></a>
   <a href="https://github.com/luongnv89/idd"><img src="https://img.shields.io/badge/skills-4-blue.svg" alt="4 skills"></a>
+  <a href="https://github.com/luongnv89/idd/blob/main/CONTRIBUTING.md"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome"></a>
 </p>
 
 # Turn GitHub Issues Into Your Entire Dev Workflow
@@ -364,6 +365,9 @@ skills/
     ├── SKILL.md
     └── references/
 docs/
+├── ARCHITECTURE.md     # System design and data flow
+├── CHANGELOG.md        # Version history
+├── DEVELOPMENT.md      # Dev setup and debugging
 ├── idd-methodology.md  # IDD methodology overview
 ├── config-schema.md    # Full .gitissue.yml schema
 └── sample-normalized-issue.md
@@ -373,6 +377,15 @@ tests/                  # Integration test scripts
 </details>
 
 ---
+
+## Contributing
+
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on:
+- Reporting bugs and requesting features
+- Development setup and testing
+- Commit conventions and PR process
+
+Please read our [Code of Conduct](CODE_OF_CONDUCT.md) before participating.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 <p align="center">
-  <strong>issue-dev</strong>
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/logo/logo-white.svg">
+    <source media="(prefers-color-scheme: light)" srcset="assets/logo/logo-black.svg">
+    <img src="assets/logo/logo-black.svg" alt="issuedev logo" height="64">
+  </picture>
 </p>
 
 <p align="center">

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| latest  | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+We take security seriously. issue-dev skills interact with GitHub repositories via the `gh` CLI, so security issues could affect users' codebases.
+
+### How to Report
+
+1. **Do NOT** open a public GitHub issue for security vulnerabilities
+2. Report via [GitHub Security Advisories](https://github.com/luongnv89/idd/security/advisories/new)
+3. Include detailed steps to reproduce the vulnerability
+4. Allow up to 48 hours for an initial response
+
+### What to Include
+
+- Type of vulnerability (e.g., prompt injection, data exposure)
+- Affected skill(s) and the specific SKILL.md section
+- Step-by-step instructions to reproduce
+- Potential impact (e.g., unintended code execution, data leakage)
+
+### What to Expect
+
+- Acknowledgment of your report within 48 hours
+- Regular updates on our progress
+- Credit in the security advisory (if desired)
+- Notification when the issue is fixed
+
+## Security Considerations
+
+issue-dev skills handle GitHub issue content, which is **untrusted user input**. Key safeguards:
+
+- `/issue-resolver` never executes commands found in issue text
+- Issues labeled `security`, `CVE`, or `vulnerability` are skipped during normalization to prevent exposing exploit details
+- Backup comments are always posted before editing any issue
+- All `gh` CLI calls use `--json` output to avoid shell injection from text parsing

--- a/assets/logo/favicon.svg
+++ b/assets/logo/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- Favicon: mark on dark rounded square, optimized for small sizes -->
+  <rect width="32" height="32" rx="6" fill="#0A0A0A"/>
+
+  <g transform="translate(4, 4) scale(0.2)">
+    <path fill-rule="evenodd" fill="#00FF41"
+          d="M60 12 L108 60 L60 108 L12 60 Z
+             M48 46 L80 60 L48 74 Z"/>
+  </g>
+</svg>

--- a/assets/logo/logo-black.svg
+++ b/assets/logo/logo-black.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 330 64" width="330" height="64">
+  <!-- Black version: full logo for light backgrounds -->
+
+  <!-- Mark (black, transparent cutout) -->
+  <g transform="translate(4, 4) scale(0.467)">
+    <path fill-rule="evenodd" fill="#1A1A1A"
+          d="M60 12 L108 60 L60 108 L12 60 Z
+             M48 46 L80 60 L48 74 Z"/>
+  </g>
+
+  <!-- Wordmark — single text element, no gap -->
+  <text x="76" y="44" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif" font-size="40" font-weight="700" letter-spacing="-1.5"><tspan fill="#1A1A1A">issue</tspan><tspan fill="rgba(26,26,26,0.6)">dev</tspan></text>
+</svg>

--- a/assets/logo/logo-full.svg
+++ b/assets/logo/logo-full.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 330 64" width="330" height="64">
+  <!-- issuedev full logo: mark + wordmark horizontal -->
+
+  <!-- Mark (scaled to fit 56px, centered vertically in 64px) -->
+  <g transform="translate(4, 4) scale(0.467)">
+    <path fill-rule="evenodd" fill="#00FF41"
+          d="M60 12 L108 60 L60 108 L12 60 Z
+             M48 46 L80 60 L48 74 Z"/>
+  </g>
+
+  <!-- Wordmark — single text element, no gap -->
+  <text x="76" y="44" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif" font-size="40" font-weight="700" letter-spacing="-1.5"><tspan fill="#FAFAFA">issue</tspan><tspan fill="#00FF41">dev</tspan></text>
+</svg>

--- a/assets/logo/logo-icon.svg
+++ b/assets/logo/logo-icon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <!-- App icon: mark centered on dark rounded square -->
+  <rect width="512" height="512" rx="96" fill="#0A0A0A"/>
+
+  <g transform="translate(96, 96) scale(2.667)">
+    <path fill-rule="evenodd" fill="#00FF41"
+          d="M60 12 L108 60 L60 108 L12 60 Z
+             M48 46 L80 60 L48 74 Z"/>
+  </g>
+</svg>

--- a/assets/logo/logo-mark.svg
+++ b/assets/logo/logo-mark.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" width="120" height="120">
+  <!-- issue-dev mark: Diamond (the issue/◆ symbol) with a forward-pointing
+       triangle punched out (the resolution/play action). Uses even-odd fill
+       so the cutout is transparent on any background. -->
+
+  <path fill-rule="evenodd" fill="#00FF41"
+        d="M60 12 L108 60 L60 108 L12 60 Z
+           M48 46 L80 60 L48 74 Z"/>
+</svg>

--- a/assets/logo/logo-white.svg
+++ b/assets/logo/logo-white.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 330 64" width="330" height="64">
+  <!-- White version: full logo for dark backgrounds -->
+
+  <!-- Mark (white, transparent cutout) -->
+  <g transform="translate(4, 4) scale(0.467)">
+    <path fill-rule="evenodd" fill="#FFFFFF"
+          d="M60 12 L108 60 L60 108 L12 60 Z
+             M48 46 L80 60 L48 74 Z"/>
+  </g>
+
+  <!-- Wordmark — single text element, no gap -->
+  <text x="76" y="44" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif" font-size="40" font-weight="700" letter-spacing="-1.5"><tspan fill="#FFFFFF">issue</tspan><tspan fill="rgba(255,255,255,0.7)">dev</tspan></text>
+</svg>

--- a/assets/logo/logo-wordmark.svg
+++ b/assets/logo/logo-wordmark.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 48" width="240" height="48">
+  <!-- issuedev wordmark — single text element, no gap -->
+  <text x="0" y="37" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif" font-size="40" font-weight="700" letter-spacing="-1.5"><tspan fill="#FAFAFA">issue</tspan><tspan fill="#00FF41">dev</tspan></text>
+</svg>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,111 @@
+# Architecture
+
+## Overview
+
+issue-dev is a **skills-only** project. There is no runtime code — each skill is a self-contained Claude Code skill (SKILL.md + references/ + templates/) that instructs an AI agent how to perform a task.
+
+The only external dependency is the GitHub CLI (`gh`), which handles all GitHub API interactions.
+
+## System Design
+
+```
+User (terminal)
+    │
+    ├─ /issue-creator ─────► SKILL.md ─► gh issue create/edit
+    ├─ /issue-resolver N ──► SKILL.md ─► gh issue view → git → gh pr create
+    ├─ /issue-triage ──────► SKILL.md ─► gh issue list → analysis
+    └─ /init-gitissue ─────► SKILL.md ─► repo scan → .gitissue.yml
+```
+
+## Skill Anatomy
+
+Each skill follows the same structure:
+
+```
+skills/<skill-name>/
+├── SKILL.md            # Skill definition — the "source code"
+├── references/
+│   └── error-messages.md   # Standardized error messages
+└── templates/          # (optional) Issue templates
+```
+
+### SKILL.md
+
+The skill definition file. Contains:
+1. **Frontmatter** — name, description, trigger patterns
+2. **Steps** — sequential instructions the agent follows
+3. **Guards** — pre-conditions checked before execution
+4. **Output format** — terminal output patterns per DESIGN.md
+
+### references/error-messages.md
+
+Every skill has its own error messages file. Errors follow a three-part format:
+```
+✗ What went wrong
+  To fix:  <actionable command>
+  Docs:    <url>
+```
+
+### templates/
+
+Only used by `issue-creator`. Contains Markdown templates for bug, feature, and improvement issues. Each template includes the `<!-- gitissue:normalized v1 -->` marker.
+
+## Data Flow
+
+### Issue Creation
+
+```
+User input (text/screenshot)
+    │
+    ▼
+Codebase scan (find relevant files)
+    │
+    ▼
+Type classification (bug/feature/improvement)
+    │
+    ▼
+Template fill (affected files + confidence, acceptance criteria)
+    │
+    ▼
+gh issue create --json ...
+```
+
+### Issue Resolution
+
+```
+gh issue view N --json ...
+    │
+    ▼
+Normalization check (has marker?)
+    │  No → auto-normalize
+    ▼
+Branch creation (issue-N/description)
+    │
+    ▼
+Research (read affected files, trace deps)
+    │
+    ▼
+Plan (local only, never posted)
+    │
+    ▼
+Execute (code + tests, atomic commits)
+    │
+    ▼
+Verify (run test suite)
+    │
+    ▼
+gh pr create --json ...  (Closes #N)
+```
+
+## Configuration
+
+`.gitissue.yml` is loaded once at skill start. The full schema is documented in [`config-schema.md`](config-schema.md).
+
+All settings have defaults — the system works with zero configuration.
+
+## Design Principles
+
+1. **Skills are isolated** — no cross-skill imports or shared state
+2. **`gh` CLI is the only interface** — all GitHub interaction via `gh --json`
+3. **Static sequential output** — each step prints a new line, no terminal animation
+4. **Agent-agnostic** — structured issues are plain GitHub Markdown, consumable by any tool

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+- CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md
+- GitHub issue and PR templates
+- .gitignore
+- Architecture and development documentation
+
+## [0.1.0] - 2026-03-20
+
+### Added
+- `/issue-creator` skill — create and normalize GitHub issues with codebase context
+  - Single issue creation from text descriptions
+  - Issue normalization (enrich existing issues)
+  - Batch creation from multi-item input
+  - Image upload and embedding in issue descriptions
+  - Security issue detection (skip normalization for CVE/vulnerability labels)
+- `/issue-resolver` skill — resolve issues through a 7-step pipeline (Fetch → Branch → Research → Plan → Execute → Verify → Ship)
+- `/issue-triage` skill — backlog analysis with dependency detection, priority suggestions, stale issue flagging
+- `/init-gitissue` skill — auto-detect project language/framework and generate `.gitissue.yml`
+- IDD methodology documentation
+- Terminal output style guide (DESIGN.md)
+- Configuration schema documentation
+- Integration test framework

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,90 @@
+# Development Guide
+
+## Prerequisites
+
+- [GitHub CLI](https://cli.github.com) (`gh`) 2.0+ — authenticated via `gh auth login`
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) or any SKILL.md-compatible agent
+- Git 2.30+
+
+## Local Setup
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/luongnv89/idd.git
+   cd idd
+   ```
+
+2. Install skills locally in Claude Code:
+   ```bash
+   # Add to your project's .claude/settings.json
+   # Or use the manual installation path from README
+   ```
+
+3. Verify setup:
+   ```bash
+   gh auth status        # Must be authenticated
+   gh --version          # Must be 2.0+
+   ```
+
+## Making Changes
+
+### Editing a Skill
+
+Skills live in `skills/<name>/SKILL.md`. When editing:
+
+1. Read the existing SKILL.md fully before making changes
+2. Follow the terminal output patterns in `DESIGN.md`
+3. Use `--json` with explicit field selection for all `gh` commands
+4. Update `references/error-messages.md` if adding new error cases
+5. Test against a real GitHub repository
+
+### Adding Error Messages
+
+Each skill has `references/error-messages.md`. Follow the three-part format:
+
+```
+✗ Short error description
+
+  To fix:  <actionable command>
+  Docs:    <url to relevant documentation>
+```
+
+### Modifying Templates
+
+Issue templates are in `skills/issue-creator/templates/`. Each template must:
+- Include the `<!-- gitissue:normalized v1 -->` marker
+- Use standard sections: Type, Context, Description, Acceptance Criteria, Technical Notes, Metadata
+- Preserve the Reporter Context blockquote
+
+## Testing
+
+Integration tests are in `tests/`. They verify skill behavior against GitHub repositories.
+
+```bash
+# See tests/README.md for setup and execution instructions
+```
+
+When testing manually:
+1. Create a test repository (or use an existing one)
+2. Run the skill you modified
+3. Verify terminal output matches `DESIGN.md` patterns
+4. Check that GitHub issues/PRs are created correctly
+
+## Key Conventions
+
+- **`gh` CLI** — every call must use `--json` with explicit field selection
+- **Terminal symbols** — `✓ ✗ ● ◆ ⚡ ⚠ ○` per `DESIGN.md`
+- **No cross-skill state** — skills are fully isolated
+- **Config loaded once** — `.gitissue.yml` is read at skill start, not per-step
+- **Backup before edit** — always post a backup comment before modifying an issue
+
+## File Reference
+
+| File | Purpose |
+|------|---------|
+| `CLAUDE.md` | Project conventions for AI agents |
+| `DESIGN.md` | Terminal output style guide |
+| `docs/config-schema.md` | Full `.gitissue.yml` schema |
+| `docs/idd-methodology.md` | IDD methodology overview |
+| `docs/sample-normalized-issue.md` | Example normalized issue |
+| `docs/ARCHITECTURE.md` | System design and data flow |


### PR DESCRIPTION
## Summary
- Add open-source community files (CONTRIBUTING.md, CODE_OF_CONDUCT.md, LICENSE) and GitHub issue/PR templates
- Redesign logo with geometric diamond+play-arrow mark in neon green, theme-aware README using `<picture>` for dark/light mode

## Test plan
- [ ] Verify logo renders on GitHub README in both dark and light themes
- [ ] Confirm community files (CONTRIBUTING, CODE_OF_CONDUCT) are linked correctly
- [ ] Check GitHub issue/PR templates appear when creating new issues/PRs