### PR TITLE
chore(skills): fix validation blocker, add missing READMEs, refactor oversize skills

### DIFF
--- a/skills/auto-pilot/SKILL.md
+++ b/skills/auto-pilot/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: auto-pilot
-description: Run a fully autonomous triage-resolve-review-merge loop over the GitHub issue backlog with zero user prompts. Use when asked to "auto-pilot", "autopilot", "resolve everything", "work through the backlog", "run the loop", or "keep going until done".
+description: "Run a fully autonomous triage-resolve-review-merge loop over the GitHub issue backlog with zero user prompts. Use when asked to auto-pilot, autopilot, resolve everything, work through the backlog, run the loop, or keep going until done. Don't use for single-issue work (use /issue-resolver), one-shot triage (use /issue-triage), or interactive PR review (use /issue-pr-review)."
 license: MIT
 compatibility: Requires git and GitHub CLI (gh) with authentication and push access. Requires merge permission for auto-merge. Uses /issue-triage, /issue-resolver, /issue-analysis, and /issue-pr-review skills internally. All agents are in shared/agents/.
 effort: max
 metadata:
-  version: 2.1.1
+  version: 2.1.2
   creator: Luong NGUYEN <luongnv89@gmail.com>
 ---
 

--- a/skills/init-gitissue/SKILL.md
+++ b/skills/init-gitissue/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: init-gitissue
-description: Generate a project-specific .gitissue.yml by auto-detecting language, framework, test runner, and repo size. Use when asked to "init gitissue", "setup gitissue", "configure gitissue", "first time setup", "/init-gitissue", or to set up IDD on a new repo.
+description: "Generate a project-specific .gitissue.yml by auto-detecting language, framework, test runner, and repo size. Use when asked to init gitissue, setup gitissue, configure gitissue, first time setup, /init-gitissue, or to set up IDD on a new repo. Don't use for editing an existing .gitissue.yml (edit directly), creating GitHub issues (use /issue-creator), or general git/repo initialization like git init or npm init."
 license: MIT
 compatibility: Requires git. No GitHub CLI or authentication needed — generates a local config file only.
 effort: low
 metadata:
-  version: 0.3.0
+  version: 0.3.1
   creator: Luong NGUYEN <luongnv89@gmail.com>
 ---
 

--- a/skills/issue-analysis/README.md
+++ b/skills/issue-analysis/README.md
@@ -1,0 +1,71 @@
+# Issue Analysis
+
+> Deep analysis of a single GitHub issue — root cause, architecture impact, implementation options, complexity, and risk — persisted to `.gitissue/analysis-N.json`.
+
+## Highlights
+
+- Scans the codebase for files most relevant to the issue
+- Traces root cause across modules rather than just symptoms
+- Generates multiple implementation options with trade-offs (effort, risk, blast radius)
+- Scores complexity and risk so planning decisions are explicit
+- Persists full analysis to `.gitissue/analysis-N.json` for later reuse
+- Offers a fast `view` mode that re-renders the cached report without re-scanning
+
+## When to Use
+
+| Say this... | Skill will... |
+|---|---|
+| `/issue-analysis 42` | Run a full root-cause + options analysis of issue #42 |
+| `/issue-analysis 42 view` | Re-render the cached analysis without calling GitHub |
+| "how hard is #42" | Score complexity/risk and outline implementation options |
+| "investigate issue #42" | Trace root cause across affected files and modules |
+| "impact analysis for #42" | Surface blast radius, dependencies, and migration concerns |
+
+## How It Works
+
+```mermaid
+graph TD
+    A["Fetch issue + repo context"] --> B["Scan affected files"]
+    B --> C["Trace root cause"]
+    C --> D["Generate implementation options"]
+    D --> E["Score complexity + risk"]
+    E --> F["Render report + persist JSON"]
+    style A fill:#4CAF50,color:#fff
+    style F fill:#2196F3,color:#fff
+```
+
+## Installation
+
+Install via [npx (Vercel)](https://www.npmjs.com/package/skills):
+
+```bash
+npx skills add https://github.com/luongnv89/idd --skill issue-analysis
+```
+
+Or via [agent-skill-manager (asm)](https://www.npmjs.com/package/agent-skill-manager):
+
+```bash
+asm install https://github.com/luongnv89/idd --skill issue-analysis
+```
+
+## Usage
+
+```
+/issue-analysis <N>
+/issue-analysis <N> view
+```
+
+## Resources
+
+| Path | Description |
+|---|---|
+| `references/error-messages.md` | Error catalog for auth failures, missing issues, corrupted cache, and empty states |
+
+## Output
+
+A structured analysis report in the terminal with:
+- Issue summary and reporter context
+- Root cause + affected files
+- 2–3 implementation options with effort/risk trade-offs
+- Complexity score and recommended approach
+- Persistent JSON report at `.gitissue/analysis-N.json`

--- a/skills/issue-analysis/SKILL.md
+++ b/skills/issue-analysis/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: issue-analysis
-description: Analyze a single GitHub issue for root cause, affected files, implementation options, complexity, and risk; persists to .gitissue/analysis-<N>.json. Use when asked to "analyze issue #N", "investigate issue", "impact analysis", "how hard is #N", or "/issue-analysis".
+description: "Analyze a single GitHub issue for root cause, affected files, implementation options, complexity, and risk; persists to .gitissue/analysis-N.json. Use when asked to analyze issue #N, investigate issue, impact analysis, how hard is #N, or /issue-analysis. Don't use for creating/filing issues (use /issue-creator), bulk triaging (use /issue-triage), or actually resolving the issue (use /issue-resolver)."
 license: MIT
 compatibility: Requires git and GitHub CLI (gh) with authentication. View mode (`/issue-analysis N view`) needs only local file access — no gh required.
 effort: high
 metadata:
-  version: 0.4.0
+  version: 0.4.1
   creator: Luong NGUYEN <luongnv89@gmail.com>
 ---
 

--- a/skills/issue-creator/SKILL.md
+++ b/skills/issue-creator/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: issue-creator
-description: Create structured GitHub issues from text, screenshots, or lists — or normalize and enrich existing ones into a standard template. Use when asked to "create issue", "file a bug", "normalize issue", "batch create", "/issue-creator", or when a user describes a bug or feature to track.
+description: "Create structured GitHub issues from text, screenshots, or lists — or normalize and enrich existing ones into a standard template. Use when asked to create issue, file a bug, normalize issue, batch create, /issue-creator, or when a user describes a bug or feature to track. Don't use for resolving or implementing an issue (use /issue-resolver), triaging/prioritizing issues (use /issue-triage), or analyzing a single issue (use /issue-analysis)."
 license: MIT
 compatibility: Requires git and GitHub CLI (gh) with authentication. Run `gh auth status` to verify.
 effort: medium
 metadata:
-  version: 0.4.0
+  version: 0.4.1
   creator: Luong NGUYEN <luongnv89@gmail.com>
 ---
 

--- a/skills/issue-pr-review-fix-loop/SKILL.md
+++ b/skills/issue-pr-review-fix-loop/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: issue-pr-review-fix-loop
-description: Run an outer review-fix loop over a PR that calls /issue-pr-review in review-only mode, fixes, commits, pushes, and repeats until clean, ending with a fresh confirmation pass. Use when asked to "review and fix my PR", "keep fixing until clean", or "review loop".
+description: "Run an outer review-fix loop over a PR that calls /issue-pr-review in review-only mode, fixes, commits, pushes, and repeats until clean, ending with a fresh confirmation pass. Use when asked to review and fix my PR, keep fixing until clean, or review loop. Don't use for a single review pass (use /issue-pr-review), creating a PR (use /issue-resolver), or backlog-wide automation (use /auto-pilot)."
 license: MIT
 compatibility: Requires git and GitHub CLI (gh) with authentication. Depends on /issue-pr-review skill (skills/issue-pr-review/SKILL.md). Uses shared agents from shared/agents/.
 effort: high
 metadata:
-  version: 0.3.0
+  version: 0.3.1
   creator: Luong NGUYEN <luongnv89@gmail.com>
 ---
 

--- a/skills/issue-pr-review/README.md
+++ b/skills/issue-pr-review/README.md
@@ -1,0 +1,76 @@
+# Issue PR Review
+
+> Review a pull request end-to-end — analyze, test, fix, check CI, and auto-merge when clean — with up to 3 token-optimized fix cycles.
+
+## Highlights
+
+- Mechanical pre-pass (lint, format, tests) before any LLM cycles to save tokens
+- Up to 3 LLM-driven review-fix cycles, ending early when clean
+- Runs the project's real test suite, not mocks
+- Monitors CI status and waits for green before merging
+- Auto-merge in `--auto` mode (used by `/auto-pilot`); read-only mode available
+- Soft-pass when zero "fix" issues remain, even if minor "note" issues linger
+
+## When to Use
+
+| Say this... | Skill will... |
+|---|---|
+| `/issue-pr-review 42` | Review PR #42 interactively, report findings, offer fixes |
+| `/issue-pr-review 42 --auto` | Review, fix, wait for CI, and auto-merge when green |
+| `/issue-pr-review --review-only` | Review and report only — never fix or merge |
+| "is this PR ready?" | Run the pipeline against the current branch's PR |
+| "clean up this PR" | Iterate fix cycles until the review is clean |
+
+## How It Works
+
+```mermaid
+graph TD
+    A["PR info + repo sync"] --> B["Mechanical pre-pass"]
+    B --> C["LLM review cycle"]
+    C --> D{"Clean?"}
+    D -- No --> E["Apply fixes"]
+    E --> C
+    D -- Yes --> F["Run tests"]
+    F --> G["Wait for CI"]
+    G --> H["Auto-merge (if --auto)"]
+    style A fill:#4CAF50,color:#fff
+    style H fill:#2196F3,color:#fff
+```
+
+## Installation
+
+Install via [npx (Vercel)](https://www.npmjs.com/package/skills):
+
+```bash
+npx skills add https://github.com/luongnv89/idd --skill issue-pr-review
+```
+
+Or via [agent-skill-manager (asm)](https://www.npmjs.com/package/agent-skill-manager):
+
+```bash
+asm install https://github.com/luongnv89/idd --skill issue-pr-review
+```
+
+## Usage
+
+```
+/issue-pr-review
+/issue-pr-review <PR_NUMBER>
+/issue-pr-review <PR_NUMBER> --auto
+/issue-pr-review --review-only
+```
+
+## Resources
+
+| Path | Description |
+|---|---|
+| `references/error-messages.md` | Error catalog for auth failures, dirty trees, CI timeouts, and merge conflicts |
+
+## Output
+
+A structured 7-step pipeline report in the terminal with:
+- PR title, number, and base/head branch
+- Pre-pass results (lint, format, test counts)
+- Per-cycle findings with confidence and severity
+- Test and CI status
+- Final verdict: pass, fix-and-retry, or hard-fail

--- a/skills/issue-pr-review/SKILL.md
+++ b/skills/issue-pr-review/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: issue-pr-review
-description: Review a pull request end-to-end with up to 3 token-optimized fix cycles, CI monitoring, and auto-merge in auto-pilot mode. Use when asked to "review PR", "review and fix PR", "is this PR ready", "clean up this PR", or "polish this branch".
+description: "Review a pull request end-to-end with up to 3 token-optimized fix cycles, CI monitoring, and auto-merge in auto-pilot mode. Use when asked to review PR, review and fix PR, is this PR ready, clean up this PR, or polish this branch. Don't use for creating a PR (use /issue-resolver), reviewing raw issues (use /issue-analysis), or reviewing code that's not yet in a PR (use /code-review or a generic reviewer)."
 license: MIT
 compatibility: Requires git and GitHub CLI (gh) with authentication. Self-contained — uses shared agents from shared/agents/.
 effort: high
 metadata:
-  version: 0.3.0
+  version: 0.3.2
   creator: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -379,70 +379,13 @@ After Step 6, go back to Step 3 — but reuse the same reviewer agent via `SendM
 
 ## Step 7 — Summary Report [7/7]
 
-Print a structured step-by-step summary showing the review pipeline results.
+Print a structured step-by-step summary showing the review pipeline results. Use the templates in `references/report-templates.md`:
 
-### Clean PR
+- *Summary — Clean PR* — all checks pass, may include soft-pass notes
+- *Summary — PR With Remaining Issues* — review couldn't clear everything within `review.max_cycles`
+- *Auto-Merge (auto mode only)* — post-report squash merge and block-on-failure handling
 
-```
-◆ PR Review: #{pr_number} (pass {N} — clean)
-┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
-
-  Script pre-pass:   ✓ lint/format auto-fixed ({auto_fixed} files)
-  Code review:       ✓ pass
-  Tests:             ✓ pass ({count} passed)
-  CI status:         ✓ pass ({checks_count} checks passed)
-  Issues fixed:      ✓ {total_fixed} total across {cycles} cycles
-  Issues noted:      ○ {note_count} (medium, not blocking)
-  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
-  Result:            PASS
-
-  {pr_url}
-```
-
-### PR with remaining issues
-
-```
-◆ PR Review: #{pr_number} (pass {max} — issues remain)
-┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
-
-  Code review:       ⚠ warn ({N} issues remain)
-  Tests:             ✓ pass
-  CI status:         ✓ pass
-  Issues fixed:      ✓ {total_fixed} total across {max} cycles
-  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
-  Result:            WARN (manual review recommended)
-
-  Remaining:
-    ● [category] description (file:line)
-
-  {pr_url}
-```
-
-### Auto-merge (auto mode only)
-
-If the PR is clean AND `--auto` flag is set:
-
-```bash
-gh pr merge {N} --squash --delete-branch
-```
-
-Append to the report:
-```
-  Merge:             ✓ pass (squash merged)
-  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
-  Result:            MERGED
-
-  ✓ PR #{N} merged — branch {branch_name} deleted
-```
-
-If merge fails:
-```
-  Merge:             ✗ fail ({reason})
-  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
-  Result:            BLOCKED (manual merge required)
-```
-
-In interactive mode: never auto-merge. Just report status.
+In interactive mode: never auto-merge — just report status.
 
 ---
 
@@ -479,19 +422,7 @@ All errors use rich format from `references/error-messages.md`:
 
 ## Expected Output
 
-A clean review prints the 7-step tracker and a summary:
-
-```
-  [1/7] PR Info       ✓ #87 fix(auth): resolve redirect (#42)
-  [2/7] Script Pre    ✓ 3 lint fixes applied
-  [3/7] Review        ✓ 0 critical, 1 medium (note)
-  [4/7] Tests         ✓ 12 passed
-  [5/7] CI            ✓ all checks green
-  [6/7] Fix           ○ skipped — nothing to fix
-  [7/7] Summary       ✓ PR ready to merge
-
-  ✓ PR #87 passed review (soft-pass: 1 medium note)
-```
+A clean review prints the 7-step tracker and a summary — see the *Expected Inline Output* example in `references/report-templates.md`.
 
 ## Edge Cases
 
@@ -504,6 +435,7 @@ A clean review prints the 7-step tracker and a summary:
 ## Additional Resources
 
 - **`shared/agents/code-reviewer.md`** — Review subagent prompt
+- **`references/report-templates.md`** — Step 7 summary templates, auto-merge flow, expected inline output
 - **`references/error-messages.md`** — Error catalog
 - **`docs/naming-conventions.md`** — Naming conventions
 - **`DESIGN.md`** — Terminal output style guide

--- a/skills/issue-pr-review/references/report-templates.md
+++ b/skills/issue-pr-review/references/report-templates.md
@@ -1,0 +1,84 @@
+# Summary Report Templates
+
+Templates for the Step 7 summary report and the expected inline pipeline output. SKILL.md keeps the contract short; this file holds the full templates.
+
+## Summary — Clean PR
+
+```
+◆ PR Review: #{pr_number} (pass {N} — clean)
+┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+
+  Script pre-pass:   ✓ lint/format auto-fixed ({auto_fixed} files)
+  Code review:       ✓ pass
+  Tests:             ✓ pass ({count} passed)
+  CI status:         ✓ pass ({checks_count} checks passed)
+  Issues fixed:      ✓ {total_fixed} total across {cycles} cycles
+  Issues noted:      ○ {note_count} (medium, not blocking)
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+  Result:            PASS
+
+  {pr_url}
+```
+
+## Summary — PR With Remaining Issues
+
+```
+◆ PR Review: #{pr_number} (pass {max} — issues remain)
+┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+
+  Code review:       ⚠ warn ({N} issues remain)
+  Tests:             ✓ pass
+  CI status:         ✓ pass
+  Issues fixed:      ✓ {total_fixed} total across {max} cycles
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+  Result:            WARN (manual review recommended)
+
+  Remaining:
+    ● [category] description (file:line)
+
+  {pr_url}
+```
+
+## Auto-Merge (auto mode only)
+
+If the PR is clean AND `--auto` is set:
+
+```bash
+gh pr merge {N} --squash --delete-branch
+```
+
+Append to the report on success:
+
+```
+  Merge:             ✓ pass (squash merged)
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+  Result:            MERGED
+
+  ✓ PR #{N} merged — branch {branch_name} deleted
+```
+
+On merge failure:
+
+```
+  Merge:             ✗ fail ({reason})
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+  Result:            BLOCKED (manual merge required)
+```
+
+In interactive mode: never auto-merge — just report status.
+
+## Expected Inline Output
+
+A clean review prints the 7-step tracker and a summary:
+
+```
+  [1/7] PR Info       ✓ #87 fix(auth): resolve redirect (#42)
+  [2/7] Script Pre    ✓ 3 lint fixes applied
+  [3/7] Review        ✓ 0 critical, 1 medium (note)
+  [4/7] Tests         ✓ 12 passed
+  [5/7] CI            ✓ all checks green
+  [6/7] Fix           ○ skipped — nothing to fix
+  [7/7] Summary       ✓ PR ready to merge
+
+  ✓ PR #87 passed review (soft-pass: 1 medium note)
+```

--- a/skills/issue-resolver/SKILL.md
+++ b/skills/issue-resolver/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: issue-resolver
-description: Create an atomic PR that closes a GitHub issue end-to-end via a 6-step pipeline. Use when asked to "resolve issue #N", "fix #N", "implement #N", "work on #N", "take issue #N", or "/issue-resolver".
+description: "Create an atomic PR that closes a GitHub issue end-to-end via a 6-step pipeline. Use when asked to resolve issue #N, fix #N, implement #N, work on #N, take issue #N, or /issue-resolver. Don't use for analyzing an issue without implementing (use /issue-analysis), reviewing an existing PR (use /issue-pr-review), or bulk backlog processing (use /auto-pilot)."
 license: MIT
 compatibility: Requires git and GitHub CLI (gh) with authentication and push access. Self-contained — uses shared agents from shared/agents/.
 effort: max
 metadata:
-  version: 0.6.0
+  version: 0.7.0
   creator: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -205,54 +205,9 @@ After preflight:
 
 ## Step 1 — Research
 
-Deeply understand the issue, the affected codebase, and possible solutions. This step also verifies the issue hasn't already been fixed.
+Deeply understand the issue, affected codebase, and possible solutions. Also verifies the issue hasn't already been fixed (early-exit path closes the issue in auto mode).
 
-### GitHub Projects status transition
-
-If `projects.sync_enabled` is true, set the issue status to `status_map.in_progress` (see `docs/github-projects-sync.md`).
-
-### Subagent delegation (preferred)
-
-Spawn the codebase-researcher agent with:
-
-```json
-{
-  "issue": { <issue data from Step 0> },
-  "config": {
-    "max_files": 30,
-    "trace_depth": 3,
-    "scan_timeout": 120,
-    "output_format": "json"
-  },
-  "repo_root": "<absolute path>"
-}
-```
-
-The researcher will:
-1. **Verify not already resolved** — check git history for closing commits, check codebase for evidence the bug is fixed
-2. **Scan codebase** — extract targets, grep/glob, read files, trace deps
-3. **Assess complexity** — trivial / low / medium / high / complex
-4. **Research solutions** (for high/complex) — algorithms, optimizations, design patterns, web search if needed
-5. **Analyze git history** — prior attempts, regressions, domain experts
-6. **Cross-reference issues** — duplicates, blockers, related work
-
-### Early exit: already resolved
-
-If the researcher returns `already_resolved: true` or `pr_in_progress: true`:
-
-```
-✓ Issue #N appears to already be resolved
-  {resolution_details}
-
-  Recommend closing the issue.
-```
-
-In auto mode: close the issue with a comment and move to the next issue.
-In interactive mode: inform the user and stop.
-
-### Inline fallback
-
-If no Agent tool, execute research inline following the same phases described in `shared/agents/codebase-researcher.md`.
+Spawn the `codebase-researcher` subagent (see `shared/agents/codebase-researcher.md`). Full delegation payload, phases, early-exit behavior, and inline fallback are in `references/pipeline-steps.md` (*Step 1 — Research*).
 
 After research:
 ```
@@ -263,90 +218,20 @@ After research:
 
 ## Step 2 — Plan
 
-Generate implementation options and select one.
+Generate implementation options and select one. Spawn the `synthesizer` subagent (see `shared/agents/synthesizer.md`). It returns 3 options — minimal / balanced / comprehensive — with the balanced option usually recommended.
 
-### Subagent delegation (preferred)
+Selection behavior (interactive auto, interactive comment-and-wait, auto-pilot) and inline fallback are in `references/pipeline-steps.md` (*Step 2 — Plan*).
 
-Spawn the synthesizer agent with:
-- Issue data
-- Research findings (JSON from Step 1)
-- Mode: `"auto"` if auto-pilot, `"interactive"` otherwise
-
-The synthesizer returns 3 options differing in scope:
-1. **Minimal fix** — smallest change
-2. **Balanced approach** — proper fix, reasonable scope (usually recommended)
-3. **Comprehensive refactor** — addresses root cause and technical debt
-
-### Plan selection
-
-**Interactive mode (`resolve.approval_gate: auto`):**
-Display the plan summary and proceed with the recommended option:
+After plan selection:
 ```
 [2/5] Plan         ✓ approach: {selected option name}
 ```
-
-**Interactive mode (`resolve.approval_gate: comment-and-wait`):**
-Present all 3 options to the user:
-
-```
-◆ Implementation Options
-┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
-
-  [1] Minimal fix (S, Low risk)
-      {summary}
-
-  [2] Balanced refactor (M, Medium risk) ← recommended
-      {summary}
-
-  [3] Comprehensive overhaul (L, High risk)
-      {summary}
-
-Select option [1/2/3]:
-```
-
-**Auto mode:**
-Auto-select the recommended option (best balance of quality and effort). No user prompt.
-
-```
-[2/5] Plan         ✓ auto-selected option {N}: {name}
-```
-
-### Inline fallback
-
-If no Agent tool, analyze the research findings and generate the plan inline.
 
 ---
 
 ## Step 3 — Implement
 
-Write code and all tests based on the selected plan.
-
-### Subagent delegation (preferred)
-
-Spawn the implementer agent with:
-- Issue data
-- Research findings (from Step 1)
-- Selected plan (the chosen option from Step 2)
-- Branch name
-- Naming conventions: `docs/naming-conventions.md`
-- Max commits: `resolve.max_commits`
-
-The implementer writes:
-1. Implementation code with atomic commits
-2. Unit tests for all new/changed functions
-3. Integration tests (if framework exists)
-4. E2e tests (if framework exists)
-5. All committed following conventional commit format
-
-### Max commits guard
-
-If commits exceed `resolve.max_commits`:
-- Interactive: warn and ask to continue
-- Auto: warn in log, continue anyway
-
-### Inline fallback
-
-If no Agent tool, implement inline following `shared/agents/implementer.md`.
+Write code and tests based on the selected plan. Spawn the `implementer` subagent (see `shared/agents/implementer.md`) with the plan, branch name, and naming conventions. Full payload, commit guardrails, and inline fallback are in `references/pipeline-steps.md` (*Step 3 — Implement*).
 
 After implementation:
 ```
@@ -357,48 +242,9 @@ After implementation:
 
 ## Step 4 — QA
 
-Automated quality assurance loop: review code, run tests, build, fix issues. Repeats until clean or max cycles reached.
+Automated review-fix loop: review → test → fix → repeat until clean or max cycles reached. Each cycle spawns a *fresh* `code-reviewer` subagent (see `shared/agents/code-reviewer.md`) for unbiased review.
 
-### QA cycle
-
-Each cycle:
-
-1. **Code review** — spawn a fresh code-reviewer agent (see `shared/agents/code-reviewer.md`). Fresh agent each cycle ensures unbiased review.
-
-2. **Run tests** — detect and run the project's test suite:
-   - Unit tests
-   - Integration tests
-   - E2e tests (if framework exists)
-   - Build/compile check
-
-3. **Evaluate results:**
-   - If reviewer returns `PASS` AND all tests pass AND build succeeds → exit loop, QA passed
-   - If issues found → fix them, then start next cycle
-
-4. **Fix issues** — for each issue from the reviewer or test failures:
-   - Read affected file
-   - Apply fix
-   - Stage and commit: `fix(scope): address review feedback (#N)`
-
-### Loop controls
-
-- **Max cycles:** `resolve.qa_max_cycles` (default: 5)
-- **Exit on clean:** Stop as soon as review passes AND tests pass
-- **Exit on stagnation:** If the same issues appear in 2 consecutive cycles, stop and report
-
-### After QA
-
-If clean:
-```
-[4/5] QA           ✓ clean after {N} cycles
-```
-
-If max cycles with remaining issues:
-```
-[4/5] QA           ⚠ {N} issues remain after {max} cycles
-```
-In interactive mode: show remaining issues and ask to continue.
-In auto mode: continue to Deliver — the PR can be created with known issues noted.
+Cycle mechanics, loop controls (`resolve.qa_max_cycles`, exit-on-clean, exit-on-stagnation), and the remaining-issues flow are in `references/pipeline-steps.md` (*Step 4 — QA*).
 
 ---
 
@@ -438,38 +284,7 @@ gh pr create --title "{pr_title}" --body "{pr_body}"
 
 **PR title:** `{type}({scope}): {description} (#{issue_number})` (see `docs/naming-conventions.md`)
 
-**PR body:**
-
-```markdown
-Closes #{issue_number}
-
-## Summary
-
-{One-paragraph summary}
-
-## Approach
-
-{Selected option name and description}
-
-## Changes
-
-| File | Change |
-|------|--------|
-| `{file}` | {description} |
-
-## Test Results
-
-- Unit tests: {count} passed
-- Integration tests: {count} passed (or skipped)
-- E2e tests: {count} passed (or skipped)
-- Build: passed
-- QA cycles: {count}
-
-## Acceptance Criteria
-
-- [x] {criterion — checked if addressed}
-- [ ] {criterion — unchecked with note}
-```
+**PR body:** Fill the template in `references/report-templates.md` (section *PR Body Template*) — Summary, Approach, Changes table, Test Results, Acceptance Criteria.
 
 ### Project board sync
 
@@ -484,61 +299,11 @@ After delivery:
 
 ## Final Report
 
-After the pipeline completes, print a structured step-by-step summary showing what happened at each stage. This gives the user a quick visual scan of the entire resolution.
+After the pipeline completes, print a structured step-by-step summary so the user can scan the whole resolution at a glance. Use the templates in `references/report-templates.md`:
 
-### Successful resolution
-
-```
-◆ Issue #{issue_number} — resolved
-┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
-
-  Preflight:       ✓ pass
-  Research:        ✓ pass ({files_read} files analyzed, {complexity})
-  Plan:            ✓ pass ({option_name}, {risk_rating} risk)
-  Implement:       ✓ pass ({files_changed} files, {tests_written} tests)
-  QA:              ✓ pass ({cycles} cycles, {issues_found} issues fixed)
-  Deliver:         ✓ pass (PR #{pr_number} created)
-  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
-  Result:          DONE
-
-  PR #{pr_number}: {pr_title}
-  https://github.com/owner/repo/pull/{pr_number}
-  Closes #{issue_number}
-```
-
-### Resolution with issues
-
-If any step had problems (e.g., QA found unfixable issues, tests still failing):
-
-```
-◆ Issue #{issue_number} — resolved with warnings
-┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
-
-  Preflight:       ✓ pass
-  Research:        ✓ pass ({files_read} files analyzed)
-  Plan:            ✓ pass ({option_name})
-  Implement:       ✓ pass ({files_changed} files)
-  QA:              ⚠ warn ({remaining} issues remain after {cycles} cycles)
-  Deliver:         ✓ pass (PR #{pr_number} created)
-  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
-  Result:          DONE (manual review recommended)
-
-  PR #{pr_number}: {pr_title}
-  https://github.com/owner/repo/pull/{pr_number}
-  Closes #{issue_number}
-```
-
-### Already resolved
-
-```
-◆ Issue #{issue_number} — already resolved
-┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
-
-  Preflight:       ✓ pass
-  Research:        ○ skipped (already fixed by {sha7})
-  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
-  Result:          SKIPPED — issue closed
-```
+- *Final Report — Successful Resolution* — every step passed
+- *Final Report — Resolution With Warnings* — QA left residual issues or another step warned
+- *Final Report — Already Resolved* — Step 0 or Step 1 detected the issue was already closed
 
 ---
 
@@ -559,22 +324,7 @@ No `[y/N]` prompts, no `Choose:` prompts, no `Continue?` prompts. Every decision
 
 ## Expected Output
 
-A successful resolve prints the full 6-step tracker and ends with the PR URL:
-
-```
-  ◆ Resolve Pipeline
-  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
-  [0/5] Preflight    ✓ issue #42 open, not yet resolved
-  [1/5] Research     ✓ read 12 files, complexity: medium
-  [2/5] Plan         ✓ option 2 selected: balanced refactor
-  [3/5] Implement    ✓ 3 files changed, 8 unit tests, 2 e2e tests
-  [4/5] QA           ✓ clean after 2 cycles
-  [5/5] Deliver      ✓ PR #87 created
-
-  ✓ Done — PR #87: fix(auth): resolve mobile auth redirect (#42)
-    https://github.com/user/repo/pull/87
-    Closes #42
-```
+A successful resolve prints the 6-step tracker and ends with the PR URL — see the *Expected Inline Pipeline Output* example in `references/report-templates.md`.
 
 ## Edge Cases
 
@@ -625,6 +375,8 @@ All errors use rich format from `references/error-messages.md`:
 - **`shared/agents/synthesizer.md`** — Plan subagent (Step 2)
 - **`shared/agents/implementer.md`** — Implement subagent (Step 3)
 - **`shared/agents/code-reviewer.md`** — QA review subagent (Step 4)
+- **`references/pipeline-steps.md`** — Full delegation payloads, phases, and inline fallbacks for Steps 1–4
+- **`references/report-templates.md`** — PR body template, final report templates, and expected inline output
 - **`references/error-messages.md`** — Complete error catalog
 - **`docs/naming-conventions.md`** — Branch, commit, PR naming conventions
 - **`docs/github-projects-sync.md`** — GitHub Projects status sync

--- a/skills/issue-resolver/references/pipeline-steps.md
+++ b/skills/issue-resolver/references/pipeline-steps.md
@@ -1,0 +1,156 @@
+# Pipeline Step Details
+
+Detailed procedures for each subagent delegation in the resolve pipeline. SKILL.md keeps the contract short; this file holds the full input/output spec and inline fallback instructions.
+
+## Step 1 — Research (codebase-researcher subagent)
+
+### Delegation payload
+
+```json
+{
+  "issue": { <issue data from Step 0> },
+  "config": {
+    "max_files": 30,
+    "trace_depth": 3,
+    "scan_timeout": 120,
+    "output_format": "json"
+  },
+  "repo_root": "<absolute path>"
+}
+```
+
+### What the researcher does
+
+1. **Verify not already resolved** — check git history for closing commits and scan the codebase for evidence the bug is fixed.
+2. **Scan codebase** — extract targets, grep/glob, read files, trace dependencies.
+3. **Assess complexity** — trivial / low / medium / high / complex.
+4. **Research solutions** (for high/complex) — algorithms, optimizations, design patterns, web search if needed.
+5. **Analyze git history** — prior attempts, regressions, domain experts (via `git blame`).
+6. **Cross-reference issues** — duplicates, blockers, related work.
+
+### Early exit: already resolved
+
+If the researcher returns `already_resolved: true` or `pr_in_progress: true`:
+
+```
+✓ Issue #N appears to already be resolved
+  {resolution_details}
+
+  Recommend closing the issue.
+```
+
+- Auto mode: close the issue with a comment and move on.
+- Interactive mode: inform the user and stop.
+
+### Inline fallback
+
+If no Agent tool, execute research inline following the same phases described in `shared/agents/codebase-researcher.md`.
+
+### GitHub Projects status transition
+
+If `projects.sync_enabled` is true, set the issue status to `status_map.in_progress` (see `docs/github-projects-sync.md`).
+
+## Step 2 — Plan (synthesizer subagent)
+
+### Delegation payload
+
+- Issue data
+- Research findings (JSON from Step 1)
+- Mode: `"auto"` if auto-pilot, `"interactive"` otherwise
+
+### Options returned
+
+The synthesizer returns 3 options differing in scope:
+
+1. **Minimal fix** — smallest change
+2. **Balanced approach** — proper fix, reasonable scope (usually recommended)
+3. **Comprehensive refactor** — addresses root cause and technical debt
+
+### Plan selection
+
+**Interactive, `resolve.approval_gate: auto`:** display the recommended option and proceed.
+
+**Interactive, `resolve.approval_gate: comment-and-wait`:** present all 3:
+
+```
+◆ Implementation Options
+┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+
+  [1] Minimal fix (S, Low risk)
+      {summary}
+
+  [2] Balanced refactor (M, Medium risk) ← recommended
+      {summary}
+
+  [3] Comprehensive overhaul (L, High risk)
+      {summary}
+
+Select option [1/2/3]:
+```
+
+**Auto mode:** auto-select the recommended option, no prompt.
+
+### Inline fallback
+
+If no Agent tool, analyze the research findings and generate the plan inline.
+
+## Step 3 — Implement (implementer subagent)
+
+### Delegation payload
+
+- Issue data
+- Research findings (from Step 1)
+- Selected plan (the chosen option from Step 2)
+- Branch name
+- Naming conventions: `docs/naming-conventions.md`
+- Max commits: `resolve.max_commits`
+
+### What the implementer writes
+
+1. Implementation code with atomic commits
+2. Unit tests for all new/changed functions
+3. Integration tests (if framework exists)
+4. E2e tests (if framework exists)
+5. All committed following conventional commit format
+
+### Max commits guard
+
+If commits exceed `resolve.max_commits`:
+- Interactive: warn and ask to continue
+- Auto: warn in log, continue anyway
+
+### Inline fallback
+
+If no Agent tool, implement inline following `shared/agents/implementer.md`.
+
+## Step 4 — QA (code-reviewer subagent, per cycle)
+
+Each cycle:
+
+1. **Code review** — spawn a *fresh* code-reviewer subagent per cycle (see `shared/agents/code-reviewer.md`) so each pass is unbiased.
+2. **Run tests** — unit, integration, e2e (if present), build/compile.
+3. **Evaluate results:**
+   - Reviewer returns `PASS` AND all tests pass AND build succeeds → exit loop, QA passed.
+   - Issues found → fix them, then start next cycle.
+4. **Fix issues** — for each issue from the reviewer or test failures: read affected file, apply fix, commit as `fix(scope): address review feedback (#N)`.
+
+### Loop controls
+
+- **Max cycles:** `resolve.qa_max_cycles` (default: 5)
+- **Exit on clean:** stop as soon as review passes AND tests pass
+- **Exit on stagnation:** if the same issues appear in 2 consecutive cycles, stop and report
+
+### After QA
+
+If clean:
+```
+[4/5] QA           ✓ clean after {N} cycles
+```
+
+If max cycles with remaining issues:
+```
+[4/5] QA           ⚠ {N} issues remain after {max} cycles
+```
+
+- Interactive: show remaining issues, ask to continue.
+- Auto: continue to Deliver — PR can be created with known issues noted.

--- a/skills/issue-resolver/references/report-templates.md
+++ b/skills/issue-resolver/references/report-templates.md
@@ -1,0 +1,111 @@
+# Report and PR Body Templates
+
+Templates for the PR body, the step-by-step final report, and the expected pipeline output. SKILL.md references this file at the relevant steps — do not inline these templates back into SKILL.md.
+
+## PR Body Template (Step 5 — Deliver)
+
+```markdown
+Closes #{issue_number}
+
+## Summary
+
+{One-paragraph summary}
+
+## Approach
+
+{Selected option name and description}
+
+## Changes
+
+| File | Change |
+|------|--------|
+| `{file}` | {description} |
+
+## Test Results
+
+- Unit tests: {count} passed
+- Integration tests: {count} passed (or skipped)
+- E2e tests: {count} passed (or skipped)
+- Build: passed
+- QA cycles: {count}
+
+## Acceptance Criteria
+
+- [x] {criterion — checked if addressed}
+- [ ] {criterion — unchecked with note}
+```
+
+The PR title follows `{type}({scope}): {description} (#{issue_number})` — see `docs/naming-conventions.md`.
+
+## Final Report — Successful Resolution
+
+```
+◆ Issue #{issue_number} — resolved
+┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+
+  Preflight:       ✓ pass
+  Research:        ✓ pass ({files_read} files analyzed, {complexity})
+  Plan:            ✓ pass ({option_name}, {risk_rating} risk)
+  Implement:       ✓ pass ({files_changed} files, {tests_written} tests)
+  QA:              ✓ pass ({cycles} cycles, {issues_found} issues fixed)
+  Deliver:         ✓ pass (PR #{pr_number} created)
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+  Result:          DONE
+
+  PR #{pr_number}: {pr_title}
+  https://github.com/owner/repo/pull/{pr_number}
+  Closes #{issue_number}
+```
+
+## Final Report — Resolution With Warnings
+
+When any step had problems (e.g., QA could not fully clean up, tests still flaky):
+
+```
+◆ Issue #{issue_number} — resolved with warnings
+┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+
+  Preflight:       ✓ pass
+  Research:        ✓ pass ({files_read} files analyzed)
+  Plan:            ✓ pass ({option_name})
+  Implement:       ✓ pass ({files_changed} files)
+  QA:              ⚠ warn ({remaining} issues remain after {cycles} cycles)
+  Deliver:         ✓ pass (PR #{pr_number} created)
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+  Result:          DONE (manual review recommended)
+
+  PR #{pr_number}: {pr_title}
+  https://github.com/owner/repo/pull/{pr_number}
+  Closes #{issue_number}
+```
+
+## Final Report — Already Resolved
+
+```
+◆ Issue #{issue_number} — already resolved
+┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+
+  Preflight:       ✓ pass
+  Research:        ○ skipped (already fixed by {sha7})
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+  Result:          SKIPPED — issue closed
+```
+
+## Expected Inline Pipeline Output
+
+A successful resolve prints the full 6-step tracker and ends with the PR URL:
+
+```
+  ◆ Resolve Pipeline
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+  [0/5] Preflight    ✓ issue #42 open, not yet resolved
+  [1/5] Research     ✓ read 12 files, complexity: medium
+  [2/5] Plan         ✓ option 2 selected: balanced refactor
+  [3/5] Implement    ✓ 3 files changed, 8 unit tests, 2 e2e tests
+  [4/5] QA           ✓ clean after 2 cycles
+  [5/5] Deliver      ✓ PR #87 created
+
+  ✓ Done — PR #87: fix(auth): resolve mobile auth redirect (#42)
+    https://github.com/user/repo/pull/87
+    Closes #42
+```

--- a/skills/issue-triage/SKILL.md
+++ b/skills/issue-triage/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: issue-triage
-description: Analyze and triage open GitHub issues for dependencies, priorities, parallelizable work, staleness, and already-fixed detection, caching results to .gitissue/triage.json. Use when asked to "triage issues", "prioritize issues", "what should I work on next", or "/issue-triage".
+description: "Analyze and triage open GitHub issues for dependencies, priorities, parallelizable work, staleness, and already-fixed detection, caching results to .gitissue/triage.json. Use when asked to triage issues, prioritize issues, what should I work on next, or /issue-triage. Don't use for analyzing one specific issue (use /issue-analysis), resolving an issue (use /issue-resolver), or creating new issues (use /issue-creator)."
 license: MIT
 compatibility: Requires git and GitHub CLI (gh) with authentication. Default mode (cached view) needs only local file access — no gh required.
 effort: medium
 metadata:
-  version: 0.5.1
+  version: 0.5.2
   creator: Luong NGUYEN <luongnv89@gmail.com>
 ---
 

--- a/skills/review-fix-loop/README.md
+++ b/skills/review-fix-loop/README.md
@@ -1,0 +1,67 @@
+# Review Fix Loop (Deprecated)
+
+> Deprecated alias — forwards all invocations to `/issue-pr-review`, which adds CI monitoring, end-to-end test execution, and auto-merge.
+
+## Highlights
+
+- Preserves the old `/review-fix-loop` command for muscle-memory users
+- Prints a one-line deprecation notice before handing off
+- Passes arguments through verbatim, including `--auto` and no-argument invocations
+- Contains no review logic of its own — all behavior lives in `/issue-pr-review`
+
+## When to Use
+
+| Say this... | Skill will... |
+|---|---|
+| `/review-fix-loop 42` | Print deprecation notice and forward to `/issue-pr-review 42` |
+| `/review-fix-loop` | Forward with no args so the target auto-detects the current branch's PR |
+| "review and fix" | Forward verbatim to `/issue-pr-review` |
+
+For any new project, prefer `/issue-pr-review` directly, or `/issue-pr-review-fix-loop` when you want the outer review-fix loop with fresh context per cycle.
+
+## How It Works
+
+```mermaid
+graph TD
+    A["User invokes /review-fix-loop"] --> B["Print deprecation notice"]
+    B --> C["Forward args to /issue-pr-review"]
+    C --> D["Hand off control"]
+    style A fill:#4CAF50,color:#fff
+    style D fill:#2196F3,color:#fff
+```
+
+## Installation
+
+Install via [npx (Vercel)](https://www.npmjs.com/package/skills):
+
+```bash
+npx skills add https://github.com/luongnv89/idd --skill review-fix-loop
+```
+
+Or via [agent-skill-manager (asm)](https://www.npmjs.com/package/agent-skill-manager):
+
+```bash
+asm install https://github.com/luongnv89/idd --skill review-fix-loop
+```
+
+## Usage
+
+```
+/review-fix-loop [PR_NUMBER] [--auto]
+```
+
+## Resources
+
+| Path | Description |
+|---|---|
+| `references/error-messages.md` | Short error catalog — mostly covers the case where `/issue-pr-review` is not installed |
+
+## Output
+
+One line from this skill:
+
+```
+○ /review-fix-loop is deprecated — forwarding to /issue-pr-review {args}
+```
+
+All further output comes from `/issue-pr-review`.

--- a/skills/review-fix-loop/SKILL.md
+++ b/skills/review-fix-loop/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: review-fix-loop
-description: Review a PR by delegating to /issue-pr-review — this skill is deprecated and forwards all invocations to the replacement, which adds CI monitoring and auto-merge. Use when asked to "review and fix", "review fix loop", or "auto-review my PR".
+description: "Review a PR by delegating to /issue-pr-review — this skill is deprecated and forwards all invocations to the replacement, which adds CI monitoring and auto-merge. Use when asked to review and fix, review fix loop, or auto-review my PR. Don't use for new projects — prefer /issue-pr-review directly, or /issue-pr-review-fix-loop for outer-loop iteration."
 license: MIT
 compatibility: Requires /issue-pr-review skill.
 effort: low
 metadata:
-  version: 0.3.0
+  version: 0.3.1
   creator: Luong NGUYEN <luongnv89@gmail.com>
 ---
 


### PR DESCRIPTION
## Summary

Evaluated all 9 skills in `skills/` against skill-creator standards and applied fixes so every skill now passes `quick_validate.py` cleanly (no errors, no warnings).

- Fix validation blocker: `issue-analysis` description contained `<N>` angle brackets that hard-failed the validator.
- Add negative-trigger clauses ("Don't use for ...") to all 9 descriptions so adjacent IDD skills stop false-triggering each other.
- Add missing `README.md` for `issue-analysis`, `issue-pr-review`, `review-fix-loop` (README is mandatory per skill-creator).
- Refactor oversize skills under the 500-line hard rule:
  - `issue-resolver`: 632 → 384 lines (moved pipeline step details and report templates into `references/`)
  - `issue-pr-review`: 509 → 441 lines (moved Step 7 summary templates into `references/report-templates.md`)
- Bump semver on every modified skill per skill-creator version rules.

## Version bumps

| Skill | From | To |
|---|---|---|
| auto-pilot | 2.1.1 | 2.1.2 |
| init-gitissue | 0.3.0 | 0.3.1 |
| issue-analysis | 0.4.0 | 0.4.1 |
| issue-creator | 0.4.0 | 0.4.1 |
| issue-pr-review | 0.3.0 | 0.3.2 |
| issue-pr-review-fix-loop | 0.3.0 | 0.3.1 |
| issue-resolver | 0.6.0 | 0.7.0 |
| issue-triage | 0.5.1 | 0.5.2 |
| review-fix-loop | 0.3.0 | 0.3.1 |

## Validation

All 9 skills pass `python3 ~/.claude/skills/skill-creator/scripts/quick_validate.py` with no errors and no warnings. All SKILL.md files are under the 500-line hard rule.

## Test plan

- [ ] Run `quick_validate.py` on each of the 9 skills — expect `Skill is valid!` with no warning
- [ ] Confirm `issue-analysis` description no longer contains `<` or `>`
- [ ] Confirm 3 new READMEs render on GitHub (issue-analysis, issue-pr-review, review-fix-loop)
- [ ] Spot-check that `issue-resolver` and `issue-pr-review` SKILL.md still reference the moved template content via the new `references/*.md` files
- [ ] Invoke one of the refactored skills (e.g., `/issue-resolver N`) to confirm the pipeline still reads references correctly