### PR TITLE
chore(skills): deprecate /issue-pr-review-fix-loop (#37)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,10 +38,7 @@ skills/
 ├── issue-pr-review/    # /issue-pr-review — review, test, CI check, fix, merge
 │   ├── SKILL.md
 │   └── references/
-├── issue-pr-review-fix-loop/  # /issue-pr-review-fix-loop — outer review-fix loop with fresh context per cycle
-│   ├── SKILL.md
-│   └── references/
-├── review-fix-loop/    # DEPRECATED — redirects to /issue-pr-review
+├── issue-pr-review-fix-loop/  # DEPRECATED v0.4.0 — redirects to /issue-pr-review (retained one release cycle)
 │   ├── SKILL.md
 │   └── references/
 └── init-gitissue/      # /init-gitissue — generate .gitissue.yml

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ graph LR
 | `/init-gitissue` | Auto-detect language/framework/test runner, generate `.gitissue.yml` | 0.3.0 | low |
 | `/auto-pilot` | Triage → resolve → review → merge loop, fully automated backlog processing | 2.1.0 | max |
 | `/issue-pr-review` | Review PR end-to-end: token-optimized code review with script pre-pass, reuses reviewer/fixer agents across cycles, fixes critical+high issues | 0.3.0 | high |
-| `/issue-pr-review-fix-loop` | Outer review-fix loop: reuses reviewer/fixer agents across cycles, fresh confirmation pass at the end, fix, commit, push, repeat until clean | 0.3.0 | high |
+| `/issue-pr-review-fix-loop` | _Deprecated — use `/issue-pr-review`._ Outer review-fix loop: reuses reviewer/fixer agents across cycles, fresh confirmation pass at the end, fix, commit, push, repeat until clean. Retained one release cycle for backward-compat references; will be removed from this index. | 0.4.0 (deprecated) | high |
 
 ---
 
@@ -196,7 +196,7 @@ You can also install individual skills. See each skill folder for per-skill comm
 | `/issue-triage` | [`skills/issue-triage/`](skills/issue-triage/) |
 | `/auto-pilot` | [`skills/auto-pilot/`](skills/auto-pilot/) |
 | `/issue-pr-review` | [`skills/issue-pr-review/`](skills/issue-pr-review/) |
-| `/issue-pr-review-fix-loop` | [`skills/issue-pr-review-fix-loop/`](skills/issue-pr-review-fix-loop/) |
+| `/issue-pr-review-fix-loop` _(deprecated)_ | [`skills/issue-pr-review-fix-loop/`](skills/issue-pr-review-fix-loop/) |
 | `/init-gitissue` | [`skills/init-gitissue/`](skills/init-gitissue/) |
 
 ---
@@ -388,7 +388,9 @@ Pipeline:
 
 Max 3 review-fix cycles with stagnation detection.
 
-### /issue-pr-review-fix-loop -- Outer Review-Fix Loop
+### /issue-pr-review-fix-loop -- Outer Review-Fix Loop _(deprecated)_
+
+> **Deprecated in v0.4.0** — use `/issue-pr-review` instead. The capabilities below now live in `/issue-pr-review`. This skill is retained for one release cycle to keep existing references resolvable; it will then be removed from the public skill index.
 
 Wraps `/issue-pr-review` in an outer loop that reuses the same reviewer and fixer agents across cycles for efficiency. A fresh confirmation pass runs at the end to provide an unbiased final check after all fixes are applied.
 
@@ -509,10 +511,7 @@ skills/
 ├── issue-pr-review/    # /issue-pr-review — review, test, CI check, fix, merge
 │   ├── SKILL.md
 │   └── references/
-├── issue-pr-review-fix-loop/  # /issue-pr-review-fix-loop — outer review-fix loop
-│   ├── SKILL.md
-│   └── references/
-├── review-fix-loop/    # /review-fix-loop (deprecated → redirects to /issue-pr-review)
+├── issue-pr-review-fix-loop/  # /issue-pr-review-fix-loop (deprecated — redirects to /issue-pr-review)
 │   ├── SKILL.md
 │   └── references/
 └── init-gitissue/      # /init-gitissue

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - Step 3 of `/issue-pr-review` now runs in a documented order per cycle: reviewer subagent → per-criterion AC verification → traceability checks → dimensional aggregation
 - Human-authored PRs without a Decision Record are reported as `traceability: partial`, not `fail`, while `Closes #N` and acceptance-criteria checks still apply at full strength
 
+### Deprecated
+- `/issue-pr-review-fix-loop` (v0.4.0) — its outer review-fix loop, agent reuse, and fresh confirmation pass are all part of `/issue-pr-review` now (since v0.3.0), and Phase 2 acceptance-criteria + traceability checks landed there in v0.4.0. The skill file is retained for one release cycle so existing references resolve; after that release cycle it will be removed from the public skill index. Migration: replace any `/issue-pr-review-fix-loop` invocation with `/issue-pr-review` (same PR number, same `--auto` flag). Tracking issue: #37.
+
 ## [0.7.0] - 2026-03-27
 
 ### Added

--- a/skills/issue-pr-review-fix-loop/README.md
+++ b/skills/issue-pr-review-fix-loop/README.md
@@ -1,5 +1,9 @@
 # Issue PR Review Fix Loop
 
+> **Deprecated as of v0.4.0** — use [`/issue-pr-review`](../issue-pr-review/) instead. The review-fix loop, traceability checks, and acceptance-criteria verification all live in `/issue-pr-review` now. This wrapper is kept for one release cycle to keep existing references resolvable, then will be removed from the public skill index.
+>
+> Migration: replace any `/issue-pr-review-fix-loop` invocation with `/issue-pr-review` (same PR number, same `--auto` flag). See the deprecation banner at the top of [`SKILL.md`](SKILL.md).
+
 > Outer review-fix loop with agent reuse across cycles and a fresh confirmation pass at the end — review, fix, commit, push, repeat until clean.
 
 ## Intent-Code Boundary

--- a/skills/issue-pr-review-fix-loop/SKILL.md
+++ b/skills/issue-pr-review-fix-loop/SKILL.md
@@ -1,15 +1,48 @@
 ---
 name: issue-pr-review-fix-loop
-description: "Run an outer PR review-fix loop that reviews, fixes, commits, pushes, and repeats until clean. Use for keep-fixing PR requests. Don't use for single review passes, PR creation, or backlog automation."
+description: "DEPRECATED — use /issue-pr-review instead. Outer PR review-fix loop wrapper kept for backward compatibility with existing references."
 license: MIT
 compatibility: Requires git and GitHub CLI (gh) with authentication. Depends on /issue-pr-review skill (skills/issue-pr-review/SKILL.md). Uses shared agents from shared/agents/.
 effort: high
 metadata:
-  version: 0.3.1
+  version: 0.4.0
   creator: Luong NGUYEN <luongnv89@gmail.com>
+  deprecated: true
+  deprecated_in: 0.4.0
+  removal_target: "one release cycle after 0.4.0"
+  successor: /issue-pr-review
 ---
 
 # /issue-pr-review-fix-loop [PR_NUMBER]
+
+> ## Deprecated — use `/issue-pr-review`
+>
+> This skill is deprecated as of version 0.4.0. All review-fix loop capabilities,
+> including review-fix cycles and traceability checks, are now part of
+> [`/issue-pr-review`](../issue-pr-review/SKILL.md).
+>
+> ### Migration
+>
+> | If you ran… | Run this instead |
+> |---|---|
+> | `/issue-pr-review-fix-loop` | `/issue-pr-review` |
+> | `/issue-pr-review-fix-loop 42` | `/issue-pr-review 42` |
+> | `/issue-pr-review-fix-loop 42 --auto` | `/issue-pr-review 42 --auto` |
+>
+> ### Why
+>
+> `/issue-pr-review` v0.3.0+ folded in this skill's outer-loop responsibilities
+> (reuse reviewer/fixer subagents across cycles, fresh confirmation pass) and
+> v0.4.0 added per-criterion acceptance-criteria verification plus traceability
+> checks. Maintaining two surfaces invites drift, so this wrapper is being
+> retired.
+>
+> ### Removal timeline
+>
+> This file is retained for **one release cycle** after 0.4.0 to keep existing
+> references resolvable. After that release cycle the directory will be removed
+> from the public skill index. The legacy contents below remain unchanged for
+> reference only — invocations should be migrated.
 
 Outer loop that reviews a PR, fixes issues, commits, and repeats — with agent reuse across cycles and a fresh confirmation pass at the end.
 

--- a/tests/test-issue-pr-review-fix-loop-deprecation.sh
+++ b/tests/test-issue-pr-review-fix-loop-deprecation.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+# test-issue-pr-review-fix-loop-deprecation.sh — Validate the /issue-pr-review-fix-loop deprecation
+#
+# This script verifies issue #37 acceptance criteria:
+#   AC #1: Audit confirms no workflow depends on /issue-pr-review-fix-loop.
+#   AC #2: skills/issue-pr-review-fix-loop/SKILL.md carries a deprecation
+#          notice and redirect to /issue-pr-review.
+#   AC #3: Tracking note added for removal from the public skill index after
+#          one release cycle.
+#
+# Usage: bash tests/test-issue-pr-review-fix-loop-deprecation.sh
+# Returns: exit 0 if all tests pass, exit 1 on failure
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SKILL_DIR="$REPO_ROOT/skills/issue-pr-review-fix-loop"
+SKILL="$SKILL_DIR/SKILL.md"
+README="$SKILL_DIR/README.md"
+ROOT_README="$REPO_ROOT/README.md"
+ROOT_CLAUDE="$REPO_ROOT/CLAUDE.md"
+CHANGELOG="$REPO_ROOT/docs/CHANGELOG.md"
+
+PASS=0
+FAIL=0
+
+pass() {
+  echo "  ✓ $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "  ✗ $1"
+  FAIL=$((FAIL + 1))
+}
+
+echo "◆ /issue-pr-review-fix-loop Deprecation Tests (issue #37)"
+echo "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄"
+
+# ───────────────────────────────────────────────────────────
+# T1: Files exist (deprecation keeps the file in place)
+# ───────────────────────────────────────────────────────────
+if [ -f "$SKILL" ]; then
+  pass "T1.1: SKILL.md retained for backward-compat references"
+else
+  fail "T1.1: SKILL.md missing — deprecation must keep file present"
+fi
+
+if [ -f "$README" ]; then
+  pass "T1.2: README.md retained for backward-compat references"
+else
+  fail "T1.2: README.md missing — deprecation must keep file present"
+fi
+
+# ───────────────────────────────────────────────────────────
+# T2: SKILL.md frontmatter signals deprecation (AC #2)
+# ───────────────────────────────────────────────────────────
+if grep -qE '^[[:space:]]+deprecated:[[:space:]]+true[[:space:]]*$' "$SKILL"; then
+  pass "T2.1: AC #2 — SKILL.md frontmatter has 'deprecated: true'"
+else
+  fail "T2.1: AC #2 — SKILL.md frontmatter missing 'deprecated: true'"
+fi
+
+if grep -qE '^[[:space:]]+deprecated_in:' "$SKILL"; then
+  pass "T2.2: AC #2 — SKILL.md frontmatter has 'deprecated_in' version"
+else
+  fail "T2.2: AC #2 — SKILL.md frontmatter missing 'deprecated_in'"
+fi
+
+if grep -qE '^[[:space:]]+successor:[[:space:]]+/issue-pr-review[[:space:]]*$' "$SKILL"; then
+  pass "T2.3: AC #2 — SKILL.md frontmatter names successor /issue-pr-review"
+else
+  fail "T2.3: AC #2 — SKILL.md frontmatter missing successor /issue-pr-review"
+fi
+
+if grep -qE '^[[:space:]]+removal_target:' "$SKILL"; then
+  pass "T2.4: AC #3 — SKILL.md frontmatter has removal_target"
+else
+  fail "T2.4: AC #3 — SKILL.md frontmatter missing removal_target"
+fi
+
+# ───────────────────────────────────────────────────────────
+# T3: SKILL.md description signals deprecation (AC #2)
+# ───────────────────────────────────────────────────────────
+desc_line="$(grep -m1 -E '^description:' "$SKILL" || true)"
+desc_lower="$(printf '%s' "$desc_line" | tr '[:upper:]' '[:lower:]')"
+case "$desc_lower" in
+  *deprecated*)
+    pass "T3.1: AC #2 — SKILL.md description starts with deprecation marker"
+    ;;
+  *)
+    fail "T3.1: AC #2 — SKILL.md description does not mention deprecation"
+    ;;
+esac
+
+case "$desc_lower" in
+  *"/issue-pr-review"*)
+    pass "T3.2: AC #2 — SKILL.md description redirects to /issue-pr-review"
+    ;;
+  *)
+    fail "T3.2: AC #2 — SKILL.md description does not redirect to /issue-pr-review"
+    ;;
+esac
+
+# ───────────────────────────────────────────────────────────
+# T4: SKILL.md body has a deprecation banner (AC #2)
+# ───────────────────────────────────────────────────────────
+if grep -qE '^>[[:space:]]*##[[:space:]]+Deprecated' "$SKILL"; then
+  pass "T4.1: AC #2 — SKILL.md body has a Deprecated banner header"
+else
+  fail "T4.1: AC #2 — SKILL.md body missing Deprecated banner header"
+fi
+
+if grep -qE 'Migration' "$SKILL"; then
+  pass "T4.2: AC #2 — SKILL.md banner has a Migration section"
+else
+  fail "T4.2: AC #2 — SKILL.md banner missing Migration section"
+fi
+
+if grep -qE '/issue-pr-review-fix-loop[[:space:]]\|[[:space:]]\`?/issue-pr-review' "$SKILL" \
+   || grep -qE '\`/issue-pr-review-fix-loop\`' "$SKILL"; then
+  pass "T4.3: AC #2 — SKILL.md banner names the deprecated invocation explicitly"
+else
+  fail "T4.3: AC #2 — SKILL.md banner missing explicit invocation reference"
+fi
+
+# ───────────────────────────────────────────────────────────
+# T5: SKILL.md tracking note for one-release-cycle removal (AC #3)
+# ───────────────────────────────────────────────────────────
+skill_lower="$(tr '[:upper:]' '[:lower:]' < "$SKILL")"
+case "$skill_lower" in
+  *"one release cycle"*|*"one-release-cycle"*)
+    pass "T5.1: AC #3 — SKILL.md notes 'one release cycle' retention window"
+    ;;
+  *)
+    fail "T5.1: AC #3 — SKILL.md missing 'one release cycle' retention note"
+    ;;
+esac
+
+case "$skill_lower" in
+  *"public skill index"*|*"removed from"*"index"*)
+    pass "T5.2: AC #3 — SKILL.md states removal from public skill index"
+    ;;
+  *)
+    fail "T5.2: AC #3 — SKILL.md missing public-skill-index removal note"
+    ;;
+esac
+
+# ───────────────────────────────────────────────────────────
+# T6: README.md (skill-local) has deprecation banner (AC #2)
+# ───────────────────────────────────────────────────────────
+readme_lower="$(tr '[:upper:]' '[:lower:]' < "$README")"
+case "$readme_lower" in
+  *deprecated*)
+    pass "T6.1: AC #2 — skills/issue-pr-review-fix-loop/README.md mentions deprecation"
+    ;;
+  *)
+    fail "T6.1: AC #2 — skills/issue-pr-review-fix-loop/README.md missing deprecation note"
+    ;;
+esac
+
+case "$readme_lower" in
+  *"/issue-pr-review"*)
+    pass "T6.2: AC #2 — skill README redirects to /issue-pr-review"
+    ;;
+  *)
+    fail "T6.2: AC #2 — skill README missing /issue-pr-review redirect"
+    ;;
+esac
+
+# ───────────────────────────────────────────────────────────
+# T7: Root README marks the skill as deprecated (AC #2 + AC #3)
+# ───────────────────────────────────────────────────────────
+if grep -qE '^\|.*\`/issue-pr-review-fix-loop\`.*[Dd]eprecated' "$ROOT_README"; then
+  pass "T7.1: AC #2 — Root README skill table marks /issue-pr-review-fix-loop deprecated"
+else
+  fail "T7.1: AC #2 — Root README skill table does not mark /issue-pr-review-fix-loop deprecated"
+fi
+
+if grep -qE '^### /issue-pr-review-fix-loop.*[Dd]eprecated' "$ROOT_README"; then
+  pass "T7.2: AC #2 — Root README section header marks skill deprecated"
+else
+  fail "T7.2: AC #2 — Root README section header missing deprecation marker"
+fi
+
+# ───────────────────────────────────────────────────────────
+# T8: Root CLAUDE.md marks skill deprecated (AC #2)
+# ───────────────────────────────────────────────────────────
+if grep -qE 'issue-pr-review-fix-loop/.*DEPRECATED' "$ROOT_CLAUDE"; then
+  pass "T8.1: AC #2 — Root CLAUDE.md project structure marks skill DEPRECATED"
+else
+  fail "T8.1: AC #2 — Root CLAUDE.md project structure missing DEPRECATED marker"
+fi
+
+# ───────────────────────────────────────────────────────────
+# T9: CHANGELOG has Deprecated entry (AC #2 + AC #3)
+# ───────────────────────────────────────────────────────────
+if awk '
+  /^## \[Unreleased\]/ {in_unrel=1; next}
+  /^## \[/ && in_unrel {exit}
+  in_unrel
+' "$CHANGELOG" | grep -qE '^### Deprecated[[:space:]]*$'; then
+  pass "T9.1: AC #3 — CHANGELOG [Unreleased] has Deprecated subsection"
+else
+  fail "T9.1: AC #3 — CHANGELOG [Unreleased] missing Deprecated subsection"
+fi
+
+if awk '
+  /^## \[Unreleased\]/ {in_unrel=1; next}
+  /^## \[/ && in_unrel {exit}
+  in_unrel
+' "$CHANGELOG" | grep -qE '/issue-pr-review-fix-loop'; then
+  pass "T9.2: AC #2 — CHANGELOG [Unreleased] mentions /issue-pr-review-fix-loop"
+else
+  fail "T9.2: AC #2 — CHANGELOG [Unreleased] missing /issue-pr-review-fix-loop entry"
+fi
+
+if awk '
+  /^## \[Unreleased\]/ {in_unrel=1; next}
+  /^## \[/ && in_unrel {exit}
+  in_unrel
+' "$CHANGELOG" | grep -qiE 'one release cycle'; then
+  pass "T9.3: AC #3 — CHANGELOG entry references one-release-cycle window"
+else
+  fail "T9.3: AC #3 — CHANGELOG entry missing one-release-cycle reference"
+fi
+
+if awk '
+  /^## \[Unreleased\]/ {in_unrel=1; next}
+  /^## \[/ && in_unrel {exit}
+  in_unrel
+' "$CHANGELOG" | grep -qE '#37'; then
+  pass "T9.4: AC #3 — CHANGELOG entry links tracking issue #37"
+else
+  fail "T9.4: AC #3 — CHANGELOG entry missing #37 tracking reference"
+fi
+
+# ───────────────────────────────────────────────────────────
+# T10: AC #1 — no workflow depends on /issue-pr-review-fix-loop
+# ───────────────────────────────────────────────────────────
+# Audit: scan every other skill SKILL.md, the shared agents, and tests for
+# runtime references that would cause /issue-pr-review-fix-loop to be invoked
+# transitively. The deprecated skill itself, its README, the CHANGELOG, and
+# this test file are excluded — those are documentation references, not
+# workflow dependencies.
+
+DEP_HITS=0
+DEP_MATCHES=""
+while IFS= read -r match; do
+  [ -z "$match" ] && continue
+  src="${match%%:*}"
+  rest="${match#*:}"
+  case "$src" in
+    "$SKILL_DIR/"*) continue ;;
+    "$CHANGELOG") continue ;;
+    "$ROOT_README") continue ;;
+    "$ROOT_CLAUDE") continue ;;
+    "$REPO_ROOT/tests/test-issue-pr-review-fix-loop-deprecation.sh") continue ;;
+    "$REPO_ROOT/improvement-plan"*".md") continue ;;
+    "$REPO_ROOT/docs/"*) continue ;;
+  esac
+  DEP_HITS=$((DEP_HITS + 1))
+  DEP_MATCHES="${DEP_MATCHES}    ${src}: ${rest}\n"
+done < <(grep -rn "issue-pr-review-fix-loop" \
+  "$REPO_ROOT/skills" \
+  "$REPO_ROOT/shared" \
+  "$REPO_ROOT/tests" \
+  2>/dev/null || true)
+
+if [ "$DEP_HITS" -eq 0 ]; then
+  pass "T10.1: AC #1 — no skill/shared/test workflow references /issue-pr-review-fix-loop"
+else
+  printf "%b" "$DEP_MATCHES"
+  fail "T10.1: AC #1 — found $DEP_HITS workflow reference(s) to /issue-pr-review-fix-loop"
+fi
+
+# Bonus: confirm /issue-pr-review is the redirect target and exists.
+if [ -f "$REPO_ROOT/skills/issue-pr-review/SKILL.md" ]; then
+  pass "T10.2: AC #1 — successor /issue-pr-review skill exists"
+else
+  fail "T10.2: AC #1 — successor /issue-pr-review skill missing"
+fi
+
+# ───────────────────────────────────────────────────────────
+# Summary
+# ───────────────────────────────────────────────────────────
+echo "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄"
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+
+if [ "$FAIL" -gt 0 ]; then
+  echo "  ✗ Deprecation spec for /issue-pr-review-fix-loop is incomplete"
+  exit 1
+fi
+
+echo "  ✓ Deprecation spec for /issue-pr-review-fix-loop satisfies issue #37 ACs"
+exit 0


### PR DESCRIPTION
Closes #37

## Summary

`/issue-pr-review-fix-loop` is deprecated as of v0.4.0. Its outer review-fix loop, agent reuse across cycles, and fresh confirmation pass are all part of `/issue-pr-review` since v0.3.0; Phase 2 (PR #44 / issue #36) added per-criterion acceptance-criteria verification and traceability checks there. Two surfaces with the same responsibility invite drift, so this skill is deprecated and retained for one release cycle to keep existing references resolvable.

## Approach

**Option 2 — Balanced (selected):** add a deprecation banner and frontmatter markers to the skill files; update the skill index in root README.md and CLAUDE.md; record the change under `[Unreleased]` in CHANGELOG with the migration path and tracking issue; lock the deprecation contract with a 24-assertion spec test in `tests/`. The skill directory is preserved (not removed), per the issue's explicit instruction to remove it from the public skill index *after one release cycle*.

Out-of-scope cleanup also performed: removed two stale `review-fix-loop/` entries from the project-structure trees in root README.md and CLAUDE.md. That older skill was deleted in commit ef05c59 but the documentation still mentioned it; while editing the same trees for #37 it was cheaper to fix than to leave behind. No behavior change.

## Decision Record

- **Root cause:** `/issue-pr-review` v0.3.0 internalized the review-fix loop with agent-reuse and a fresh confirmation pass — capabilities that previously justified `/issue-pr-review-fix-loop` as a wrapper. With v0.4.0 also adding traceability + AC checks there, the wrapper has no unique surface, and keeping both invites silent drift between two skills with identical contracts.
- **Options considered:** Option 1 — minimal banner only (SKILL.md frontmatter); Option 2 — deprecation banner + skill-index updates + CHANGELOG entry + tracking note + spec test; Option 3 — comprehensive deprecation including immediate removal of references/ contents and inlining of all redirects.
- **Options rejected:** Option 1 — fails AC #3 (no tracking note for one-release-cycle removal) and gives users no migration guidance in the README skill index. Option 3 — violates the issue's explicit "Remove from public skill index after one release cycle" instruction; deleting now would break any external references that still resolve via deep links to the SKILL.md.
- **Selected option:** Option 2 — Balanced.
- **Residual risk:** None identified. The spec test (`tests/test-issue-pr-review-fix-loop-deprecation.sh`) locks in all three ACs against future drift; if a later change inadvertently re-introduces a workflow dependency on `/issue-pr-review-fix-loop`, T10.1 fails the test suite.

Analyzed at: `chore/37-deprecate-pr-review-fix-loop @ b441842` (2026-04-27)

## Changes

| File | Change |
|------|--------|
| `skills/issue-pr-review-fix-loop/SKILL.md` | Add frontmatter `deprecated: true`, `deprecated_in: 0.4.0`, `removal_target`, `successor: /issue-pr-review`. Rewrite description as deprecation marker. Bump version 0.3.1 → 0.4.0 (deprecation is a meaningful API surface change). Insert blockquote Deprecated banner with migration table at top of body, retain legacy content beneath for reference. |
| `skills/issue-pr-review-fix-loop/README.md` | Add deprecation note pointing to `/issue-pr-review` and the SKILL.md banner. |
| `README.md` | Mark skill row in command table as deprecated (version label `0.4.0 (deprecated)`); mark heading "/issue-pr-review-fix-loop -- Outer Review-Fix Loop" as _(deprecated)_; mark skill folder row as _(deprecated)_ in the per-skill folders table; drop stale `review-fix-loop/` row from project-structure tree. |
| `CLAUDE.md` | Mark `issue-pr-review-fix-loop/` in project-structure tree as DEPRECATED v0.4.0; drop stale `review-fix-loop/` row. |
| `docs/CHANGELOG.md` | Add `### Deprecated` subsection under `[Unreleased]` referencing /issue-pr-review-fix-loop, the migration path, the one-release-cycle window, and tracking issue #37. |
| `tests/test-issue-pr-review-fix-loop-deprecation.sh` | New: 24 spec assertions covering AC #1 (T10 — workflow-dependency audit), AC #2 (T2-T8 — deprecation notice + redirect across SKILL.md frontmatter, body banner, skill-local README, root README, root CLAUDE.md, CHANGELOG), and AC #3 (T2.4, T5, T9 — one-release-cycle removal note across SKILL.md and CHANGELOG). |

## Test Results

- Spec assertions: 24 passed (`tests/test-issue-pr-review-fix-loop-deprecation.sh`)
- Regression check: `test-idd-doctor.sh` (61/61 passed), `test-issue-pr-review-traceability.sh` (50/50 passed), `test-autopilot-modes.sh` (34/34 passed), `test-projects-sync.sh` (41/42 — the 1 failure is pre-existing on `main` and unrelated to this branch)
- Build: n/a (skills-only project, no compile step)
- QA cycles: 1 (clean — no review-fix iterations needed)

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Audit confirms no workflow depends on `/issue-pr-review-fix-loop`. | pass | `tests/test-issue-pr-review-fix-loop-deprecation.sh` T10.1 scans `skills/`, `shared/`, `tests/` for runtime references and excludes only documentation files (the deprecated skill itself, CHANGELOG, root README, root CLAUDE.md, improvement-plan-*.md, docs/, this test). It currently finds 0 hits. `/auto-pilot` delegates to `/issue-pr-review --auto` directly (skills/auto-pilot/SKILL.md lines 165-186). |
| `skills/issue-pr-review-fix-loop/SKILL.md` carries a deprecation notice and redirect. | pass | SKILL.md frontmatter (`deprecated: true`, `successor: /issue-pr-review`); description rewritten as "DEPRECATED — use /issue-pr-review instead..."; body has a blockquote-styled `> ## Deprecated — use `/issue-pr-review`` header followed by a migration table. Spec test T2-T4 enforces all four pieces. |
| Tracking note added for removal from the public skill index after one release cycle. | pass | SKILL.md frontmatter `removal_target: "one release cycle after 0.4.0"`; SKILL.md body banner says "This file is retained for **one release cycle** after 0.4.0... After that release cycle the directory will be removed from the public skill index"; CHANGELOG `[Unreleased] / Deprecated` entry repeats the one-release-cycle window and links #37. Spec test T2.4, T5.1, T5.2, T9.1-T9.4 enforce all surfaces. |

## Test plan

- [x] `bash tests/test-issue-pr-review-fix-loop-deprecation.sh` returns 0 with 24 passes
- [x] No other test in `tests/` regresses on this branch versus `main`
- [x] No skill SKILL.md, shared agent, or test invokes `/issue-pr-review-fix-loop` (T10.1)
- [x] `/issue-pr-review` skill exists and is the documented successor (T10.2)
- [ ] Reviewer: confirm version bump 0.3.1 → 0.4.0 is acceptable for a deprecation (rationale: `deprecated: true` is an API surface change; `/issue-pr-review` itself uses 0.4.0 as the version where its review responsibilities expanded, so aligning the deprecated wrapper's last published version with its successor's introduction makes the migration window readable from the metadata alone)
- [ ] Reviewer: confirm out-of-scope cleanup (removing stale `review-fix-loop/` entries from CLAUDE.md/README.md trees) is acceptable here rather than as a separate PR