### PR TITLE
docs(skills): propagate analysis-artifact decision (#35)

### DIFF
--- a/docs/idd-methodology.md
+++ b/docs/idd-methodology.md
@@ -206,6 +206,14 @@ IDD separates durable intent from time-sensitive codebase analysis:
 
 This boundary keeps issues stable while still allowing analysis to stay fresh. A file prediction made when an issue is created can become stale after one merge. A codebase scan run during analysis or resolution reflects the current repository.
 
+## Analysis Artifacts and Durable Memory
+
+`/issue-analysis` writes its findings to `.gitissue/analysis-<N>.json` so the resolver can reuse them and reviewers can inspect the current-code reality the analysis ran against. That JSON is **local cache**: it is not required to be committed, it is safe to delete, and a fresh `/issue-analysis N` regenerates it. Local cache is useful for the live workflow but cannot be the home of project memory — once the PR merges and the cache is cleared, the reasoning would disappear with it.
+
+Durable project memory therefore lives in artifacts that already survive: the **issue body** (intent), the **PR body** (analysis lift, decision record, acceptance verification), and the **squash commit body** that lands on the default branch (the same content carried into git history). The dual-write rule says: any analysis signal worth preserving must appear in both the PR body and the squash commit body. Concretely, `/issue-resolver` lifts a five-field **Decision Record** — root cause, options considered, options rejected, selected option, residual risk — out of the analysis JSON and into the PR body, alongside an acceptance-criteria verification table. `/issue-pr-review` checks for the presence of those fields as part of its traceability dimension. Deleting `.gitissue/analysis-<N>.json` after the PR merges does not destroy the reasoning — it is already in `git log -p`.
+
+This rule **assumes squash-merge as the merge strategy**. GitHub's squash-merge carries the PR body verbatim into the commit message; standard merge commits and rebase-merge do not without extra tooling. Repos using a different strategy will keep durable memory in the PR body (and therefore only on GitHub) rather than in git history. `/init-gitissue` should warn when the repo's default merge strategy is not squash.
+
 ## Minimal Example
 
 Raw report:

--- a/skills/issue-analysis/SKILL.md
+++ b/skills/issue-analysis/SKILL.md
@@ -230,7 +230,16 @@ Step 8 renders the analysis as a structured terminal report following DESIGN.md 
 
 Summary:
 - Terminal report has 8 sections: header, classification, root cause, affected files, options, complexity, risk, recommendation.
-- JSON has keys: `issue`, `keywords`, `files`, `history`, `analysis`, `options`, `complexity`, `risk`, `generated_at`.
+- JSON has keys: `issue`, `keywords`, `files`, `history`, `analysis`, `options`, `complexity`, `risk`, `git_state`, `decision_record`, `generated_at`.
+
+### Durable analysis fields
+
+`/issue-analysis` JSON is local cache — see *Analysis Artifacts and Durable Memory* in `docs/idd-methodology.md`. To make the analysis durable, two structured fields are persisted alongside the existing analysis content so `/issue-resolver` can lift them into the PR body:
+
+1. **`git_state`** — the branch and commit SHA the analysis ran against. This pins the analysis to a specific point in time so reviewers can verify the current-code reality the recommendation was made against.
+2. **`decision_record`** — five fields lifted from Steps 6 and 7: `root_cause`, `options_considered`, `options_rejected`, `selected_option`, `residual_risk`. The labels are stable across `/issue-analysis`, `/issue-resolver`, and `/issue-pr-review` because the downstream presence checks are string-matched.
+
+Persisting these fields does **not** change the analysis pipeline — it only adds two new keys to the JSON and a *Decision Record* section to the terminal report. See `references/output-and-persist.md` for the exact schema and rendering.
 
 ---
 

--- a/skills/issue-analysis/references/output-and-persist.md
+++ b/skills/issue-analysis/references/output-and-persist.md
@@ -164,6 +164,24 @@ Omit the `Create:` line if no files need to be created for that option.
     Recommended:  Option {N} — {name}
 ```
 
+### Decision Record
+
+The Decision Record is the durable analysis signal that `/issue-resolver` lifts into the PR body and squash commit body. It uses the same five field labels as the JSON `decision_record` block — labels are stable across `/issue-analysis`, `/issue-resolver`, and `/issue-pr-review` because downstream presence checks are string-matched.
+
+```
+  ◆ Decision Record
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+    Root cause:         {one-paragraph diagnosis from Step 6}
+    Options considered: Option 1 — {name}; Option 2 — {name}; Option 3 — {name}
+    Options rejected:   Option 1 — {one-line reason}; Option 3 — {reason}
+    Selected option:    Option {N} — {name}
+    Residual risk:      {what remains uncertain or accepted as known limitation}
+
+    Analyzed at:        {branch} @ {commit_sha_short} ({YYYY-MM-DD})
+```
+
+If only one option was generated, render `Options rejected: none`. If `residual_risk` is empty, render `Residual risk: none identified`.
+
 After output:
 ```
 [8/8] Report         ✓ analysis complete
@@ -176,9 +194,22 @@ After output:
 After Step 8, save the analysis to `.gitissue/analysis-<N>.json`.
 
 1. Create the directory if it doesn't exist: `mkdir -p .gitissue/`
-2. Build the JSON object from Steps 1-8 analysis results using the schema below
-3. Write `.gitissue/analysis-<N>.json` with formatted JSON (readable diffs in git)
-4. Print: `✓ Analysis saved to .gitissue/analysis-<N>.json`
+2. Capture `git_state` so the analysis is pinned to a specific point in time:
+   ```bash
+   git rev-parse --abbrev-ref HEAD            # branch
+   git rev-parse HEAD                         # commit_sha
+   git rev-parse --short=7 HEAD               # commit_sha_short
+   ```
+   If the working tree is detached or the branch cannot be resolved, fall back to `branch: "(detached)"` and continue.
+3. Build the `decision_record` block by lifting fields from Steps 6 and 7:
+   - `root_cause` ← `analysis.summary` (one paragraph; use `analysis.details` first paragraph if `summary` is empty)
+   - `options_considered` ← compact list of every entry in `options[]` (number + name only)
+   - `options_rejected` ← every option whose number is not `recommended_option`, each with a one-line reason derived from `options[].cons[0]` or `options[].risk_details`
+   - `selected_option` ← `options[recommended_option - 1]` reduced to number + name + summary
+   - `residual_risk` ← the highest-severity con of the selected option, or `"none identified"` if none
+4. Build the full JSON object from Steps 1-8 analysis results plus `git_state` and `decision_record` using the schema below
+5. Write `.gitissue/analysis-<N>.json` with formatted JSON (readable diffs in git)
+6. Print: `✓ Analysis saved to .gitissue/analysis-<N>.json`
 
 If writing fails:
 ```
@@ -306,6 +337,30 @@ This is a warning, not a fatal error — the terminal output from Step 6 was alr
     "keywords_extracted": 8,
     "file_refs_extracted": 2,
     "scan_duration_seconds": 45
+  },
+  "git_state": {
+    "branch": "main",
+    "commit_sha": "01afdc5ba2a1f856f116d46168f870d35b549789",
+    "commit_sha_short": "01afdc5",
+    "captured_at": "2026-04-27T05:35:43Z"
+  },
+  "decision_record": {
+    "root_cause": "One-paragraph diagnosis lifted from analysis.summary or analysis.details.",
+    "options_considered": [
+      {"number": 1, "name": "Minimal fix"},
+      {"number": 2, "name": "Balanced refactor"},
+      {"number": 3, "name": "Comprehensive overhaul"}
+    ],
+    "options_rejected": [
+      {"number": 1, "reason": "Hardcoded list grows over time."},
+      {"number": 3, "reason": "Out of scope for this issue."}
+    ],
+    "selected_option": {
+      "number": 2,
+      "name": "Balanced refactor",
+      "summary": "One-sentence description of the chosen approach."
+    },
+    "residual_risk": "What remains uncertain after the fix lands, or 'none identified'."
   }
 }
 ```
@@ -389,4 +444,20 @@ This is a warning, not a fatal error — the terminal output from Step 6 was alr
 | `scan_stats.keywords_extracted` | integer | Keywords found in issue body |
 | `scan_stats.file_refs_extracted` | integer | Explicit file paths found |
 | `scan_stats.scan_duration_seconds` | integer | Time spent on research |
+| `git_state.branch` | string | Branch name HEAD pointed at when analysis ran |
+| `git_state.commit_sha` | string | Full 40-character commit SHA at analysis time |
+| `git_state.commit_sha_short` | string | First 7 characters of `commit_sha` for display |
+| `git_state.captured_at` | ISO 8601 string | Timestamp when `git_state` was captured (matches top-level `timestamp`) |
+| `decision_record.root_cause` | string | One-paragraph diagnosis lifted from `analysis.summary` or `analysis.details` |
+| `decision_record.options_considered[]` | array | Compact list of all options proposed in Step 7 |
+| `decision_record.options_considered[].number` | integer | Option number (matches `options[].number`) |
+| `decision_record.options_considered[].name` | string | Option name (matches `options[].name`) |
+| `decision_record.options_rejected[]` | array | Options not chosen, with one-line reason; empty array if only one option was generated |
+| `decision_record.options_rejected[].number` | integer | Option number |
+| `decision_record.options_rejected[].reason` | string | One-line reason this option was not selected |
+| `decision_record.selected_option` | object | The chosen option, lifted from `options[recommended_option - 1]` |
+| `decision_record.selected_option.number` | integer | Option number |
+| `decision_record.selected_option.name` | string | Option name |
+| `decision_record.selected_option.summary` | string | One-sentence description of the chosen approach |
+| `decision_record.residual_risk` | string | What remains uncertain or accepted as a known limitation; `"none identified"` if empty |
 

--- a/skills/issue-pr-review/SKILL.md
+++ b/skills/issue-pr-review/SKILL.md
@@ -238,6 +238,24 @@ gh issue view {linked_issue} --json number,title,body,labels
 
 Check each acceptance criterion against the PR changes.
 
+### Durable analysis fields (presence check)
+
+Per the dual-write rule (see *Analysis Artifacts and Durable Memory* in `docs/idd-methodology.md`), `/issue-resolver` is expected to lift a Decision Record and an Acceptance Criteria Verification table into the PR body so the durable signal survives the squash-merge into git history.
+
+Scan the PR body for the following fields. This is a **presence check only** — full per-criterion verification is handled by `/issue-pr-review`'s Phase 2 work, not here.
+
+- A `## Decision Record` section containing the labels `Root cause`, `Options considered`, `Options rejected`, `Selected option`, `Residual risk`.
+- A `## Acceptance Criteria Verification` section (table or list) with at least one entry, OR an explicit `No acceptance criteria defined` note.
+- A `Closes #{N}` reference linking the PR to its issue.
+
+Report results as a `note`-level traceability finding (does not block a soft pass):
+
+- All three present → ○ traceability: full
+- Decision Record absent (e.g., human-authored PR not produced by `/issue-resolver`) → ○ traceability: partial — Decision Record absent; full verification deferred to manual review
+- `Closes #{N}` absent → ⚠ traceability: fail — PR is not linked to an issue (this is the only traceability finding that escalates beyond `note`)
+
+The presence check uses the exact field labels emitted by `/issue-analysis` and `/issue-resolver` because the labels are the stable contract — do not rewrite them.
+
 ---
 
 ## Step 4 — Run Tests & Build [4/7]

--- a/skills/issue-resolver/SKILL.md
+++ b/skills/issue-resolver/SKILL.md
@@ -284,7 +284,7 @@ gh pr create --title "{pr_title}" --body "{pr_body}"
 
 **PR title:** `{type}({scope}): {description} (#{issue_number})` (see `docs/naming-conventions.md`)
 
-**PR body:** Fill the template in `references/report-templates.md` (section *PR Body Template*) — Summary, Approach, Changes table, Test Results, Acceptance Criteria.
+**PR body:** Fill the template in `references/report-templates.md` (section *PR Body Template*) — Summary, Approach, **Decision Record** (lifted from `.gitissue/analysis-<N>.json` if present, else synthesized from Steps 1-2 findings), Changes table, Test Results, **Acceptance Criteria Verification** table. The Decision Record and the verification table are the durable analysis signal that survives the squash-merge into git history; do not omit them. See *Analysis Artifacts and Durable Memory* in `docs/idd-methodology.md`.
 
 ### Project board sync
 

--- a/skills/issue-resolver/references/report-templates.md
+++ b/skills/issue-resolver/references/report-templates.md
@@ -4,6 +4,8 @@ Templates for the PR body, the step-by-step final report, and the expected pipel
 
 ## PR Body Template (Step 5 — Deliver)
 
+This template is the load-bearing artifact for durable project memory. Under squash-merge, GitHub copies the PR body verbatim into the commit message that lands on the default branch, so every section here is preserved in `git log -p` after merge. Repos using merge-commit or rebase-merge keep this content only on GitHub. See *Analysis Artifacts and Durable Memory* in `docs/idd-methodology.md`.
+
 ```markdown
 Closes #{issue_number}
 
@@ -14,6 +16,16 @@ Closes #{issue_number}
 ## Approach
 
 {Selected option name and description}
+
+## Decision Record
+
+- **Root cause:** {one-paragraph diagnosis from analysis Step 6}
+- **Options considered:** Option 1 — {name}; Option 2 — {name}; Option 3 — {name}
+- **Options rejected:** Option 1 — {one-line reason}; Option 3 — {reason}
+- **Selected option:** Option {N} — {name}
+- **Residual risk:** {what remains uncertain or accepted as known limitation, or "none identified"}
+
+Analyzed at: `{branch} @ {commit_sha_short}` ({YYYY-MM-DD})
 
 ## Changes
 
@@ -29,13 +41,23 @@ Closes #{issue_number}
 - Build: passed
 - QA cycles: {count}
 
-## Acceptance Criteria
+## Acceptance Criteria Verification
 
-- [x] {criterion — checked if addressed}
-- [ ] {criterion — unchecked with note}
+| Criterion | Status | Evidence |
+|-----------|--------|----------|
+| {criterion text from issue body} | pass | {short pointer — file/line, test name, manual check} |
+| {criterion text from issue body} | unverified | {explanation — out of scope, manual review needed} |
+
+Use `pass`, `fail`, or `unverified` per criterion. Always cite evidence (a file path, a test name, or a one-line explanation). If the issue has no acceptance criteria, replace the table with `> **Note:** No acceptance criteria defined — manual review recommended.`
 ```
 
 The PR title follows `{type}({scope}): {description} (#{issue_number})` — see `docs/naming-conventions.md`.
+
+### Lifting the Decision Record
+
+If a fresh `.gitissue/analysis-<N>.json` exists for this issue, lift its `decision_record` and `git_state` blocks directly into the *Decision Record* section above. Field labels are stable across `/issue-analysis`, `/issue-resolver`, and `/issue-pr-review` because downstream presence checks are string-matched — do not rename them.
+
+If no analysis JSON exists (e.g., resolver was invoked without prior analysis), synthesize the same five fields from the resolver's own Step 1 (Research) and Step 2 (Plan) findings, and use the synced base SHA as `commit_sha_short`. Either source produces the same template — what matters is that the durable analysis signal lands in the PR body, where squash-merge will carry it into git history.
 
 ## Final Report — Successful Resolution
 


### PR DESCRIPTION
Closes #35

## Summary

Propagate the dual-write rule for durable project memory across the skill docs. `.gitissue/analysis-*.json` is local cache; durable analysis signal must survive the squash-merge into git history by living in the PR body (and therefore the squash commit body).

## Approach

Balanced refactor — touch the four skill doc surfaces called out in improvement-plan-final.md §1d, with stable field labels across all three skills so downstream presence checks string-match.

## Decision Record

- **Root cause:** Without an explicit dual-write contract, durable analysis reasoning lives only in `.gitissue/analysis-<N>.json` (local cache). Deleting that file after merge would erase the rationale; a reviewer six months later reading `git log -p` cannot answer "why does this change exist?" without re-fetching the issue or PR from GitHub.
- **Options considered:** Option 1 — minimal: add only the artifact-decision paragraph to `docs/idd-methodology.md`; Option 2 — balanced: paragraph + propagate field-level changes through `/issue-analysis`, `/issue-resolver`, and `/issue-pr-review` docs; Option 3 — comprehensive: also implement the `/init-gitissue` squash warning, schema additions in `.gitissue.yml`, and the `/idd-doctor` rule that flags non-squash repos.
- **Options rejected:** Option 1 — leaves the methodology paragraph orphaned; the skills it describes do not actually emit or check the new fields. Option 3 — out of scope for #35; the `/init-gitissue` warning and `/idd-doctor` rule belong with their own roadmap items.
- **Selected option:** Option 2 — Balanced refactor.
- **Residual risk:** The check in `/issue-pr-review` is presence-only; full per-criterion `pass`/`fail`/`unverified` verification is left to Phase 2 (#36). PRs not produced by `/issue-resolver` will report partial traceability rather than fail.

Analyzed at: `main @ b29afca` (2026-04-27)

## Changes

| File | Change |
|------|--------|
| `docs/idd-methodology.md` | Add *Analysis Artifacts and Durable Memory* section: local-cache vs durable-memory split, five-field Decision Record contract, squash-merge assumption |
| `skills/issue-analysis/SKILL.md` | Document new `git_state` and `decision_record` JSON keys; explain stable field labels for downstream presence checks |
| `skills/issue-analysis/references/output-and-persist.md` | Add Decision Record terminal section, JSON schema fields for `git_state` + `decision_record`, schema-field reference rows, persist-step instructions for capturing branch + SHA and lifting the five fields |
| `skills/issue-resolver/SKILL.md` | Point Step 5 (Deliver) at the new Decision Record and Acceptance Criteria Verification sections |
| `skills/issue-resolver/references/report-templates.md` | Add Decision Record block to PR body template; convert Acceptance Criteria into a verification table with status/evidence; document lift-or-synthesize behavior |
| `skills/issue-pr-review/SKILL.md` | Presence-only check in Step 3 Review for Decision Record, Acceptance Criteria Verification, and `Closes #N`; reports as note-level traceability finding |

## Test Results

- Unit tests: n/a (docs-only)
- Integration tests: n/a (docs-only)
- E2e tests: n/a (docs-only)
- Build: n/a
- QA cycles: 1 (presence checks for label consistency, schema additions, cross-references)

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Deleting `.gitissue/analysis-*.json` after a PR merges does not destroy project memory | pass | `docs/idd-methodology.md` *Analysis Artifacts and Durable Memory* explicitly states durable signal lives in PR body + squash commit body; `/issue-resolver` PR template lifts the Decision Record |
| A reviewer reading `git log -p` can answer "why does this change exist?" without opening the issue or PR on GitHub | pass | Squash-merge carries the PR body verbatim into the commit message; PR body now contains Decision Record + Acceptance Criteria Verification (see `skills/issue-resolver/references/report-templates.md`) |
| `docs/idd-methodology.md` contains the artifact-decision paragraph | pass | New section *Analysis Artifacts and Durable Memory* added between *Intent-Code Boundary* and *Minimal Example* |
| `/issue-analysis`, `/issue-resolver`, `/issue-pr-review` docs reflect the dual-write rule | pass | `/issue-analysis` records `git_state` + emits `decision_record` JSON block; `/issue-resolver` PR body template includes Decision Record + verification table; `/issue-pr-review` performs presence check on those exact field labels |