### PR TITLE
feat(auto-pilot): conservative-by-default merge modes (#33)

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -178,6 +178,25 @@ review:
 
 # Auto-pilot settings (used by /auto-pilot)
 autopilot:
+  # Merge mode — controls when /auto-pilot is allowed to merge PRs.
+  # Type: string
+  # Values: "conservative" | "balanced" | "aggressive"
+  # Default: "conservative"
+  # "conservative": create PR, run review-fix cycles, leave PR open. Never auto-merges.
+  # "balanced":     auto-merge clean PRs only. Unresolved issues create a follow-up
+  #                 and leave the PR open.
+  # "aggressive":   auto-merge clean PRs AND, when merge_partial=true, merge partial
+  #                 PRs with a follow-up issue. Documented as risky; opt-in only.
+  # When set, this field is authoritative — autopilot.auto_merge is ignored.
+  mode: conservative
+
+  # Allow merging PRs that still have unresolved fixable review issues.
+  # Type: boolean
+  # Default: false
+  # Only honored when mode is "aggressive"; ignored otherwise. Both keys must be
+  # set explicitly to reach partial-merge behavior — there is no casual opt-in.
+  merge_partial: false
+
   # Max iterations (issues to process) before stopping
   # Type: integer
   # Default: 10
@@ -195,6 +214,10 @@ autopilot:
   # Auto-merge PRs after review passes
   # Type: boolean
   # Default: true
+  # LEGACY: kept for backwards compatibility. Ignored when autopilot.mode is set.
+  # When mode is unset, falling back to legacy interpretation:
+  #   auto_merge: true  ≈ mode: aggressive + merge_partial: true (preserves prior 2.1.x behavior)
+  #   auto_merge: false ≈ mode: conservative
   auto_merge: true
 
   # Pause loop on failure instead of skipping to next issue
@@ -342,9 +365,11 @@ graph TD
     RV --> RV8["test_timeout"]
     RV --> RV9["soft_pass"]
 
+    AP --> AP0["mode"]
+    AP --> AP00["merge_partial"]
     AP --> AP1["max_iterations"]
     AP --> AP2["review_cycles"]
-    AP --> AP3["auto_merge"]
+    AP --> AP3["auto_merge<br/>(legacy)"]
     AP --> AP4["pause_on_failure"]
     AP --> AP5["skip_labels"]
     AP --> AP6["critical_labels"]
@@ -419,9 +444,11 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `review.ci_timeout` | `600` | CI polling timeout |
 | `review.test_timeout` | `300` | Review test timeout |
 | `review.soft_pass` | `true` | Treat soft-pass as pass |
+| `autopilot.mode` | `conservative` | Merge mode: `conservative` (never merge), `balanced` (merge clean PRs), `aggressive` (merge clean + partial w/ `merge_partial: true`) |
+| `autopilot.merge_partial` | `false` | Allow merging PRs with unresolved review issues. Only honored when `mode: aggressive` |
 | `autopilot.max_iterations` | `10` | Max issues to process |
 | `autopilot.review_cycles` | `3` | Max review-fix cycles per PR |
-| `autopilot.auto_merge` | `true` | Auto-merge PRs after review |
+| `autopilot.auto_merge` | `true` | LEGACY — auto-merge PRs after review. Ignored when `autopilot.mode` is set |
 | `autopilot.pause_on_failure` | `true` | Pause on failure |
 | `autopilot.skip_labels` | `["wontfix", "blocked", "do-not-merge"]` | Labels that skip issues |
 | `autopilot.critical_labels` | `["critical", "priority:critical"]` | Labels that prioritize issues |

--- a/skills/auto-pilot/README.md
+++ b/skills/auto-pilot/README.md
@@ -8,10 +8,11 @@
 
 ## Highlights
 
+- **Conservative-by-default merge modes** — fresh installs never auto-merge. `autopilot.mode` (`conservative` | `balanced` | `aggressive`) controls when the loop is allowed to merge; aggressive partial-merge requires both `mode: aggressive` AND `merge_partial: true`. See SKILL.md *Merge Modes* for the full decision matrix.
 - **Token-optimized review** — script pre-pass auto-fixes lint/format (zero tokens), LLM only reviews critical issues, soft pass skips nits
 - **3-cycle review-fix loop** — with script pre-pass handling mechanical issues, 3 LLM cycles suffice; follow-up issues track anything left
 - **Critical issue guard** — critical issues get human oversight: if the review can't fully resolve them, the loop stops and asks you for a decision
-- **Zero-confirmation autonomy** — makes all non-critical decisions automatically, only asks for genuinely irreversible actions
+- **Zero-confirmation autonomy** — makes all non-critical decisions automatically (within the configured mode), only asks for genuinely irreversible actions
 - **Smart batching** — analyzes related issues and batch-resolves them in a single PR to save iterations
 - **Self-healing** — auto-stashes dirty trees, auto-switches branches, auto-recovers from sync conflicts
 - **Subagent architecture** — fresh context per issue keeps quality high across long runs
@@ -55,8 +56,10 @@ graph TD
 
 The auto-pilot classifies decisions into two categories:
 
-- **Auto-decide** (99%) — branch switching, strategy selection, failure recovery, merging
+- **Auto-decide** (99%) — branch switching, strategy selection, failure recovery, and merging *within the bounds of `autopilot.mode`*
 - **Confirm with user** (rare) — force-push to shared branches, deleting remote branches that others might depend on, production deployments, package publishing, modifying repository settings or branch protection rules
+
+Merging itself is gated by `autopilot.mode`. The default `conservative` mode never auto-merges — the loop creates and reviews PRs but leaves the merge decision to you. Switch to `balanced` to merge clean PRs, or to `aggressive` (with `merge_partial: true`) to also merge partial PRs alongside follow-up issues.
 
 When something fails, the auto-pilot skips and continues rather than stopping. All work is pushed to remote PRs, so nothing is lost.
 

--- a/skills/auto-pilot/SKILL.md
+++ b/skills/auto-pilot/SKILL.md
@@ -5,13 +5,20 @@ license: MIT
 compatibility: Requires git and GitHub CLI (gh) with authentication and push access. Requires merge permission for auto-merge. Uses /issue-triage, /issue-resolver, /issue-analysis, and /issue-pr-review skills internally. All agents are in shared/agents/.
 effort: max
 metadata:
-  version: 2.1.2
+  version: 2.2.0
   creator: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # /auto-pilot
 
 Fully autonomous development loop: triage, pick, resolve, review, fix, merge, repeat — zero user prompts.
+
+### Changes in 2.2.0 — Conservative-by-default merge modes
+
+- New `autopilot.mode` setting (`conservative` | `balanced` | `aggressive`). Default is **`conservative`**: PRs are created and reviewed but never auto-merged.
+- New `autopilot.merge_partial: false` setting. Aggressive partial-merge behavior now requires both `mode: aggressive` AND `merge_partial: true` — the previous "merge anyway with follow-up" path is no longer reachable by accident.
+- Final-report iteration outcomes now use the categorical labels `merged`, `left_open`, `partial_followup`, `failed`, `skipped`.
+- Legacy `autopilot.auto_merge` is honored when `autopilot.mode` is unset, but `mode` is authoritative when both are present. The schema is being consolidated separately in the autopilot/review config schema work — this release ships only the merge-mode behavior change.
 
 ### Changes in 2.1.0 — Token optimization
 
@@ -38,7 +45,7 @@ Inspired by the auto-adapt-mode pattern: **always proceed, never block on recove
    - Choosing resolution strategies, picking implementation approaches
    - Skipping failed issues and moving to the next one
    - Retrying after transient failures
-   - Merging PRs that pass review
+   - Merging PRs that pass review (only when `autopilot.mode` permits — see Configuration)
    - Falling back to simpler strategies when optimizations fail
 
 2. **Confirm with user** (rare, critical) — Only for genuinely irreversible or dangerous actions:
@@ -101,15 +108,36 @@ Load `.gitissue.yml` from the repo root once at start. If the file does not exis
 ```
 
 Defaults:
+- `autopilot.mode: conservative` — merge mode. See **Merge Modes** below for the three values.
+- `autopilot.merge_partial: false` — never merge a PR with unresolved fixable review issues unless explicitly opted in. Only honored when `mode: aggressive`.
 - `autopilot.max_iterations: 10` — maximum issues to process before stopping
-- `autopilot.review_cycles: 3` — maximum fix attempts per PR. After this many cycles, if issues remain the auto-pilot creates a follow-up issue and merges the PR anyway. Reduced from 10 — the script pre-pass in issue-pr-review handles lint/format, so 3 LLM cycles suffice for logic issues. A cycle = one fix attempt + one review pass. Confirmation-only review passes (spawned after a PASS to verify, without a preceding fix) do not consume a cycle.
-- `autopilot.auto_merge: true` — merge PRs automatically after review passes
+- `autopilot.review_cycles: 3` — maximum fix attempts per PR. After this many cycles, if issues remain the auto-pilot's behavior depends on `autopilot.mode` (see *Merge Modes* below). Reduced from 10 — the script pre-pass in issue-pr-review handles lint/format, so 3 LLM cycles suffice for logic issues. A cycle = one fix attempt + one review pass. Confirmation-only review passes (spawned after a PASS to verify, without a preceding fix) do not consume a cycle.
+- `autopilot.auto_merge: true` — **legacy** field, retained for backwards compatibility. When `autopilot.mode` is set, `mode` wins and this field is ignored. When `mode` is unset, falling back to legacy behavior, this still controls clean-PR merging. The schema cleanup is tracked separately.
 - `autopilot.pause_on_failure: false` — skip failed issues and continue to the next one (autonomous default). When false, the auto-pilot logs the failure, adds the issue to the skip list, and moves on. Set to true only if you want the loop to halt on every failure for manual inspection.
 - `autopilot.skip_labels: ["wontfix", "blocked", "do-not-merge"]` — skip issues with these labels
 - `autopilot.critical_labels: ["critical", "priority:critical"]` — labels that mark an issue as critical. When a critical issue has unresolved review problems after all cycles, the loop stops and asks the user for a decision instead of auto-creating a follow-up.
 - All `resolve.*` and `triage.*` settings are inherited by the sub-skills
 
 Do not re-read the config at each iteration.
+
+### Merge Modes
+
+The `autopilot.mode` setting controls when the loop is allowed to merge PRs. The default is **conservative** — a fresh install will create PRs and run review-fix cycles, but never auto-merge. Aggressive partial-merge behavior is unreachable without explicit opt-in.
+
+| Mode | Clean PR (review passes) | Partial PR (cycles exhausted, non-critical) | Critical with unresolved issues |
+|------|--------------------------|---------------------------------------------|----------------------------------|
+| `conservative` (default) | leave PR open | leave PR open + create follow-up issue | stop and ask user |
+| `balanced` | merge PR | leave PR open + create follow-up issue | stop and ask user |
+| `aggressive` (requires `merge_partial: true`) | merge PR | merge PR + create follow-up issue (`partial_followup`) | stop and ask user |
+| `aggressive` with `merge_partial: false` | merge PR | leave PR open + create follow-up issue (same as `balanced`) | stop and ask user |
+
+**Resolution rules:**
+
+- If `autopilot.mode` is set, it is the source of truth. The legacy `autopilot.auto_merge` field is ignored.
+- If `autopilot.mode` is unset, fall back to the legacy interpretation: `auto_merge: true` ≈ `aggressive` + `merge_partial: true` (preserves the prior 2.1.x behavior); `auto_merge: false` ≈ `conservative`.
+- Critical-issue handling is unchanged across all modes — the loop always stops and asks when a critical issue still has unresolved review problems after all cycles.
+
+The full per-phase decision logic lives in `references/phases.md` (Phase 3-4 partial gate, Phase 5 merge gate). Read that file when implementing or debugging a specific merge path.
 
 ---
 
@@ -216,12 +244,13 @@ See `references/phases.md` for full prompts, error handling, and decision tables
 ---
 ## Iteration Report
 
-After each iteration, print a brief status:
+After each iteration, print a brief status. The `Outcome` line uses one of the five categorical labels (`merged`, `left_open`, `partial_followup`, `failed`, `skipped`) so the iteration log and final summary stay consistent.
 
 ```
 ✓ Iteration {i}/{max} complete
   Issue:    #{number} — {title}
-  PR:       #{pr_number} — merged ✓
+  PR:       #{pr_number}
+  Outcome:  {merged | left_open | partial_followup | failed | skipped}
   Duration: {time}
   ────────────────────────────────────
   Remaining: {remaining} eligible issues
@@ -242,32 +271,44 @@ The loop stops when any of these conditions are met (except "Merge blocked", whi
 | Explicit list exhausted | `✓ All requested issues resolved!` |
 | No eligible issues (all blocked/skipped) | `⚠ No eligible issues to pick` |
 | Resolution failure (pause_on_failure: true) | `⚠ Auto-pilot paused` |
-| Review exhausted (non-critical) | Follow-up issue created, PR merged, loop continues |
+| Review exhausted (non-critical, mode-dependent) | Follow-up issue created. PR merged (`partial_followup`) only if `mode: aggressive` and `merge_partial: true`; otherwise PR left open (`left_open`). Loop continues either way. |
 | Review exhausted (critical issue) | `⚠ CRITICAL — auto-pilot requires your decision` (loop pauses) |
-| Merge blocked | `⚠ PR #{pr_number} is not mergeable — PR left open, continuing` |
+| Merge blocked (CI/conflicts) | `⚠ PR #{pr_number} is not mergeable — PR left open, continuing` (`left_open`) |
+| Mode forbids merge (clean PR in `conservative`) | `○ PR #{pr_number} ready for manual merge (mode: conservative)` (`left_open`) |
 | User cancellation | `○ Auto-pilot stopped by user` |
 
 ---
 
 ## Final Summary
 
-When the loop ends (for any reason), print a structured step-by-step summary showing each iteration's outcome:
+When the loop ends (for any reason), print a structured step-by-step summary showing each iteration's outcome. Each iteration is tagged with one of five categorical outcomes: **`merged`**, **`left_open`**, **`partial_followup`**, **`failed`**, **`skipped`**.
+
+| Outcome | Meaning |
+|---------|---------|
+| `merged` | PR passed review and was merged cleanly. |
+| `left_open` | PR was created but not merged — either the mode forbids merge, the merge was blocked (CI/conflicts), or unresolved review issues prevented merge under the current mode. |
+| `partial_followup` | PR was merged with unresolved review issues; a follow-up issue captures the remaining work. Only reachable in `aggressive` mode with `merge_partial: true`. |
+| `failed` | The resolver subagent failed before a PR could be created (or another fatal step failed). |
+| `skipped` | Issue was skipped before resolution started — already resolved, blocked by labels/dependencies, in the `--skip` list, or assigned to another user. |
 
 ```
 ◆ Auto-Pilot Summary — {completed}/{max} iterations
 ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
 
-  Iteration 1:       ✓ pass — #{n1} {title1} → PR #{pr1} merged
-  Iteration 2:       ✓ pass — #{n2} {title2} → PR #{pr2} merged
-  Iteration 3:       ⚠ partial — #{n5} {title5} → PR #{pr5} merged, follow-up #{f5}
-  Iteration 4:       ○ skip — #{n3} {title3} (blocked)
+  Iteration 1:       ✓ merged           — #{n1} {title1} → PR #{pr1}
+  Iteration 2:       ⚠ left_open        — #{n2} {title2} → PR #{pr2}
+  Iteration 3:       ⚠ partial_followup — #{n5} {title5} → PR #{pr5}, follow-up #{f5}
+  Iteration 4:       ○ skipped          — #{n3} {title3} (blocked)
+  Iteration 5:       ✗ failed           — #{n4} {title4} (resolver step {step})
   ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
-  Resolved:          {resolved_count}
-  Partial:           {partial_count} (follow-up issues created)
-  Skipped:           {skipped_count}
-  Failed:            {failed_count}
+  merged:            {merged_count}
+  left_open:         {left_open_count}
+  partial_followup:  {partial_followup_count}
+  failed:            {failed_count}
+  skipped:           {skipped_count}
   ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
   Result:            {COMPLETED / PAUSED / LIMIT REACHED}
+  Mode:              {conservative / balanced / aggressive}
 
   Remaining:         {remaining_count} open issues
   Next action:       /auto-pilot to continue
@@ -279,15 +320,17 @@ If batch analysis was used (explicit issue list):
 ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
 
   Analysis:          ✓ pass ({N} issues, {batches} batch groups)
-  Iteration 1:       ✓ pass — #{n1} {title1} → PR #{pr1} merged
-  Iteration 2:       ✓ pass — #{n2} {title2} → PR #{pr2} merged
+  Iteration 1:       ✓ merged           — #{n1} {title1} → PR #{pr1}
+  Iteration 2:       ⚠ left_open        — #{n2} {title2} → PR #{pr2}
   ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
-  Resolved:          {resolved_count}
-  Partial:           {partial_count} (follow-up issues created)
-  Skipped:           {skipped_count}
-  Failed:            {failed_count}
+  merged:            {merged_count}
+  left_open:         {left_open_count}
+  partial_followup:  {partial_followup_count}
+  failed:            {failed_count}
+  skipped:           {skipped_count}
   ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
   Result:            {COMPLETED / PAUSED / LIMIT REACHED}
+  Mode:              {conservative / balanced / aggressive}
 
   Remaining:         {remaining_count} open issues
   Next action:       /auto-pilot to continue
@@ -344,7 +387,7 @@ All errors use the rich format from `references/error-messages.md`:
 
 ## Expected Output
 
-Each iteration prints a static block like this:
+Each iteration prints a static block. The `Merge` line resolves to one of the five categorical outcomes (`merged`, `left_open`, `partial_followup`, `failed`, `skipped`) — the example below assumes a `balanced` or `aggressive` mode where a clean PR is merged. Under the default `conservative` mode the same iteration would end with `Merge ⚠ left_open (mode: conservative)`.
 
 ```
   ◆ Auto-Pilot Iteration 1
@@ -355,7 +398,7 @@ Each iteration prints a static block like this:
   Merge      ✓ merged
 ```
 
-On final stop, a summary table lists each iteration's issue, PR, status (merged / follow-up / failed), and cycle count.
+On final stop, a summary table lists each iteration's issue, PR, outcome (one of `merged`, `left_open`, `partial_followup`, `failed`, `skipped`), and cycle count.
 
 ## Edge Cases
 

--- a/skills/auto-pilot/references/examples.md
+++ b/skills/auto-pilot/references/examples.md
@@ -6,6 +6,8 @@ Detailed example runs and edge-case behaviors referenced from SKILL.md.
 
 **User says:** `/auto-pilot --limit 3`
 
+> Assumes `autopilot.mode: balanced` or `aggressive` in `.gitissue.yml`. Under the default `conservative` mode, each PR would end with `Outcome: left_open` instead of being merged automatically.
+
 ```
 ● Checking environment...
 ✓ Environment ready
@@ -15,7 +17,7 @@ Detailed example runs and edge-case behaviors referenced from SKILL.md.
   Issues to process:  5 (of 8 open)
   Limit:              3
   Review cycles:      3
-  Auto-merge:         {yes/no}
+  Merge mode:         {conservative | balanced | aggressive}
   First issue:        #12 — Fix auth redirect loop
 
   Execution order:
@@ -111,7 +113,7 @@ Detailed example runs and edge-case behaviors referenced from SKILL.md.
 ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
   Issues to process:  3 (of 3 provided)
   Review cycles:      3
-  Auto-merge:         {yes/no}
+  Merge mode:         {conservative | balanced | aggressive}
   Mode:               explicit list (analyzed + optimized)
   Batches:            1 (saving ~1 iterations)
 
@@ -199,7 +201,7 @@ Detailed example runs and edge-case behaviors referenced from SKILL.md.
 ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
   Issues to process:  1 (of 3 provided)
   Review cycles:      3
-  Auto-merge:         {yes/no}
+  Merge mode:         {conservative | balanced | aggressive}
   Mode:               explicit list (analyzed + optimized)
 
   Optimized execution order:

--- a/skills/auto-pilot/references/phases.md
+++ b/skills/auto-pilot/references/phases.md
@@ -71,7 +71,7 @@ On the first iteration, display the execution plan and immediately begin — no 
   Issues to process:  {eligible_count} (of {total_open} open)
   Limit:              {max_iterations}
   Review cycles:      {review_cycles}
-  Auto-merge:         {yes/no}
+  Merge mode:         {conservative | balanced | aggressive}
   First issue:        #{number} — {title}
 
   Execution order:
@@ -154,9 +154,10 @@ The resolver subagent may report that the issue is already fixed (status: `alrea
 
 ```
 ○ #{issue_number} already resolved — skipping
+  Outcome: skipped
 ```
 
-Continue to the next iteration.
+Record the iteration outcome as `skipped` and continue to the next iteration.
 
 **On failure:**
 
@@ -164,9 +165,10 @@ Continue to the next iteration.
 ✗ Resolution failed for #{issue_number} at step {failure_step}
 
   {failure_reason}
+  Outcome: failed
 ```
 
-**Autonomous behavior:** Log the failure, add the issue to the skip list, and continue to the next issue. Failed issues can always be retried later — stopping the entire loop wastes time on issues that might succeed.
+**Autonomous behavior:** Log the failure as outcome `failed`, add the issue to the skip list, and continue to the next issue. Failed issues can always be retried later — stopping the entire loop wastes time on issues that might succeed.
 
 ```
 ⚠ Skipping #{issue_number} — will retry on next run.
@@ -224,13 +226,22 @@ Proceed to Phase 5 (Merge).
 
 **On NEEDS_FIX (review cycles exhausted with remaining issues):**
 
-The review-fix loop tried `review_cycles` times (default: 3) but could not resolve all issues. The behavior depends on whether the original issue is critical.
+The review-fix loop tried `review_cycles` times (default: 3) but could not resolve all issues. The behavior depends on (a) whether the original issue is critical and (b) the configured `autopilot.mode` (and `autopilot.merge_partial` for `aggressive`).
 
-#### Non-critical issues: create follow-up issue, merge PR, continue
+#### Non-critical issues: mode-gated partial-merge decision
 
-For non-critical issues (no `critical` or `priority:critical` label), the auto-pilot captures the unresolved problems as a new GitHub issue, then merges the PR to preserve the progress that was made, and continues to the next issue.
+For non-critical issues (no `critical` or `priority:critical` label), the auto-pilot always captures the unresolved problems as a follow-up issue. Whether the original PR is then merged depends on the mode:
 
-**Step 1 — Create follow-up issue:**
+| Mode (effective) | `merge_partial` | Behavior | Outcome label |
+|------------------|-----------------|----------|----------------|
+| `conservative` (default) | n/a (ignored) | follow-up created, PR left open | `left_open` |
+| `balanced` | n/a (ignored) | follow-up created, PR left open | `left_open` |
+| `aggressive` | `false` (default) | follow-up created, PR left open | `left_open` |
+| `aggressive` | `true` | follow-up created, PR merged anyway | `partial_followup` |
+
+The default install (`mode: conservative`) **never** auto-merges a PR with unresolved fixable review issues. Aggressive partial-merge is unreachable without setting both `mode: aggressive` and `merge_partial: true` in `.gitissue.yml`.
+
+**Step 1 — Create follow-up issue (always, regardless of mode):**
 
 ```bash
 gh issue create \
@@ -243,7 +254,7 @@ gh issue create \
 Enhancement
 
 ## Context
-Auto-pilot resolved #{issue_number} ({issue_title}) but the review-fix loop could not resolve all issues within {review_cycles} cycles. The PR #{pr_number} was merged with the following issues remaining.
+Auto-pilot resolved #{issue_number} ({issue_title}) but the review-fix loop could not resolve all issues within {review_cycles} cycles.
 
 ## Description
 The following review issues were not resolved:
@@ -259,12 +270,23 @@ The following review issues were not resolved:
 - PR with partial fix: #{pr_number}
 - Branch: {branch_name}
 - Review cycles attempted: {review_cycles}
+- Auto-pilot mode at run time: {mode} (merge_partial={merge_partial})
 
 ## Metadata
 - **Priority:** medium
 - **Effort:** small
 EOF
 )"
+```
+
+**Step 2 — Mode-gated merge decision:**
+
+If the effective mode is `aggressive` AND `autopilot.merge_partial` is `true`, merge the PR to preserve the partial progress; otherwise leave the PR open. Compute the **effective mode** by reading `autopilot.mode` if set, else applying the legacy mapping (`auto_merge: true` → aggressive+merge_partial; `auto_merge: false` → conservative).
+
+If merging (aggressive + merge_partial: true):
+
+```bash
+gh pr merge {pr_number} --squash --delete-branch
 ```
 
 ```
@@ -276,29 +298,38 @@ EOF
 
   ✓ Created follow-up issue #{followup_number}
     "Follow-up: unresolved review issues from #{issue_number}"
-  ⟶ Merging PR with partial fix...
-```
-
-**Step 2 — Merge the PR anyway:**
-
-The PR contains valid progress (the resolver completed, and some or all review issues may have been fixed). Merge it to avoid losing that work:
-
-```bash
-gh pr merge {pr_number} --squash --delete-branch
-```
-
-```
+  ⟶ mode: aggressive + merge_partial: true — merging partial PR...
   ✓ PR #{pr_number} merged (partial fix) — #{issue_number} closed
     Unresolved issues tracked in #{followup_number}
+    Outcome: partial_followup
   Continuing to next issue...
 ```
 
-If merge fails (branch protection, etc.), leave the PR open and note it:
+If the merge command itself fails (branch protection, etc.):
 ```
   ⚠ Merge failed for PR #{pr_number} — PR left open
     Unresolved issues tracked in #{followup_number}
+    Outcome: left_open
   Continuing to next issue...
 ```
+
+If NOT merging (`conservative`, `balanced`, or `aggressive` + `merge_partial: false`):
+
+```
+⚠ PR #{pr_number} has unresolved issues after {review_cycles} cycles
+
+  Remaining issues:
+    ● {issue_description_1}
+    ● {issue_description_2}
+
+  ✓ Created follow-up issue #{followup_number}
+    "Follow-up: unresolved review issues from #{issue_number}"
+  ○ mode: {mode} — PR left open for manual merge
+    Outcome: left_open
+  Continuing to next issue...
+```
+
+Record the iteration outcome (`partial_followup` or `left_open`) for the final summary.
 
 #### Critical issues: stop and ask the user
 
@@ -355,16 +386,34 @@ If not mergeable:
 
 **Autonomous behavior:** Leave the PR open and move on. The PR is already created with all changes — it can be merged manually later or picked up on the next auto-pilot run. Only pause if `autopilot.pause_on_failure` is explicitly `true`.
 
-### Step 5.2 — Merge
+### Step 5.2 — Merge (mode-gated)
 
-First, check `autopilot.auto_merge`. If it is explicitly set to `false`, skip the merge entirely and continue to the next issue:
+Merge behavior is controlled by `autopilot.mode`. This step only runs after the PR review returned PASS (clean PR, no unresolved fixable issues). The partial-merge case is handled in Phase 3-4.
+
+**Compute the effective mode:**
+
+1. If `autopilot.mode` is set in `.gitissue.yml`, use it directly (`conservative` | `balanced` | `aggressive`).
+2. If `autopilot.mode` is unset, fall back to legacy interpretation:
+   - `autopilot.auto_merge: false` → effective mode = `conservative`
+   - `autopilot.auto_merge: true` (or unset) → effective mode = `aggressive` (with `merge_partial: true`, preserving prior 2.1.x behavior)
+
+**Decision table for clean PRs:**
+
+| Effective mode | Action | Outcome label |
+|----------------|--------|----------------|
+| `conservative` | leave PR open for manual merge | `left_open` |
+| `balanced` | merge | `merged` |
+| `aggressive` | merge | `merged` |
+
+If the mode forbids merge (`conservative`):
 ```
-○ PR #{pr_number} ready for manual merge (auto_merge: false)
+○ PR #{pr_number} ready for manual merge (mode: conservative)
   https://github.com/owner/repo/pull/{pr_number}
+  Outcome: left_open
   Continuing to next issue...
 ```
 
-If `autopilot.auto_merge` is `true` (the default), merge the PR:
+If the mode allows merge (`balanced` or `aggressive`):
 
 ```bash
 gh pr merge {pr_number} --squash --delete-branch
@@ -373,13 +422,17 @@ gh pr merge {pr_number} --squash --delete-branch
 ```
 ✓ PR #{pr_number} merged — #{issue_number} closed
   https://github.com/owner/repo/pull/{pr_number}
+  Outcome: merged
 ```
 
-If merge fails (branch protection, required approvals, etc.), leave the PR open and continue:
+If the merge command fails (branch protection, required approvals, conflicts, etc.), leave the PR open and continue:
 ```
 ⚠ Merge failed for PR #{pr_number} — PR left open
+  Outcome: left_open
   Continuing to next issue...
 ```
+
+Record the iteration outcome (`merged` or `left_open`) for the final summary.
 
 ### Step 5.3 — Cleanup
 

--- a/skills/init-gitissue/templates/gitissue-template.yml
+++ b/skills/init-gitissue/templates/gitissue-template.yml
@@ -61,6 +61,26 @@ triage:
   # Max seconds to scan codebase per issue for file dependencies
   scan_timeout_per_issue: 30
 
+# Auto-pilot settings (used by /auto-pilot)
+autopilot:
+  # Merge mode — controls when /auto-pilot is allowed to merge PRs.
+  # Values: "conservative" | "balanced" | "aggressive"
+  # Default: "conservative" — create PR, run review-fix cycles, leave PR open.
+  #   Never auto-merges. Safest default; recommended for most projects.
+  # "balanced":     auto-merge clean PRs (review passed). PRs with unresolved
+  #                 review issues get a follow-up issue and stay open.
+  # "aggressive":   auto-merge clean PRs AND merge partial PRs when
+  #                 merge_partial=true is also set (see below). Risky —
+  #                 only enable on disposable/experimental repos.
+  mode: conservative
+
+  # Allow merging PRs that still have unresolved fixable review issues.
+  # Default: false — never merge a partial PR.
+  # Only honored when mode is "aggressive". With any other mode this
+  # field is ignored. Combined opt-in (mode=aggressive AND merge_partial=true)
+  # is required to reach the prior 2.1.x "merge anyway with follow-up" path.
+  merge_partial: false
+
 # Issue analysis settings
 analysis:
   # Max files to read during deep analysis (5-100)

--- a/tests/test-autopilot-modes.sh
+++ b/tests/test-autopilot-modes.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# test-autopilot-modes.sh — Validate the conservative-by-default merge modes
+#
+# This script verifies issue #33 acceptance criteria:
+#  - .gitissue.yml supports `autopilot.mode` with values conservative|balanced|aggressive
+#  - Default install never merges a PR with unresolved fixable review issues
+#  - Aggressive behavior is unreachable without explicit config (no casual flag)
+#  - /init-gitissue emits conservative defaults
+#  - /auto-pilot final report uses the five categories: merged, left_open,
+#    partial_followup, failed, skipped
+#
+# Usage: bash tests/test-autopilot-modes.sh
+# Returns: exit 0 if all tests pass, exit 1 on first failure
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0
+FAIL=0
+
+pass() {
+  echo "  ✓ $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "  ✗ $1"
+  FAIL=$((FAIL + 1))
+}
+
+echo "◆ Auto-Pilot Conservative Merge Modes Tests (issue #33)"
+echo "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄"
+
+# ───────────────────────────────────────────────────────────
+# T1: init-gitissue template ships conservative defaults
+# ───────────────────────────────────────────────────────────
+TEMPLATE="$REPO_ROOT/skills/init-gitissue/templates/gitissue-template.yml"
+
+if [ -f "$TEMPLATE" ]; then
+  pass "T1.0: template file exists"
+else
+  fail "T1.0: $TEMPLATE not found"
+fi
+
+if grep -qE '^\s*mode:\s*conservative\b' "$TEMPLATE"; then
+  pass "T1.1: template ships 'mode: conservative' as the default"
+else
+  fail "T1.1: template does not ship 'mode: conservative' as default"
+fi
+
+if grep -qE '^\s*merge_partial:\s*false\b' "$TEMPLATE"; then
+  pass "T1.2: template ships 'merge_partial: false' as the default"
+else
+  fail "T1.2: template does not ship 'merge_partial: false' as default"
+fi
+
+if grep -qE '^autopilot:' "$TEMPLATE"; then
+  pass "T1.3: template has autopilot: section"
+else
+  fail "T1.3: template missing autopilot: section"
+fi
+
+# ───────────────────────────────────────────────────────────
+# T2: docs/config-schema.md documents both new keys
+# ───────────────────────────────────────────────────────────
+SCHEMA="$REPO_ROOT/docs/config-schema.md"
+
+if grep -qE 'autopilot\.mode' "$SCHEMA"; then
+  pass "T2.1: config-schema.md documents autopilot.mode"
+else
+  fail "T2.1: config-schema.md missing autopilot.mode"
+fi
+
+if grep -qE 'autopilot\.merge_partial' "$SCHEMA"; then
+  pass "T2.2: config-schema.md documents autopilot.merge_partial"
+else
+  fail "T2.2: config-schema.md missing autopilot.merge_partial"
+fi
+
+# All three mode values are documented
+for mode_value in conservative balanced aggressive; do
+  if grep -qE "\"?${mode_value}\"?" "$SCHEMA"; then
+    pass "T2.3.${mode_value}: schema documents mode value '${mode_value}'"
+  else
+    fail "T2.3.${mode_value}: schema missing mode value '${mode_value}'"
+  fi
+done
+
+# Default in defaults table is conservative
+if grep -qE '\| \`autopilot\.mode\` \| \`conservative\`' "$SCHEMA"; then
+  pass "T2.4: defaults table lists conservative as the default mode"
+else
+  fail "T2.4: defaults table does not list conservative as the default mode"
+fi
+
+# Default merge_partial is false
+if grep -qE '\| \`autopilot\.merge_partial\` \| \`false\`' "$SCHEMA"; then
+  pass "T2.5: defaults table lists merge_partial: false as default"
+else
+  fail "T2.5: defaults table does not list merge_partial: false as default"
+fi
+
+# Legacy auto_merge field is documented as legacy
+if grep -qE 'LEGACY' "$SCHEMA"; then
+  pass "T2.6: schema marks legacy auto_merge field"
+else
+  fail "T2.6: schema does not mark auto_merge as legacy"
+fi
+
+# ───────────────────────────────────────────────────────────
+# T3: auto-pilot SKILL.md documents merge modes
+# ───────────────────────────────────────────────────────────
+SKILL="$REPO_ROOT/skills/auto-pilot/SKILL.md"
+
+if grep -qiE 'Merge Modes' "$SKILL"; then
+  pass "T3.1: SKILL.md has a Merge Modes section"
+else
+  fail "T3.1: SKILL.md missing Merge Modes section"
+fi
+
+for mode_value in conservative balanced aggressive; do
+  if grep -qE "\b${mode_value}\b" "$SKILL"; then
+    pass "T3.2.${mode_value}: SKILL.md mentions mode '${mode_value}'"
+  else
+    fail "T3.2.${mode_value}: SKILL.md does not mention mode '${mode_value}'"
+  fi
+done
+
+if grep -qE 'autopilot\.mode' "$SKILL"; then
+  pass "T3.3: SKILL.md references autopilot.mode key"
+else
+  fail "T3.3: SKILL.md does not reference autopilot.mode"
+fi
+
+if grep -qE 'autopilot\.merge_partial|merge_partial' "$SKILL"; then
+  pass "T3.4: SKILL.md references autopilot.merge_partial key"
+else
+  fail "T3.4: SKILL.md does not reference autopilot.merge_partial"
+fi
+
+# Final-report uses the five categorical labels
+for category in merged left_open partial_followup failed skipped; do
+  if grep -qE "\b${category}\b" "$SKILL"; then
+    pass "T3.5.${category}: SKILL.md final report mentions outcome '${category}'"
+  else
+    fail "T3.5.${category}: SKILL.md final report does not mention outcome '${category}'"
+  fi
+done
+
+# ───────────────────────────────────────────────────────────
+# T4: phases.md gates merge behavior on mode
+# ───────────────────────────────────────────────────────────
+PHASES="$REPO_ROOT/skills/auto-pilot/references/phases.md"
+
+if grep -qE 'autopilot\.mode|effective mode' "$PHASES"; then
+  pass "T4.1: phases.md describes mode gating"
+else
+  fail "T4.1: phases.md does not describe mode gating"
+fi
+
+if grep -qiE 'mode:\s*conservative.*manual\s+merge|conservative.*leave PR open|leave PR open.*conservative' "$PHASES"; then
+  pass "T4.2: phases.md describes conservative-mode leave-open behavior"
+else
+  fail "T4.2: phases.md does not describe conservative-mode leave-open behavior"
+fi
+
+if grep -qE 'merge_partial' "$PHASES"; then
+  pass "T4.3: phases.md references merge_partial gate"
+else
+  fail "T4.3: phases.md does not reference merge_partial gate"
+fi
+
+if grep -qE 'aggressive' "$PHASES"; then
+  pass "T4.4: phases.md describes aggressive-mode behavior"
+else
+  fail "T4.4: phases.md does not describe aggressive-mode behavior"
+fi
+
+# Outcome labels appear in phases.md
+for category in merged left_open partial_followup; do
+  if grep -qE "\b${category}\b" "$PHASES"; then
+    pass "T4.5.${category}: phases.md uses outcome label '${category}'"
+  else
+    fail "T4.5.${category}: phases.md does not use outcome label '${category}'"
+  fi
+done
+
+# ───────────────────────────────────────────────────────────
+# T5: README highlights conservative-by-default
+# ───────────────────────────────────────────────────────────
+README="$REPO_ROOT/skills/auto-pilot/README.md"
+
+if grep -qiE 'conservative' "$README"; then
+  pass "T5.1: README mentions conservative mode"
+else
+  fail "T5.1: README does not mention conservative mode"
+fi
+
+if grep -qE 'autopilot\.mode' "$README"; then
+  pass "T5.2: README references autopilot.mode key"
+else
+  fail "T5.2: README does not reference autopilot.mode key"
+fi
+
+# ───────────────────────────────────────────────────────────
+# T6: Acceptance — aggressive partial-merge requires BOTH keys
+# (Static check: phases.md must require both mode=aggressive AND merge_partial=true)
+# ───────────────────────────────────────────────────────────
+if grep -qE 'aggressive.*merge_partial|merge_partial.*aggressive' "$PHASES"; then
+  pass "T6.1: aggressive partial-merge gated on both mode AND merge_partial"
+else
+  fail "T6.1: phases.md does not gate aggressive partial-merge on both keys"
+fi
+
+# AC #2: default install never merges a PR with unresolved fixable review issues
+# This is enforced by the conservative default + merge_partial: false default.
+# Verify the SKILL.md merge-modes table makes this explicit.
+if grep -qiE 'Default install never merges|never auto-merge' "$SKILL"; then
+  pass "T6.2: SKILL.md states default never auto-merges (AC #2)"
+else
+  fail "T6.2: SKILL.md does not explicitly state default never auto-merges"
+fi
+
+# ───────────────────────────────────────────────────────────
+# Summary
+# ───────────────────────────────────────────────────────────
+echo ""
+echo "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄"
+echo "  Result: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+else
+  exit 0
+fi


### PR DESCRIPTION
Closes #33

## Summary

Introduce `autopilot.mode` (`conservative` | `balanced` | `aggressive`) with **conservative as the default** so a fresh install never auto-merges a PR that has unresolved fixable review issues. Add `autopilot.merge_partial` (default `false`) — aggressive partial-merge requires both keys set explicitly, eliminating any casual opt-in. Final-report iteration outcomes are now categorical: `merged | left_open | partial_followup | failed | skipped`.

## Approach

Selected **balanced** plan (single coherent change, four small docs/skill edits + one new test). Scope is intentionally tight per the issue context: this PR ships only merge-mode behavior. The autopilot/review config schema cleanup (e.g., removing the legacy `auto_merge` field) is deferred to #38.

### Decision matrix

| Mode | Clean PR | Partial PR (non-critical, cycles exhausted) | Critical unresolved |
|------|----------|---------------------------------------------|---------------------|
| `conservative` (default) | leave open | follow-up + leave open | stop + ask |
| `balanced` | merge | follow-up + leave open | stop + ask |
| `aggressive` + `merge_partial: true` | merge | follow-up + merge (`partial_followup`) | stop + ask |
| `aggressive` + `merge_partial: false` | merge | follow-up + leave open (≡ balanced) | stop + ask |

## Changes

| File | Change |
|------|--------|
| `skills/auto-pilot/SKILL.md` | Bump 2.1.2 → 2.2.0. New Merge Modes section + decision table. Defaults updated. Final summary template uses the five categorical outcomes. Stop-conditions table updated. |
| `skills/auto-pilot/references/phases.md` | Phase 3-4 partial-merge gate now mode-aware. Phase 5 clean-PR merge gated on effective mode. Phase 2 outcomes wired to `skipped` / `failed`. |
| `skills/auto-pilot/README.md` | Conservative-by-default highlight; autonomy model notes mode gating. |
| `skills/init-gitissue/templates/gitissue-template.yml` | Adds `autopilot:` section with `mode: conservative` and `merge_partial: false`. |
| `docs/config-schema.md` | Adds the two new keys with defaults; marks legacy `auto_merge` as ignored when `mode` is set; updates defaults table and config map. |
| `skills/auto-pilot/references/examples.md` | Plan-display label updated to `Merge mode:`; example annotated as assuming non-conservative mode. |
| `tests/test-autopilot-modes.sh` | New static-grep test (34 assertions) covering AC #1–#5. |

## Test Results

- New test suite: `tests/test-autopilot-modes.sh` — **34 passed / 0 failed**
- Existing test suite: `tests/test-projects-sync.sh` — 41 passed / 1 failed (pre-existing T7 failure on `main`, unrelated to this PR)
- This is a docs/skills-only repo (no runtime code), so no unit/integration suite to run.

## Acceptance Criteria

- [x] `.gitissue.yml` supports `autopilot.mode` with values `conservative | balanced | aggressive`.
- [x] Default install never merges a PR with unresolved fixable review issues. (Default = `conservative`; Phase 3-4 partial gate documented to leave PR open in conservative/balanced/aggressive-without-merge_partial.)
- [x] Aggressive behavior is unreachable without explicit config. (Requires both `mode: aggressive` AND `merge_partial: true` — verified by test T6.1.)
- [x] `/init-gitissue` emits conservative defaults. (Template updated; verified by tests T1.1–T1.3.)
- [x] `/auto-pilot` final report uses the five categories: `merged`, `left_open`, `partial_followup`, `failed`, `skipped`. (Verified by tests T3.5.*.)

## Reviewer notes

Two opinionated calls worth flagging:

1. **Legacy mapping for users without `mode` set.** When `autopilot.mode` is absent, the docs map `auto_merge: true` → `aggressive + merge_partial: true` (preserving prior 2.1.x behavior). Mapping it to `balanced` instead would silently change behavior for users who never set `mode`. Open to changing if you'd prefer a stricter break — let me know.
2. **Defaults section keeps both `mode: conservative` and `auto_merge: true`.** Reads as contradictory at a glance but is moot in practice (`mode` wins per documented precedence). Final cleanup of `auto_merge` is intentionally left for #38, which owns the autopilot/review schema work.

## Test plan

- [x] `bash tests/test-autopilot-modes.sh` passes (34/34)
- [x] Existing `tests/test-projects-sync.sh` shows no new failures
- [ ] Manual: open the schema doc and verify the defaults table renders cleanly
- [ ] Manual: skim SKILL.md *Merge Modes* section for clarity to a first-time reader