### PR TITLE
feat(issue-pr-review): per-criterion AC verification and traceability dimensions (#36)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+- `/issue-pr-review` per-criterion acceptance-criteria verification — each criterion in the linked issue reports `pass` / `fail` / `unverified` with required evidence
+- `/issue-pr-review` four-check traceability dimension — verifies `Closes #N` in PR body, at least one commit referencing the issue (via `git log --grep`), durable analysis fields (Decision Record + Acceptance Criteria Verification block), and the squash-merge assumption
+- Five-dimension review output — `correctness`, `acceptance_criteria`, `traceability`, `maintainability`, `safety` — replacing the prior single-line review verdict in cycle reports and the Step 7 summary
+- `tests/test-issue-pr-review-traceability.sh` — 50 spec assertions verifying every Phase 2 acceptance criterion from issue #36
+
+### Changed
+- `/issue-pr-review` soft-pass condition now hard-blocks on `traceability: fail` (e.g., missing `Closes #N`) and any `acceptance_criteria: fail`, even when tests and CI are green — this matches the explicit issue #36 contract that a PR can pass tests and fail traceability
+- `/issue-pr-review` v0.4.0 — Phase 2 review-traceability work
+- Step 3 of `/issue-pr-review` now runs in a documented order per cycle: reviewer subagent → per-criterion AC verification → traceability checks → dimensional aggregation
+- Human-authored PRs without a Decision Record are reported as `traceability: partial`, not `fail`, while `Closes #N` and acceptance-criteria checks still apply at full strength
+
 ## [0.7.0] - 2026-03-27
 
 ### Added

--- a/skills/issue-pr-review/README.md
+++ b/skills/issue-pr-review/README.md
@@ -13,7 +13,9 @@
 - Runs the project's real test suite, not mocks
 - Monitors CI status and waits for green before merging
 - Auto-merge in `--auto` mode (used by `/auto-pilot`); read-only mode available
-- Soft-pass when zero "fix" issues remain, even if minor "note" issues linger
+- Five-dimension review output — correctness, acceptance_criteria, traceability, maintainability, safety — so a PR can pass tests and still be flagged for missing issue links or unmet acceptance criteria
+- Per-criterion acceptance-criteria verification (`pass` / `fail` / `unverified` with evidence) against the linked issue
+- Soft-pass when zero "fix" issues remain, with **hard blocks** on `traceability: fail` (missing `Closes #N`) and any `acceptance_criteria: fail` — green tests do not override these
 
 ## When to Use
 

--- a/skills/issue-pr-review/SKILL.md
+++ b/skills/issue-pr-review/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: Requires git and GitHub CLI (gh) with authentication. Self-contained — uses shared agents from shared/agents/.
 effort: high
 metadata:
-  version: 0.3.2
+  version: 0.4.0
   creator: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -228,7 +228,8 @@ Return the same JSON format as before.
 After the fix cycle reports zero fixable issues, spawn a **fresh** confirmation reviewer (new agent, no memory). If it finds new fixable issues, they go back to the existing fixer. If it confirms clean, the PR passes.
 
 ```
-[3/7] Review       ✓ {result} — {fixable_count} fixable, {note_count} noted
+[3/7] Review       ✓ correctness:pass  ac:pass  trace:pass  maint:partial  safety:pass
+                     {fixable_count} fixable, {note_count} noted
 ```
 
 Also fetch linked issues for acceptance criteria verification:
@@ -236,25 +237,104 @@ Also fetch linked issues for acceptance criteria verification:
 gh issue view {linked_issue} --json number,title,body,labels
 ```
 
-Check each acceptance criterion against the PR changes.
+Parse the `## Acceptance Criteria` section into one entry per checklist item and check each criterion against the PR changes — see *Acceptance-criteria verification (per criterion)* below.
 
-### Durable analysis fields (presence check)
+### Order within Step 3
 
-Per the dual-write rule (see *Analysis Artifacts and Durable Memory* in `docs/idd-methodology.md`), `/issue-resolver` is expected to lift a Decision Record and an Acceptance Criteria Verification table into the PR body so the durable signal survives the squash-merge into git history.
+Within a single review cycle, the work runs in this order:
+1. Spawn (or re-message) the reviewer subagent and collect its findings.
+2. Run per-criterion acceptance-criteria verification against the linked issue.
+3. Run the four traceability checks against the PR body and commit history.
+4. Aggregate reviewer findings + AC results + traceability results into the five user-facing dimensions for the cycle report.
 
-Scan the PR body for the following fields. This is a **presence check only** — full per-criterion verification is handled by `/issue-pr-review`'s Phase 2 work, not here.
+### Dimensional review output
 
-- A `## Decision Record` section containing the labels `Root cause`, `Options considered`, `Options rejected`, `Selected option`, `Residual risk`.
-- A `## Acceptance Criteria Verification` section (table or list) with at least one entry, OR an explicit `No acceptance criteria defined` note.
-- A `Closes #{N}` reference linking the PR to its issue.
+Step 3 produces a single review verdict organized into **five dimensions**. The reviewer subagent reports findings against its own internal categories (correctness, test_coverage, code_quality, security, edge_cases); this skill maps those findings into the user-facing dimensions and adds two dimensions the reviewer does not produce (acceptance criteria, traceability). Mapping is fixed:
 
-Report results as a `note`-level traceability finding (does not block a soft pass):
+| User-facing dimension | Source | Failure means |
+|----------------------|--------|---------------|
+| `correctness` | reviewer category `correctness` | logic, off-by-one, race conditions |
+| `acceptance_criteria` | per-criterion verification (this skill) | one or more criteria report `fail` |
+| `traceability` | PR-body and commit-history scan (this skill) | issue-to-code link is broken |
+| `maintainability` | reviewer categories `code_quality` + `test_coverage` | dead code, untested paths, complex logic |
+| `safety` | reviewer categories `security` + `edge_cases` | injection, auth bypass, unsafe nulls, crash paths |
 
-- All three present → ○ traceability: full
-- Decision Record absent (e.g., human-authored PR not produced by `/issue-resolver`) → ○ traceability: partial — Decision Record absent; full verification deferred to manual review
-- `Closes #{N}` absent → ⚠ traceability: fail — PR is not linked to an issue (this is the only traceability finding that escalates beyond `note`)
+Each dimension reports `pass`, `partial`, or `fail`. A PR can pass tests and still fail on `traceability` or `acceptance_criteria` — those dimensions are not gated by test results.
 
-The presence check uses the exact field labels emitted by `/issue-analysis` and `/issue-resolver` because the labels are the stable contract — do not rewrite them.
+### Acceptance-criteria verification (per criterion)
+
+Fetch the linked issue and parse its `## Acceptance Criteria` section into individual checklist items. For each criterion, evaluate against the PR diff and produce one of three statuses:
+
+| Status | When |
+|--------|------|
+| `pass` | The PR demonstrably satisfies the criterion. Evidence is required: a file path with line range, a test name, or a one-line description of how the change fulfills the criterion. |
+| `fail` | The PR does not satisfy the criterion. Evidence is required: what's missing or what contradicts the criterion. |
+| `unverified` | The criterion cannot be verified from the diff alone (e.g., needs production validation, manual user testing, or behavior outside the change set). Explanation is required. |
+
+Output a structured block:
+
+```
+○ Acceptance Criteria
+  | # | Criterion | Status | Evidence |
+  |---|-----------|--------|----------|
+  | 1 | "{criterion text}" | pass | tests/foo.test.ts: case 'rejects empty' |
+  | 2 | "{criterion text}" | fail | exclusion list still hard-codes /login |
+  | 3 | "{criterion text}" | unverified | needs manual mobile-device test |
+```
+
+If the issue has no acceptance criteria:
+
+```
+○ Acceptance Criteria — none defined; manual review recommended
+```
+
+**Pass/partial/fail rule for the dimension:**
+- All criteria `pass` → ✓ acceptance_criteria: pass
+- Any criterion `fail` → ✗ acceptance_criteria: fail (blocks soft-pass; treat as fixable)
+- No fails, but at least one `unverified` → ⚠ acceptance_criteria: partial (does not block soft-pass; surfaced in report)
+- No criteria defined → ○ acceptance_criteria: pass (with the "manual review recommended" note)
+
+Each `fail` criterion becomes a fixable issue in Step 6 with `category: acceptance_criteria`, `action: fix`, evidence as the description, and the criterion text as the suggested fix target.
+
+### Traceability checks
+
+Per the dual-write rule (see *Analysis Artifacts and Durable Memory* in `docs/idd-methodology.md`), the durable analysis signal must survive the squash-merge into git history. Run the following four checks against the PR body and the commits in the PR:
+
+1. **Issue link** — PR body contains `Closes #{N}`, `Fixes #{N}`, or `Resolves #{N}` for the linked issue. Detected with the same regex used by GitHub itself: `(?i)(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#\d+`.
+2. **Commit references issue** — at least one commit between base and head references the issue number:
+   ```bash
+   git log "{base_branch}..{head_branch}" --grep="#{N}" --oneline
+   ```
+   The reference may live in the subject or body. A reference inside a `Co-authored-by:` trailer does not count.
+3. **Durable analysis fields in PR body** — the PR body contains a `## Decision Record` section with the five stable labels (`Root cause`, `Options considered`, `Options rejected`, `Selected option`, `Residual risk`) and a `## Acceptance Criteria Verification` section (table or the explicit `No acceptance criteria defined` note). The labels are the contract — match them as exact strings, do not rewrite.
+4. **Squash-commit-body assumption** — under squash-merge (the project default per `docs/idd-methodology.md`), GitHub copies the PR body verbatim into the commit message. Treat passing check 3 as evidence the squash commit will carry the durable summary; no separate check is needed pre-merge. Note this assumption explicitly in the report so reviewers know what is and is not verified.
+
+**Pass/partial/fail rule for the dimension:**
+
+| Outcome | Conditions | Status |
+|---------|-----------|--------|
+| All four checks pass | Closes #N + commit ref + Decision Record + AC Verification block all present | ✓ traceability: pass |
+| `Closes #{N}` absent | check 1 fails (regardless of other checks) | ✗ traceability: fail (blocking — see below) |
+| Decision Record absent on a human-authored PR | check 3 partially fails: PR was not produced by `/issue-resolver` and has no Decision Record | ⚠ traceability: partial — "PR not produced by `/issue-resolver`; Decision Record absent" |
+| Commit reference absent | check 2 fails but check 1 passes (PR body has Closes #N but no commit references the issue) | ⚠ traceability: partial — "no commit references #{N}" |
+| Acceptance Criteria Verification block absent on a `/issue-resolver` PR | check 3 fails on a PR that does include a Decision Record | ⚠ traceability: partial — "Acceptance Criteria Verification block missing" |
+
+The `Closes #{N}` failure is the only traceability outcome that **blocks** the soft-pass. All other partial outcomes are reported but do not block. This matches issue #36's contract: a PR missing `Closes #N` reports a traceability failure even if tests pass; a human-authored PR without a Decision Record reports `partial`, not `fail`.
+
+When traceability fails on `Closes #{N}`, emit a fixable issue in Step 6 with `category: traceability`, `action: fix`, suggested fix: "Add `Closes #{N}` to the PR body."
+
+### Reviewer call-out for the other three dimensions
+
+Pass the reviewer the issue body alongside the diff (the existing `pr_context` field is fine). The reviewer's JSON output already partitions findings by category — at the end of Step 3, this skill aggregates:
+
+- `correctness` findings → `correctness` dimension
+- `code_quality` + `test_coverage` findings → `maintainability` dimension
+- `security` + `edge_cases` findings → `safety` dimension
+
+Each dimension's status is computed from its findings:
+- Any `action: fix` finding in the dimension → ✗ `fail`
+- Only `action: note` findings → ⚠ `partial`
+- No findings → ✓ `pass`
 
 ---
 
@@ -344,9 +424,13 @@ In auto mode: proceed — the next cycle will re-check.
 
 Collect issues from Steps 3-5, but **only fix issues with `action: "fix"`**. Issues with `action: "note"` are reported in the summary but do not trigger a fix cycle. This is the key token optimization — note-only issues (medium code_quality, test_coverage suggestions) are skipped.
 
-- Code review issues with `action: "fix"` (from the reviewer agent)
+- Code review issues with `action: "fix"` (from the reviewer agent — `correctness`, `maintainability`, `safety` dimensions)
+- Acceptance-criteria failures (from Step 3 per-criterion verification — one fixable issue per `fail` criterion, `category: acceptance_criteria`)
+- Traceability failures on `Closes #{N}` (from Step 3 traceability checks — `category: traceability`, suggested fix: edit the PR body to add the link)
 - Test failures (from Step 4)
 - CI failures (from Step 5)
+
+Acceptance-criteria fixes typically require code changes (the criterion is unmet); traceability `Closes #{N}` fixes require a PR-body edit via `gh pr edit {N} --body`. Apply both kinds of fixes, then commit and push as usual.
 
 ### If no fixable issues
 
@@ -388,7 +472,8 @@ After Step 6, go back to Step 3 — but reuse the same reviewer agent via `SendM
 **Loop controls:**
 - **Max cycles:** `review.max_cycles` (default: 3)
 - **Agent reuse:** Cycles 2+ reuse the existing reviewer and fixer agents. Fresh spawn only for the confirmation pass after fixer reports zero issues.
-- **Soft pass (default):** Stop when zero `action: "fix"` issues remain AND tests pass AND CI passes. Medium "note" issues (≤ 2) are allowed — they don't block the pass.
+- **Soft pass (default):** Stop when ALL of the following hold: zero `action: "fix"` issues remain (across all five dimensions, including `acceptance_criteria` and `traceability` failures) AND tests pass AND CI passes AND traceability is not `fail`. Medium "note" issues (≤ 2) and `partial` dimensions are allowed — they don't block the pass.
+- **Hard-block conditions:** `traceability: fail` (e.g., `Closes #{N}` missing) and any `acceptance_criteria: fail` always block, even if every other dimension is clean. Tests passing does not override these — that is the explicit contract from issue #36.
 - **Confirmation pass:** When the fixer reports all fixed, spawn one fresh reviewer for unbiased verification. If clean → PASS. If new issues → back to existing fixer (counts as a cycle).
 - **Exit on stagnation:** If the same issues appear in 2 consecutive cycles, stop and report
 - **Review-only mode:** Run one cycle of Steps 3-5 only, never fix or loop

--- a/skills/issue-pr-review/references/report-templates.md
+++ b/skills/issue-pr-review/references/report-templates.md
@@ -2,6 +2,8 @@
 
 Templates for the Step 7 summary report and the expected inline pipeline output. SKILL.md keeps the contract short; this file holds the full templates.
 
+The Step 7 summary always shows the **five review dimensions** explicitly so reviewers can see, at a glance, that a PR is being judged on more than just tests. A PR can pass tests and still fail on `traceability` or `acceptance_criteria` — those dimensions are reported with their own status line.
+
 ## Summary — Clean PR
 
 ```
@@ -9,7 +11,14 @@ Templates for the Step 7 summary report and the expected inline pipeline output.
 ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
 
   Script pre-pass:   ✓ lint/format auto-fixed ({auto_fixed} files)
-  Code review:       ✓ pass
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+  Review dimensions:
+    correctness:         ✓ pass
+    acceptance_criteria: ✓ pass ({n_pass}/{n_total} criteria pass)
+    traceability:        ✓ pass (Closes #{N}, commit ref, Decision Record, AC block)
+    maintainability:     ○ partial ({note_count} note-level findings)
+    safety:              ✓ pass
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
   Tests:             ✓ pass ({count} passed)
   CI status:         ✓ pass ({checks_count} checks passed)
   Issues fixed:      ✓ {total_fixed} total across {cycles} cycles
@@ -26,7 +35,13 @@ Templates for the Step 7 summary report and the expected inline pipeline output.
 ◆ PR Review: #{pr_number} (pass {max} — issues remain)
 ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
 
-  Code review:       ⚠ warn ({N} issues remain)
+  Review dimensions:
+    correctness:         ⚠ partial ({N} issues)
+    acceptance_criteria: ✗ fail ({n_fail}/{n_total} criteria fail, {n_unverified} unverified)
+    traceability:        ✗ fail — Closes #{N} missing
+    maintainability:     ✓ pass
+    safety:              ✓ pass
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
   Tests:             ✓ pass
   CI status:         ✓ pass
   Issues fixed:      ✓ {total_fixed} total across {max} cycles
@@ -34,10 +49,30 @@ Templates for the Step 7 summary report and the expected inline pipeline output.
   Result:            WARN (manual review recommended)
 
   Remaining:
-    ● [category] description (file:line)
+    ● [acceptance_criteria] criterion 2: "{text}" — fail ({evidence})
+    ● [traceability] PR body missing Closes #{N}
+    ● [correctness] {description} ({file}:{line})
 
   {pr_url}
 ```
+
+The `traceability: fail` line is the one case where tests can be green and the PR is still blocked from soft-pass. Issue #36's contract: missing `Closes #N` always reports a traceability failure even if tests pass.
+
+## Summary — Human-Authored PR (Decision Record absent)
+
+When a human-authored PR (one not produced by `/issue-resolver`) is reviewed, the Decision Record is typically absent. This is reported as `partial` traceability, not `fail`, per issue #36's "Human-Authored PRs" decision (see issue #36 body and the IDD methodology doc):
+
+```
+  Review dimensions:
+    correctness:         ✓ pass
+    acceptance_criteria: ✓ pass ({n_pass}/{n_total} criteria pass)
+    traceability:        ⚠ partial — PR not produced by /issue-resolver;
+                           Decision Record absent
+    maintainability:     ✓ pass
+    safety:              ✓ pass
+```
+
+Acceptance-criteria checks still apply at full strength — they do not relax for human PRs. `Closes #{N}` checks also still apply at full strength — a human PR missing the issue link still fails traceability.
 
 ## Auto-Merge (auto mode only)
 
@@ -65,6 +100,8 @@ On merge failure:
   Result:            BLOCKED (manual merge required)
 ```
 
+Auto-merge is gated on the same soft-pass condition as the loop exit, including `traceability != fail` and zero `acceptance_criteria: fail`. A PR that passes tests and CI but fails traceability or acceptance criteria is **not** auto-merged.
+
 In interactive mode: never auto-merge — just report status.
 
 ## Expected Inline Output
@@ -74,7 +111,8 @@ A clean review prints the 7-step tracker and a summary:
 ```
   [1/7] PR Info       ✓ #87 fix(auth): resolve redirect (#42)
   [2/7] Script Pre    ✓ 3 lint fixes applied
-  [3/7] Review        ✓ 0 critical, 1 medium (note)
+  [3/7] Review        ✓ correctness:pass ac:pass trace:pass maint:pass safety:pass
+                        0 fixable, 1 noted
   [4/7] Tests         ✓ 12 passed
   [5/7] CI            ✓ all checks green
   [6/7] Fix           ○ skipped — nothing to fix

--- a/tests/test-issue-pr-review-traceability.sh
+++ b/tests/test-issue-pr-review-traceability.sh
@@ -1,0 +1,328 @@
+#!/usr/bin/env bash
+# test-issue-pr-review-traceability.sh — Validate the /issue-pr-review
+# acceptance-criteria verification and traceability dimensions spec.
+#
+# This script verifies issue #36 acceptance criteria:
+#  AC1. /issue-pr-review on a PR missing Closes #N reports a traceability
+#       failure even if tests pass.
+#  AC2. /issue-pr-review on a human-authored PR reports `partial`
+#       traceability, not `fail`.
+#  AC3. A merged PR leaves enough context in git history to answer
+#       "why does this change exist?" without relying on local JSON cache.
+#  AC4. Review output is structured by the five dimensions: correctness,
+#       acceptance_criteria, traceability, maintainability, safety.
+#  AC5. /issue-resolver PR template emits all required durable fields
+#       (Decision Record + Acceptance Criteria Verification + Closes #N).
+#
+# Strategy: this is a documentation/skill repo — there is no runtime to
+# exercise. Tests therefore verify that the SKILL.md and template files
+# *contain* the spec language that satisfies each AC. If the language is
+# present, the agent following the skill will produce the documented
+# behavior.
+#
+# Usage: bash tests/test-issue-pr-review-traceability.sh
+# Returns: exit 0 if all tests pass, exit 1 on first failure category.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SKILL="$REPO_ROOT/skills/issue-pr-review/SKILL.md"
+TEMPLATES="$REPO_ROOT/skills/issue-pr-review/references/report-templates.md"
+RESOLVER_TEMPLATES="$REPO_ROOT/skills/issue-resolver/references/report-templates.md"
+METHODOLOGY="$REPO_ROOT/docs/idd-methodology.md"
+PASS=0
+FAIL=0
+
+pass() {
+  echo "  ✓ $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "  ✗ $1"
+  FAIL=$((FAIL + 1))
+}
+
+echo "◆ /issue-pr-review Traceability + AC Tests (issue #36)"
+echo "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄"
+
+# ───────────────────────────────────────────────────────────
+# T0: Files exist
+# ───────────────────────────────────────────────────────────
+for f in "$SKILL" "$TEMPLATES" "$RESOLVER_TEMPLATES" "$METHODOLOGY"; do
+  if [ -f "$f" ]; then
+    pass "T0: $(basename "$f") exists"
+  else
+    fail "T0: $f missing"
+  fi
+done
+
+# ───────────────────────────────────────────────────────────
+# T1: AC4 — Review output is structured by the five dimensions.
+# All five dimension names must appear in the SKILL spec and in
+# the Step 7 templates.
+# ───────────────────────────────────────────────────────────
+for dim in correctness acceptance_criteria traceability maintainability safety; do
+  if grep -qF "$dim" "$SKILL"; then
+    pass "T1.AC4: SKILL.md mentions dimension '$dim'"
+  else
+    fail "T1.AC4: SKILL.md missing dimension '$dim'"
+  fi
+done
+
+for dim in correctness acceptance_criteria traceability maintainability safety; do
+  if grep -qF "$dim" "$TEMPLATES"; then
+    pass "T1.AC4: report-templates.md mentions dimension '$dim'"
+  else
+    fail "T1.AC4: report-templates.md missing dimension '$dim'"
+  fi
+done
+
+# Each dimension must appear in the Clean PR summary template as a status
+# line (the report shows them all explicitly per AC4).
+if grep -qE 'correctness:.*pass|correctness:.*partial|correctness:.*fail' "$TEMPLATES"; then
+  pass "T1.AC4: templates show 'correctness' status line"
+else
+  fail "T1.AC4: templates do not show 'correctness' status line"
+fi
+if grep -qE 'acceptance_criteria:.*pass|acceptance_criteria:.*fail|acceptance_criteria:.*partial' "$TEMPLATES"; then
+  pass "T1.AC4: templates show 'acceptance_criteria' status line"
+else
+  fail "T1.AC4: templates do not show 'acceptance_criteria' status line"
+fi
+if grep -qE 'traceability:.*pass|traceability:.*fail|traceability:.*partial' "$TEMPLATES"; then
+  pass "T1.AC4: templates show 'traceability' status line"
+else
+  fail "T1.AC4: templates do not show 'traceability' status line"
+fi
+
+# ───────────────────────────────────────────────────────────
+# T2: AC1 — PR missing Closes #N reports traceability failure
+# even if tests pass.
+# ───────────────────────────────────────────────────────────
+# The SKILL must explicitly state that missing Closes #N causes
+# traceability to FAIL (not partial) and that this BLOCKS the
+# soft-pass even when tests pass.
+if grep -qiE 'Closes #\{?N\}?[^a-z]*(absent|missing)|missing.*Closes #|absent.*Closes #' "$SKILL"; then
+  pass "T2.AC1: SKILL.md addresses missing Closes #N"
+else
+  fail "T2.AC1: SKILL.md does not address missing Closes #N"
+fi
+
+if grep -qE 'traceability: fail' "$SKILL" || grep -qE 'traceability:.*fail' "$SKILL"; then
+  pass "T2.AC1: SKILL.md uses the literal 'traceability: fail' verdict"
+else
+  fail "T2.AC1: SKILL.md never declares 'traceability: fail'"
+fi
+
+# AC1 hinges on the fact that traceability fail BLOCKS even with green tests.
+# The hard-block clause in the loop controls must explicitly state this.
+if grep -qiE '(hard.block|block.*soft.?pass|block.*even.*tests|tests.*not.*override)' "$SKILL"; then
+  pass "T2.AC1: SKILL.md documents that traceability fail blocks soft-pass"
+else
+  fail "T2.AC1: SKILL.md does not document traceability blocking even with green tests"
+fi
+
+# ───────────────────────────────────────────────────────────
+# T3: AC2 — Human-authored PR reports `partial`, not `fail`.
+# ───────────────────────────────────────────────────────────
+if grep -qiE 'human.authored.*PR|PR.*not.*produced.*by.*/issue-resolver' "$SKILL"; then
+  pass "T3.AC2: SKILL.md addresses human-authored PRs"
+else
+  fail "T3.AC2: SKILL.md does not address human-authored PRs"
+fi
+
+if grep -qiE 'traceability:.*partial' "$SKILL"; then
+  pass "T3.AC2: SKILL.md uses 'traceability: partial' for the soft case"
+else
+  fail "T3.AC2: SKILL.md never declares 'traceability: partial'"
+fi
+
+if grep -qiE 'Decision Record absent' "$SKILL"; then
+  pass "T3.AC2: SKILL.md notes Decision Record may be absent"
+else
+  fail "T3.AC2: SKILL.md does not note Decision Record absent case"
+fi
+
+# ───────────────────────────────────────────────────────────
+# T4: AC3 — Merged PR leaves enough context in git history to
+# answer "why does this change exist?" without local JSON cache.
+# This relies on:
+#   (a) the durable analysis fields (Decision Record + AC Verification)
+#       being present in the PR body,
+#   (b) the squash-merge assumption (PR body becomes commit body),
+#   (c) the methodology doc explaining the rule.
+# ───────────────────────────────────────────────────────────
+if grep -qE 'squash.merge' "$SKILL"; then
+  pass "T4.AC3: SKILL.md mentions the squash-merge assumption"
+else
+  fail "T4.AC3: SKILL.md does not mention squash-merge"
+fi
+
+if grep -qiE 'Decision Record' "$SKILL"; then
+  pass "T4.AC3: SKILL.md references the Decision Record contract"
+else
+  fail "T4.AC3: SKILL.md does not reference Decision Record"
+fi
+
+# All five Decision Record stable labels must be enumerated, since they
+# are the string-matched contract.
+for label in "Root cause" "Options considered" "Options rejected" "Selected option" "Residual risk"; do
+  if grep -qF "$label" "$SKILL"; then
+    pass "T4.AC3: SKILL.md enumerates Decision Record label '$label'"
+  else
+    fail "T4.AC3: SKILL.md missing Decision Record label '$label'"
+  fi
+done
+
+# AC3 also depends on the methodology doc explaining the durable-memory
+# argument — without it, future readers can't audit the design choice.
+if grep -qiE 'Analysis Artifacts and Durable Memory' "$METHODOLOGY"; then
+  pass "T4.AC3: docs/idd-methodology.md has the durable-memory section"
+else
+  fail "T4.AC3: docs/idd-methodology.md missing durable-memory section"
+fi
+
+# ───────────────────────────────────────────────────────────
+# T5: AC5 — /issue-resolver PR template emits all required
+# durable fields (Decision Record, Acceptance Criteria
+# Verification, Closes #N).
+# ───────────────────────────────────────────────────────────
+if grep -qE '^Closes #\{issue_number\}$|Closes #\{issue_number\}' "$RESOLVER_TEMPLATES"; then
+  pass "T5.AC5: resolver template emits Closes #{issue_number}"
+else
+  fail "T5.AC5: resolver template missing Closes #{issue_number}"
+fi
+
+if grep -qiE '## Decision Record' "$RESOLVER_TEMPLATES"; then
+  pass "T5.AC5: resolver template has '## Decision Record' section"
+else
+  fail "T5.AC5: resolver template missing Decision Record section"
+fi
+
+if grep -qiE '## Acceptance Criteria Verification' "$RESOLVER_TEMPLATES"; then
+  pass "T5.AC5: resolver template has '## Acceptance Criteria Verification' section"
+else
+  fail "T5.AC5: resolver template missing AC Verification section"
+fi
+
+# AC verification must allow per-criterion pass/fail/unverified.
+for status in pass fail unverified; do
+  if grep -qF "$status" "$RESOLVER_TEMPLATES"; then
+    pass "T5.AC5: resolver template documents per-criterion status '$status'"
+  else
+    fail "T5.AC5: resolver template missing per-criterion status '$status'"
+  fi
+done
+
+# ───────────────────────────────────────────────────────────
+# T6: Per-criterion AC verification spec in /issue-pr-review.
+# The skill must parse the issue body's "## Acceptance Criteria"
+# section and report each criterion individually.
+# ───────────────────────────────────────────────────────────
+if grep -qiE 'per.criterion|per criterion|each (criterion|acceptance criteria)' "$SKILL"; then
+  pass "T6: SKILL.md documents per-criterion verification"
+else
+  fail "T6: SKILL.md does not document per-criterion verification"
+fi
+
+# All three statuses must be documented in /issue-pr-review too,
+# alongside the requirement that evidence accompanies pass/fail.
+for status in pass fail unverified; do
+  if grep -qE "\\\`$status\\\`" "$SKILL" || grep -qiE "(^|[^a-z_])$status([^a-z_]|$)" "$SKILL"; then
+    pass "T6: SKILL.md documents AC status '$status'"
+  else
+    fail "T6: SKILL.md missing AC status '$status'"
+  fi
+done
+
+if grep -qiE 'evidence' "$SKILL"; then
+  pass "T6: SKILL.md requires evidence on AC verifications"
+else
+  fail "T6: SKILL.md does not require evidence on AC verifications"
+fi
+
+# ───────────────────────────────────────────────────────────
+# T7: Traceability check enumeration. The four checks defined
+# in the issue body must be present:
+#   1. PR body contains Closes #N
+#   2. At least one commit references the issue
+#   3. PR body contains durable analysis signal
+#   4. Squash commit body contains the durable summary
+# ───────────────────────────────────────────────────────────
+if grep -qiE 'PR body.*Closes #|Closes #.*PR body|Issue link' "$SKILL"; then
+  pass "T7: SKILL.md documents 'PR body contains Closes #N' check"
+else
+  fail "T7: SKILL.md missing 'PR body contains Closes #N' check"
+fi
+
+if grep -qE 'git log.*--grep' "$SKILL"; then
+  pass "T7: SKILL.md documents commit-references-issue check via git log --grep"
+else
+  fail "T7: SKILL.md missing commit-references-issue check"
+fi
+
+if grep -qiE 'durable analysis|durable summary|Decision Record' "$SKILL"; then
+  pass "T7: SKILL.md documents durable-analysis-fields check"
+else
+  fail "T7: SKILL.md missing durable-analysis-fields check"
+fi
+
+if grep -qiE 'squash.commit.body|squash[- ]merge' "$SKILL"; then
+  pass "T7: SKILL.md documents squash-commit assumption"
+else
+  fail "T7: SKILL.md missing squash-commit assumption"
+fi
+
+# ───────────────────────────────────────────────────────────
+# T8: Loop control wiring — soft-pass must require
+# traceability != fail and acceptance_criteria != fail.
+# ───────────────────────────────────────────────────────────
+if grep -qiE 'soft.?pass' "$SKILL"; then
+  pass "T8: SKILL.md keeps soft-pass terminology"
+else
+  fail "T8: SKILL.md missing soft-pass terminology"
+fi
+
+# The hard-block conditions must mention both traceability fail
+# and acceptance_criteria fail explicitly.
+if grep -qiE 'traceability:.*fail.*block|hard.block.*traceability|traceability.*hard.block' "$SKILL"; then
+  pass "T8: SKILL.md states traceability fail blocks soft-pass"
+else
+  # Fallback — looser match, since wording may vary
+  if grep -qiE 'traceability.*block' "$SKILL"; then
+    pass "T8: SKILL.md states traceability blocks soft-pass (loose match)"
+  else
+    fail "T8: SKILL.md does not state traceability blocks soft-pass"
+  fi
+fi
+
+if grep -qiE 'acceptance_criteria.*fail|fail.*acceptance.criteria' "$SKILL"; then
+  pass "T8: SKILL.md states acceptance_criteria fail blocks soft-pass"
+else
+  fail "T8: SKILL.md does not state acceptance_criteria fail blocks"
+fi
+
+# ───────────────────────────────────────────────────────────
+# T9: Version bump
+# ───────────────────────────────────────────────────────────
+if grep -qE '^[[:space:]]*version:[[:space:]]+0\.4\.[0-9]+' "$SKILL"; then
+  pass "T9: SKILL.md version bumped to 0.4.x"
+else
+  fail "T9: SKILL.md version not bumped to 0.4.x"
+fi
+
+# ───────────────────────────────────────────────────────────
+# Summary
+# ───────────────────────────────────────────────────────────
+echo "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄"
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+
+if [ "$FAIL" -gt 0 ]; then
+  echo "  Result: FAIL"
+  exit 1
+else
+  echo "  Result: PASS"
+  exit 0
+fi


### PR DESCRIPTION
Closes #36

## Summary

Extends the presence-only durable-fields check added in #35 into a full five-dimension review with per-criterion acceptance-criteria verification and four-check traceability — so a PR can pass tests and still be flagged for missing issue links or unmet acceptance criteria. This PR is a self-applying example: its own body carries the Decision Record and Acceptance Criteria Verification table that the new spec requires.

## Approach

**Balanced, skill-level aggregation (recommended option, auto-selected):** extend `skills/issue-pr-review/SKILL.md` to (a) parse the linked issue's `## Acceptance Criteria` per-criterion and report `pass` / `fail` / `unverified` with evidence, (b) run four traceability checks against PR body and commit history, and (c) aggregate reviewer findings + AC results + traceability results into five user-facing dimensions (correctness, acceptance_criteria, traceability, maintainability, safety). The shared `shared/agents/code-reviewer.md` schema is intentionally left unchanged — three skills share it; mapping the reviewer's internal categories into the user-facing dimensions happens at the `/issue-pr-review` skill level instead.

## Decision Record

- **Root cause:** PR review previously emitted a single "PASS / NEEDS_FIX" verdict without separating concerns. A PR could pass tests and CI while losing the link between issue intent and PR implementation. #35 added a presence-only check for the durable fields but explicitly deferred per-criterion verification, dimensional output, and the hard-block contract to this issue.
- **Options considered:** Option 1 — Minimal: extend only the presence-only block to four traceability checks, leave review verdict single-line; Option 2 — Balanced: skill-level aggregation into five dimensions, full per-criterion AC verification, hard-block on traceability/AC fail, leave shared `code-reviewer.md` untouched; Option 3 — Comprehensive: also extend `shared/agents/code-reviewer.md` output schema to dimensional and update all three call sites (`issue-pr-review`, `issue-resolver` Step 4, `auto-pilot`).
- **Options rejected:** Option 1 — does not satisfy AC #4 (five dimensions) or the AC #1 hard-block contract; Option 3 — churns three callers for marginal gain, since `issue-resolver` Step 4 and `auto-pilot` reuse the reviewer for in-loop QA where the user-facing dimensional report is not the primary surface.
- **Selected option:** Option 2 — Balanced.
- **Residual risk:** the reviewer subagent still emits its existing five categories; mapping into the five user-facing dimensions is deterministic but lives in the skill prose rather than in machine-checkable code (this is a documentation/skill repo). If a future caller forgets the mapping, the dimensional report could regress to category names. Mitigation: the test script asserts dimension names appear in both `SKILL.md` and the report templates, and the per-cycle order is documented at the top of Step 3.

Analyzed at: `feat/36-ac-verification-traceability @ 989cf27` (2026-04-27)

## Changes

| File | Change |
|------|--------|
| `skills/issue-pr-review/SKILL.md` | Replace presence-only block with per-criterion AC verification, four-check traceability, dimensional aggregation; document per-cycle order; update Review Loop soft-pass to hard-block on traceability/AC fail; bump v0.3.2 → v0.4.0 |
| `skills/issue-pr-review/references/report-templates.md` | Show five dimensions in Clean and Issues-Remain summaries; add Human-Authored PR template; note auto-merge gating |
| `skills/issue-pr-review/README.md` | Update Highlights to mention dimensional output, per-criterion AC verification, and hard-block conditions |
| `tests/test-issue-pr-review-traceability.sh` | New: 50 spec assertions covering all five issue #36 ACs |
| `docs/CHANGELOG.md` | Unreleased Added/Changed entries |

## Test Results

- Unit tests: 50 spec assertions passed (`tests/test-issue-pr-review-traceability.sh`)
- Integration tests: existing suites unchanged — `tests/test-idd-doctor.sh` 61/61 pass, `tests/test-autopilot-modes.sh` 34/34 pass; `tests/test-projects-sync.sh` 41/42 (1 pre-existing failure on `main`, not introduced by this PR)
- Build: not applicable (skill markdown repo)
- QA cycles: 1 (no fixes required after initial implementation)

## Acceptance Criteria Verification

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | `/issue-pr-review` on a PR missing `Closes #N` reports a traceability failure even if tests pass. | pass | `skills/issue-pr-review/SKILL.md` lines 309 ("`Closes #{N}` absent → ✗ traceability: fail (blocking)") and the new Loop-controls "Hard-block conditions" clause; verified by T2.AC1 assertions in `tests/test-issue-pr-review-traceability.sh` (3 assertions including the literal verdict, blocking-even-with-green-tests language, and the missing-Closes-#N case). |
| 2 | `/issue-pr-review` on a human-authored PR reports `partial` traceability, not `fail`. | pass | `skills/issue-pr-review/SKILL.md` traceability rule table row "Decision Record absent on a human-authored PR → ⚠ traceability: partial"; `references/report-templates.md` "Summary — Human-Authored PR (Decision Record absent)" template; verified by T3.AC2 assertions (3 assertions). |
| 3 | A merged PR leaves enough context in git history to answer "why does this change exist?" without relying on local JSON cache. | pass | This PR's own body is the demonstration — under the project's squash-merge default, the `## Decision Record` and `## Acceptance Criteria Verification` sections above land verbatim in `git log -p` after merge. `skills/issue-pr-review/SKILL.md` documents the squash-merge assumption (check 4) and the five stable Decision Record labels; `docs/idd-methodology.md` "Analysis Artifacts and Durable Memory" section explains the dual-write rule. Verified by T4.AC3 assertions (8 assertions including all five label names). |
| 4 | Review output is structured by the five dimensions: correctness, acceptance criteria, traceability, maintainability, safety. | pass | `skills/issue-pr-review/SKILL.md` "Dimensional review output" mapping table and `references/report-templates.md` Clean PR / Issues-Remain / Human-Authored summaries each show all five dimensions on their own status line; verified by T1.AC4 assertions (13 assertions: each dimension named in spec and in templates, plus three explicit status-line checks). |
| 5 | `/issue-resolver` PR template emits all required durable fields. | pass | Already satisfied by #35's work in `skills/issue-resolver/references/report-templates.md` (lines 10, 20-26, 44-51 emit `Closes #{issue_number}`, `## Decision Record` with all five labels, and `## Acceptance Criteria Verification` table with pass/fail/unverified). Not duplicated in this PR. Verified by T5.AC5 assertions (6 assertions). |