### PR TITLE
docs(issue-creator): rewrite README and SKILL.md to intent-only language (#31)

### DIFF
--- a/skills/issue-creator/README.md
+++ b/skills/issue-creator/README.md
@@ -1,22 +1,33 @@
 # Issue Creator
 
-> Create structured, codebase-aware GitHub issues — single, batch, or normalize existing ones with codebase context.
+> Creates structured, intent-focused GitHub issues from text, screenshots, or lists. Preserves reporter context and generates acceptance criteria without guessing implementation details.
 
 ## Highlights
 
-- Scans your codebase to identify affected files with confidence levels (high/medium/low)
-- Auto-classifies issues as bug, feature, or improvement
+- Captures durable human intent in a standard template (type, description, reporter context, acceptance criteria, metadata)
+- Auto-classifies issues as bug, feature, or improvement with confidence levels (high/medium/low)
 - **Batch mode**: extract multiple issues from a single input with preview table and approval
 - Normalizes messy existing issues with backup safety and security-label protection
-- Generates acceptance criteria, technical notes, and labels from codebase context
+- Generates acceptance criteria from the problem description — never from the codebase
+
+## Output Contract
+
+`/issue-creator` is an **intent-capture tool only**. The issue body it produces MUST NOT include any of the following:
+
+- **No predicted affected files** — no file paths, modules, or directories guessed from the codebase
+- **No generated technical notes** — no implementation approach, architecture constraints, or design notes derived from code
+- **No root cause** — no diagnostic reasoning about *why* a bug occurs in the current code
+- **No implementation hints** — no code snippets, function signatures, or "how to fix" instructions
+
+Those four artifacts are produced fresh by `/issue-analysis`, `/issue-triage`, and `/issue-resolver` against the current codebase at the moment work begins. Reporter-supplied technical detail is preserved verbatim inside the Reporter Context blockquote — only skill-generated technical content is prohibited.
 
 ## When to Use
 
 | Say this... | Skill will... |
 |---|---|
-| "/issue-creator the login page is broken on mobile" | Scan codebase, create structured bug issue with affected files and acceptance criteria |
-| "/issue-creator 42" | Fetch issue #42, enrich with codebase context, preserve original text in backup |
-| "/issue-creator 42 --dry-run" | Preview what normalization would add without changing anything |
+| "/issue-creator the login page is broken on mobile" | Classify as a bug, draft a structured issue from your description, generate acceptance criteria from the stated problem |
+| "/issue-creator 42" | Fetch issue #42, restructure into the standard intent-only template, preserve original text in a backup comment |
+| "/issue-creator 42 --dry-run" | Preview what normalization would change without modifying the issue |
 | "file a bug about the checkout timeout" | Create a structured bug issue from the description |
 | "/issue-creator 1. Fix auth bug 2. Add dark mode 3. Refactor DB" | Detect 3 items, show preview table, create all after approval |
 
@@ -24,10 +35,10 @@
 
 ```mermaid
 graph TD
-    A["Parse input text or image"] --> B["Scan codebase for affected files"]
-    B --> C["Classify type & check duplicates"]
-    C --> D["Generate structured issue from template"]
-    D --> E["Preview & confirm with user"]
+    A["Parse input text or image"] --> B["Classify type and draft title"]
+    B --> C["Check for duplicate issues"]
+    C --> D["Generate intent-only issue body from template"]
+    D --> E["Preview and confirm with user"]
     E --> F["Create via gh CLI"]
     style A fill:#4CAF50,color:#fff
     style F fill:#2196F3,color:#fff
@@ -38,13 +49,15 @@ graph TD
 ```mermaid
 graph TD
     A["Fetch issue #N"] --> B["Check: normalized? locked? security?"]
-    B --> C["Scan codebase for context"]
+    B --> C["Re-classify type from current body"]
     C --> D["Preview with confidence scores"]
     D --> E["Backup original body"]
-    E --> F["Update issue & add labels"]
+    E --> F["Update issue and add labels"]
     style A fill:#4CAF50,color:#fff
     style F fill:#2196F3,color:#fff
 ```
+
+The skill never reads project source files when generating an issue. Duplicate detection compares against existing issues only, not against code.
 
 ## Installation
 
@@ -79,7 +92,7 @@ asm install https://github.com/luongnv89/idd --skill issue-creator
 
 ## Output
 
-- A structured GitHub issue with `<!-- gitissue:normalized v1 -->` marker
+- A structured GitHub issue with `<!-- gitissue:normalized v1 -->` marker, populated only with intent-capture content (type, description, reporter context, screenshots, acceptance criteria, metadata)
 - Terminal preview with confidence scores before creation
 - For batch: preview table of all items, per-item progress, summary with retry hints for failures
 - For normalization: backup comment preserving original body, normalization summary comment

--- a/skills/issue-creator/SKILL.md
+++ b/skills/issue-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue-creator
-description: "Create or normalize structured GitHub issues from text, screenshots, or lists. Use for filing bugs/features, batch creation, or template cleanup. Don't use for resolving, triaging, or deep issue analysis."
+description: "Creates structured, intent-focused GitHub issues from text, screenshots, or lists. Preserves reporter context and generates acceptance criteria without guessing implementation details. Use for filing bugs/features, batch creation, or template cleanup. Don't use for resolving, triaging, or deep issue analysis."
 license: MIT
 compatibility: Requires git and GitHub CLI (gh) with authentication. Run `gh auth status` to verify.
 effort: medium
@@ -11,9 +11,24 @@ metadata:
 
 # /issue-creator
 
-Create structured GitHub issues — or normalize existing ones into a standard template. Supports single, batch, and normalization modes. Issues capture human intent only (no codebase analysis) — the resolver and triage skills scan the codebase themselves when needed.
+Creates structured, intent-focused GitHub issues from text, screenshots, or lists. Preserves reporter context and generates acceptance criteria without guessing implementation details.
+
+This skill is an **intent-capture tool only**. It does not analyze the codebase, predict affected files, or generate technical notes. The resolver and triage skills perform their own current-code analysis when needed — see the Output Contract below.
 
 Three modes: **Create** (new issue from text/image), **Normalize** (restructure existing issue #N into standard template), and **Batch** (extract multiple issues from one input).
+
+## Output Contract
+
+Issues produced by `/issue-creator` capture **durable human intent only**. The skill MUST NOT include any of the following in the issue body:
+
+- **No predicted affected files** — file paths, modules, or directories that the skill guessed by inspecting the codebase
+- **No generated technical notes** — implementation approach, architecture constraints, or design notes derived from code
+- **No root cause** — diagnostic reasoning about *why* a bug occurs in the current code
+- **No implementation hints** — code snippets, function signatures, or step-by-step "how to fix" instructions
+
+These four artifacts are the responsibility of `/issue-analysis`, `/issue-triage`, and `/issue-resolver`, which produce them fresh against the current codebase at the moment work begins. Encoding them in the issue body would freeze stale understanding into durable memory.
+
+What the issue body **does** contain: type classification, problem description, reporter context (verbatim), screenshots, acceptance criteria, and metadata (priority, effort, labels). Reporter-supplied technical detail is preserved verbatim inside the Reporter Context blockquote — only skill-generated technical content is prohibited.
 
 ## Modes
 
@@ -296,7 +311,7 @@ Read the appropriate template from `templates/` (bug.md, feature.md, or improvem
 5. **Acceptance Criteria** — 3-5 testable criteria derived from the problem description, with confidence levels
 6. **Metadata** — suggested priority, estimated effort (XS/S/M/L/XL), suggested labels
 
-**Note:** Issues intentionally do NOT include codebase analysis (affected files, technical notes, architecture constraints). The resolver and triage skills scan the codebase themselves when needed, against current code.
+**Note:** Per the Output Contract above, the issue body MUST NOT include predicted affected files, generated technical notes, root cause, or implementation hints. Acceptance criteria express *what done looks like*, not *how to implement it*.
 
 ### Step 5 — Preview and Confirm
 


### PR DESCRIPTION
Closes #31

## Summary

Rewrites the user-facing docs for `/issue-creator` so they describe the skill purely as an intent-capture tool. Replaces every claim that the skill scans the codebase, predicts affected files, or generates technical notes from code. Aligns the skill's documented contract with the IDD methodology's intent-code boundary: issues capture durable intent only; codebase reality is produced fresh by `/issue-analysis`, `/issue-triage`, and `/issue-resolver` when work begins.

## Approach

1. Replace the SKILL.md frontmatter `description` with the canonical sentence from the issue.
2. Add a top-level `## Output Contract` section to **both** `SKILL.md` and `README.md` that enumerates the four prohibitions verbatim.
3. Rewrite the README tagline, highlights, "When to Use" rows, mermaid diagrams, and output description to remove every codebase-scan claim.
4. Tighten the inline note in SKILL.md Step 4 to reference the new contract.

The duplicate-detector subagent (which compares issues against other issues, not against code) is preserved. Templates already had no Technical Notes section, so they were left untouched.

## Changes

| File | Change |
|------|--------|
| `skills/issue-creator/SKILL.md` | Canonical description in frontmatter and body; new Output Contract section; tightened Step-4 note |
| `skills/issue-creator/README.md` | Intent-only tagline, highlights, when-to-use, mermaid diagrams; new Output Contract section |

## Acceptance Criteria

- [x] `skills/issue-creator/README.md` no longer claims the skill scans code, predicts files, or generates technical notes.
- [x] `skills/issue-creator/SKILL.md` uses the canonical description above.
- [x] An "Output contract" section enumerates the four prohibitions (no predicted affected files, no generated technical notes, no root cause, no implementation hints).
- [x] Reading both files leaves no doubt that the skill is intent-capture only.

## Test Plan

- [x] Adversarial grep for banned phrases (`scan.*codebase`, `affected files`, `technical notes`, `root cause`, `implementation hint`, `codebase-aware`, `codebase context`, `predict.*file`) — only the prohibition statements themselves remain.
- [x] Frontmatter description length (325 chars) is within the range of existing skills (210–436 chars), so asm validation continues to pass.
- [x] Manual re-read of both files confirms the intent-capture-only mandate is unambiguous.

Tracks milestone "IDD Improvement Plan (Final)" §1a.