### PR TITLE
fix(issue-resolver): remove invalid --json flag from gh pr create (#17)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -89,7 +89,7 @@ graph TD
     E --> F["Plan (local only, never posted)"]
     F --> G["Execute (code + tests, atomic commits)"]
     G --> H["Verify (run test suite)"]
-    H --> I["gh pr create --json ... (Closes #N)"]
+    H --> I["gh pr create (Closes #N)"]
 
     style A fill:#4CAF50,color:#fff
     style I fill:#2196F3,color:#fff

--- a/skills/issue-resolver/SKILL.md
+++ b/skills/issue-resolver/SKILL.md
@@ -413,10 +413,10 @@ If the push fails, output the error from `references/error-messages.md` and stop
 ### Create PR
 
 ```bash
-gh pr create --title "{pr_title}" --body "{pr_body}" --json number,url
+gh pr create --title "{pr_title}" --body "{pr_body}"
 ```
 
-This returns the PR number and URL as structured JSON for use in the final report.
+The PR URL is printed to stdout on success.
 
 **PR title** (Conventional Commits format — see `docs/naming-conventions.md` for the full reference):
 `{type}({scope}): {description} (#{issue_number})`


### PR DESCRIPTION
Closes #17

## Summary

Removes the invalid `--json number,url` flag from the `gh pr create` command in the issue-resolver skill. `gh pr create` does not support `--json` — that flag is only for read/query commands like `gh pr view` and `gh pr list`. This was causing PR creation to fail with "unknown flag: --json" during the Ship phase.

## Approach

Removed the unsupported flag from the command example and updated the accompanying description to reflect that the PR URL comes from stdout.

## Changes

| File | Change |
|------|--------|
| `skills/issue-resolver/SKILL.md` | Removed `--json number,url` from `gh pr create` command (line 416), updated description (line 419) |
| `docs/ARCHITECTURE.md` | Removed `--json ...` from Mermaid diagram label (line 92) |

## Acceptance Criteria

- [x] `skills/issue-resolver/SKILL.md` line 416 removes `--json number,url` from the `gh pr create` command
- [x] `skills/issue-resolver/SKILL.md` line 419 is updated to reflect that PR URL comes from stdout
- [x] `docs/ARCHITECTURE.md` line 92 diagram no longer shows `--json` on `gh pr create`