### PR TITLE
docs: audit skill READMEs for codebase-enriched claims (#32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ IDD is also **Intention-Driven Development** — and that name captures somethin
 
 Expressing what you actually want is hard. Even experienced developers struggle to articulate a problem clearly enough for someone else — human or AI — to act on it. Vague descriptions lead to wrong assumptions, wasted effort, and solutions that miss the point.
 
-`/issue-creator` changes this dynamic. When you describe a problem in plain language, it structures your input into a typed issue with acceptance criteria, context, and technical notes. But the real value isn't the output — it's the **feedback loop**:
+`/issue-creator` changes this dynamic. When you describe a problem in plain language, it structures your input into a typed issue with reporter context and acceptance criteria — capturing intent only, never guessing affected files or implementation notes. But the real value isn't the output — it's the **feedback loop**:
 
 1. **You describe the problem** — loosely, incompletely, however it comes to mind
 2. **The agent proposes a structured issue** — classifying the type, filling in context, generating acceptance criteria

--- a/docs/idea.md
+++ b/docs/idea.md
@@ -1,5 +1,8 @@
 # Idea: GitIssue — Issue-Driven Development (IDD)
 
+> **Historical document — superseded by [`docs/idd-methodology.md`](idd-methodology.md).**
+> This file captures the original product concept (early 2026) when the design assumed `/issue-creator` would auto-enrich issues with codebase context. That direction was reversed: issues now capture **intent only**, and codebase analysis lives in `/issue-analysis`, `/issue-triage`, and `/issue-resolver` against current code. Phrases like "codebase-aware issues", "auto-enriched", or "affected files in the issue body" are historical and do **not** describe the shipped behavior. See `docs/idd-methodology.md` for the current intent-code boundary.
+
 ## Original Concept
 
 Introduce a new software development methodology called **Issue-Driven Development (IDD)**, more adapted to brownfield projects than greenfield. The core workflow is two commands:

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,5 +1,8 @@
 # PRD: gitissue
 
+> **Historical document — superseded by [`docs/idd-methodology.md`](idd-methodology.md) for the current methodology.**
+> This PRD (v1.1, 2026-03-20) describes the early product direction in which `/issue-creator` was specified to scan the codebase and embed affected files, technical notes, and architecture constraints into the issue body. That direction was reversed: issues now capture **intent only**. References in this document to "codebase-aware issues", "issue enrichment with codebase context", "affected files in the template", or "auto-enriched issues" are historical and do **not** describe the shipped behavior. The shipped behavior is described in skill READMEs and `docs/idd-methodology.md` (intent-code boundary).
+
 ## Table of Contents
 1. [Document Info](#document-info)
 2. [Product Overview](#1-product-overview)

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,5 +1,8 @@
 # Tasks — gitissue / IDD
 
+> **Historical document — superseded by GitHub issues.**
+> This task list was generated from PRD v1.1 (2026-03-20) and predates the intent-code boundary correction. Several deliverables describe issue templates with codebase-derived sections (affected files, technical notes, architecture constraints) that the shipped product does **not** include — those sections are produced fresh by `/issue-analysis`, `/issue-triage`, and `/issue-resolver` against the current codebase, not embedded in issue bodies. Active work tracking now lives in GitHub issues; consult skill READMEs and `docs/idd-methodology.md` for current behavior.
+
 Generated from PRD v1.1 and review decisions on 2026-03-20.
 
 ## Sprint 1: Foundation (v0.1.0) — Target: 2026-04-02

--- a/docs/validate.md
+++ b/docs/validate.md
@@ -1,5 +1,8 @@
 # Validation: GitIssue — Issue-Driven Development (IDD)
 
+> **Historical document — superseded by [`docs/idd-methodology.md`](idd-methodology.md).**
+> This early validation memo describes a direction in which `/issue-creator` was assumed to perform "codebase-aware issue enrichment at creation time". That direction was reversed: issues now capture **intent only**. The differentiator versus competing tools today is structured intent capture plus separate, on-demand current-code analysis (`/issue-analysis`, `/issue-triage`, `/issue-resolver`) — not in-issue codebase enrichment. Treat any "codebase-aware issue" or "auto-enriched issue" wording below as historical, not as a description of the shipped product.
+
 ## Quick Verdict
 **Build it**
 

--- a/skills/auto-pilot/README.md
+++ b/skills/auto-pilot/README.md
@@ -2,6 +2,10 @@
 
 > Fully autonomous development loop that triages, resolves, reviews, and merges GitHub issues end-to-end with zero user prompts.
 
+## Intent-Code Boundary
+
+`/auto-pilot` respects the intent-code boundary at every step of the loop. It treats **issues as durable intent contracts** and orchestrates `/issue-triage`, `/issue-resolver`, and `/issue-pr-review` — each of which scans the **current codebase** when it needs file-level information. The auto-pilot itself never reads source files, predicts affected files into issue bodies, or freezes implementation guesses into stored state. When `/issue-creator` is invoked to normalize an unstructured issue mid-loop, it captures intent only — no codebase enrichment. See `docs/idd-methodology.md` for the full boundary contract.
+
 ## Highlights
 
 - **Token-optimized review** — script pre-pass auto-fixes lint/format (zero tokens), LLM only reviews critical issues, soft pass skips nits

--- a/skills/issue-analysis/README.md
+++ b/skills/issue-analysis/README.md
@@ -2,6 +2,10 @@
 
 > Deep analysis of a single GitHub issue — root cause, architecture impact, implementation options, complexity, and risk — persisted to `.gitissue/analysis-N.json`.
 
+## Intent-Code Boundary
+
+`/issue-analysis` respects the intent-code boundary that separates durable intent from time-sensitive code understanding. The **issue body** is the source of truth for *what* should change — problem, reporter context, acceptance criteria. This skill does the *where and why* against the **current codebase**: root cause, affected files, implementation options, complexity, and risk. Those findings are written to `.gitissue/analysis-N.json` so they stay attached to a specific point in time, not frozen into the issue body. A fresh `/issue-analysis N` always re-scans current code rather than trusting cached file lists. See `docs/idd-methodology.md` for the full boundary contract.
+
 ## Highlights
 
 - Scans the codebase for files most relevant to the issue

--- a/skills/issue-pr-review-fix-loop/README.md
+++ b/skills/issue-pr-review-fix-loop/README.md
@@ -2,6 +2,10 @@
 
 > Outer review-fix loop with agent reuse across cycles and a fresh confirmation pass at the end — review, fix, commit, push, repeat until clean.
 
+## Intent-Code Boundary
+
+`/issue-pr-review-fix-loop` respects the intent-code boundary. It wraps `/issue-pr-review` in an outer loop; both reviewer and fixer subagents read the **PR diff** and the **current codebase** for every cycle — they do not rely on predicted file lists or implementation hints from the linked issue body. The linked issue's **acceptance criteria** define the pass condition; the loop converges by addressing live review findings, not by reconciling against stale issue-embedded notes. Cycle history and remaining issues stay in the PR thread, not in the issue body. See `docs/idd-methodology.md` for the full boundary contract.
+
 ## Highlights
 
 - **Reuses reviewer and fixer agents** across cycles for efficiency — the reviewer verifies its own issues were fixed, and the fixer retains repo context

--- a/skills/issue-pr-review/README.md
+++ b/skills/issue-pr-review/README.md
@@ -2,6 +2,10 @@
 
 > Review a pull request end-to-end — analyze, test, fix, check CI, and auto-merge when clean — with up to 3 token-optimized fix cycles.
 
+## Intent-Code Boundary
+
+`/issue-pr-review` respects the intent-code boundary. The reviewer reads the **PR diff** and the **current codebase** for findings — it never relies on a predicted file list embedded in the linked issue body. When the linked issue exists, its **acceptance criteria** are the contract the PR is evaluated against; everything else (root cause, affected files, implementation choices) is verified against the code as it is right now. Findings stay in the PR review thread and per-cycle reports — they are not written back into the issue body. See `docs/idd-methodology.md` for the full boundary contract.
+
 ## Highlights
 
 - Mechanical pre-pass (lint, format, tests) before any LLM cycles to save tokens

--- a/skills/issue-resolver/README.md
+++ b/skills/issue-resolver/README.md
@@ -2,6 +2,10 @@
 
 > Resolve a GitHub issue end-to-end — from open issue to atomic PR in 6 steps.
 
+## Intent-Code Boundary
+
+`/issue-resolver` respects the intent-code boundary. The **issue body** owns durable intent: the problem statement, reporter context, and acceptance criteria. The resolver scans the **current codebase** during Research (Step 1) to discover affected files, dependencies, and constraints — it never trusts the issue body for predicted file lists or implementation hints. The atomic PR captures *how* the change was made; the linked issue captures *why* it mattered. If the issue body lacks structure (e.g., no acceptance criteria), the resolver runs `/issue-creator` first to normalize it without inventing technical detail. See `docs/idd-methodology.md` for the full boundary contract.
+
 ## Highlights
 
 - **Full pipeline**: Preflight → Research → Plan → Implement → QA → Deliver

--- a/skills/issue-triage/README.md
+++ b/skills/issue-triage/README.md
@@ -2,6 +2,10 @@
 
 > Analyze open GitHub issues to surface dependencies, suggest priorities, identify parallelizable work, flag stale issues, and detect issues already fixed by other PRs.
 
+## Intent-Code Boundary
+
+`/issue-triage` respects the intent-code boundary. **Issues** are read for intent — title, body keywords, age, labels — and the **current codebase** is scanned fresh at triage time to discover which files each issue touches. Dependencies between issues are computed from this live scan, not from any predicted file list embedded in issue bodies. Already-fixed detection comes from current git history (commits and merged PRs), not from claims inside the issue. Results are cached to `.gitissue/triage.json` with a timestamp so users see immediately when the snapshot is stale. See `docs/idd-methodology.md` for the full boundary contract.
+
 ## Highlights
 
 - Builds a dependency graph from shared affected files across issues

--- a/skills/issue-triage/SKILL.md
+++ b/skills/issue-triage/SKILL.md
@@ -268,7 +268,7 @@ Two subagents run in parallel: the **history scanner** finds issues already fixe
 
 Summary:
 - **Step 1b** — flags open issues whose titles/bodies match recent commit messages or merged PR descriptions. Marks them `potentially_fixed` with evidence links.
-- **Step 2** — for each issue, derives affected files from the body, then computes pairwise overlap to produce a `dependencies[]` graph.
+- **Step 2** — for each issue, extracts keywords from the title and body and scans the current codebase to discover affected files, then computes pairwise overlap to produce a `dependencies[]` graph. Affected files are derived from the codebase scan, never read from the issue body.
 - **Step 3** — detects circular dependency cycles in the graph and breaks them before the topological sort.
 
 ---


### PR DESCRIPTION
Closes #32

## Summary

Audit every skill README and SKILL.md for stale "codebase-enriched issue" language inherited from the original product direction (PRD v1.1) and align them with the intent-code boundary that `/issue-creator` was rewritten to enforce in #31.

- Add a one-paragraph **Intent-Code Boundary** section to every skill README that touches issues, analysis, PRs, or automation: `issue-analysis`, `issue-resolver`, `issue-triage`, `auto-pilot`, `issue-pr-review`, `issue-pr-review-fix-loop`. Each paragraph states what *that skill* owns vs. what the issue body owns and points at `docs/idd-methodology.md` as the canonical contract.
- `issue-creator` (already corrected in #31) keeps its existing **Output Contract** section, which is functionally equivalent and more rigorous; not modified per the merge note.
- `init-gitissue` is intentionally exempt — it generates `.gitissue.yml`, never touches issue content.
- Fix `skills/issue-triage/SKILL.md` Step 2 wording: replace the misleading "derives affected files from the body" with the accurate "extracts keywords from the title and body and scans the current codebase". The implementation (in `shared/agents/issue-relationship-scanner.md`) was already correct — only the SKILL.md summary line contradicted the boundary.
- Fix public `README.md` line 233: drop "technical notes" from the description of what `/issue-creator` produces and clarify that intent capture excludes affected-file guesses and implementation notes.
- Mark `docs/idea.md`, `docs/prd.md`, `docs/tasks.md`, and `docs/validate.md` as **historical** with a one-line banner pointing readers at `docs/idd-methodology.md`. The body text is intentionally not rewritten — those documents are snapshots of the original product reasoning when the design assumed in-issue codebase enrichment, and preserving them keeps the decision trail intact.

## Why marked-historical for docs/{idea,prd,tasks,validate}.md

Acceptance criterion #4 explicitly allows "updated, marked historical, or archived." Marked-historical is the lowest-risk option: the original product context stays accessible (useful for understanding decisions) and a single banner is enough to keep new readers from being misled. Rewriting these multi-thousand-line documents would have been higher risk and lower value than fixing the live skill READMEs and SKILL.md files where the contradictions actually mattered.

## Acceptance criteria

- [x] No skill README contradicts the intent-code boundary
- [x] Each skill README touching issues/analysis/PRs/automation contains an "intent-code boundary" paragraph
- [x] Public README, skill READMEs, and `docs/idd-methodology.md` tell one coherent story
- [x] Decision recorded for `docs/idea.md`, `docs/prd.md`, `docs/tasks.md` (and `docs/validate.md` for symmetry): marked historical with a banner

## Test plan

- [x] `grep -rn -E "codebase-aware|codebase-enriched|auto-enrich|enrich.{0,30}codebase context" skills/*/README.md skills/*/SKILL.md README.md docs/idd-methodology.md` returns zero hits
- [x] Each skill README contains either an "Intent-Code Boundary" section or an equivalent "Output Contract" section (verified for 7/8 skills; `init-gitissue` exempt)
- [x] All four planning docs (`idea.md`, `prd.md`, `tasks.md`, `validate.md`) start with a Historical banner
- [x] No source code changes; docs-only PR — no test suite to run