### PR TITLE
refactor(idd-doctor): rewrite paths for src/ layout (#50)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,15 @@ graph LR
 | `/init-gitissue` | Auto-detect language/framework/test runner, generate `.gitissue.yml` | 0.3.2 | low |
 | `/auto-pilot` | Triage → resolve → review → merge loop. Conservative-by-default merge modes (`conservative`/`balanced`/`aggressive`) and explicit issue lists for targeted runs | 2.2.0 | max |
 | `/issue-pr-review` | Review PR end-to-end: script pre-pass (lint/format/test auto-fix), per-criterion AC verification, five-dimension scoring (correctness, acceptance_criteria, traceability, maintainability, safety), reuses reviewer/fixer agents across cycles | 0.4.1 | high |
-| `/idd-doctor` | Read-only health check: verifies issue-creator intent-only contract, gh `--json` field selection, error-message format, and merge strategy assumptions | 0.1.0 | low |
 | `/issue-pr-review-fix-loop` | _Deprecated v0.4.0 — use `/issue-pr-review`._ The outer review-fix loop is now part of `/issue-pr-review`. Retained one release cycle for backward-compat references; will be removed from this index. | 0.4.0 (deprecated) | high |
+
+### Internal tooling
+
+Internal-only skills are not published in the public skill index and are not built into `dist/`. They live alongside the source for repo maintainers to invoke directly from a working tree.
+
+| Skill | Folder | Purpose |
+|-------|--------|---------|
+| `/idd-doctor` | [`src/internal-skills/idd-doctor/`](src/internal-skills/idd-doctor/) | Read-only health check for IDD repository invariants — runs against the local `src/` checkout; not distributed |
 
 ---
 
@@ -197,9 +204,9 @@ You can also install individual skills. See each skill folder for per-skill comm
 | `/issue-triage` | [`src/skills/issue-triage/`](src/skills/issue-triage/) |
 | `/auto-pilot` | [`src/skills/auto-pilot/`](src/skills/auto-pilot/) |
 | `/issue-pr-review` | [`src/skills/issue-pr-review/`](src/skills/issue-pr-review/) |
-| `/idd-doctor` | [`src/internal-skills/idd-doctor/`](src/internal-skills/idd-doctor/) |
 | `/issue-pr-review-fix-loop` _(deprecated)_ | [`src/deprecated-skills/issue-pr-review-fix-loop/`](src/deprecated-skills/issue-pr-review-fix-loop/) |
 | `/init-gitissue` | [`src/skills/init-gitissue/`](src/skills/init-gitissue/) |
+| `/idd-doctor` _(internal)_ | [`src/internal-skills/idd-doctor/`](src/internal-skills/idd-doctor/) |
 
 ---
 

--- a/src/internal-skills/idd-doctor/README.md
+++ b/src/internal-skills/idd-doctor/README.md
@@ -61,7 +61,7 @@ No arguments. The skill reads from the current repo and prints a four-line repor
 | # | Check | Result type |
 |---|-------|-------------|
 | 1 | Stale `/issue-creator` claims in skill README/SKILL files | PASS / FAIL |
-| 2 | Forbidden fields in `skills/issue-creator/templates/*.md` and `.github/ISSUE_TEMPLATE/*` | PASS / FAIL |
+| 2 | Forbidden fields in `src/skills/issue-creator/templates/*.md` and `.github/ISSUE_TEMPLATE/*` | PASS / FAIL |
 | 3 | `autopilot.mode` is set in `.gitissue.yml` (when the file exists) | PASS / FAIL / SKIP |
 | 4 | Repo's default merge strategy is squash-only | PASS / WARN / SKIP |
 

--- a/src/internal-skills/idd-doctor/SKILL.md
+++ b/src/internal-skills/idd-doctor/SKILL.md
@@ -17,7 +17,7 @@ Run a report-only health check on an IDD repository. Surfaces doc drift on the i
 
 ## When to Use
 
-- **Do** run this skill before landing any change that touches `skills/issue-creator/` README/SKILL text or the issue templates.
+- **Do** run this skill before landing any change that touches `src/skills/issue-creator/` README/SKILL text or the issue templates.
 - **Do** run it after `/init-gitissue` to confirm the generated config sets `autopilot.mode`.
 - **Do** wire it into pre-merge or pre-release checks.
 - **Avoid** running it as a fix tool — v1 is **report-only**. No files are modified, no issues are commented on, no PRs are created.
@@ -29,8 +29,8 @@ The doctor performs exactly four checks. Anything beyond these is **out of scope
 
 | # | Check | What it verifies | Failure mode |
 |---|-------|-----------------|--------------|
-| 1 | Stale skill claims | `skills/issue-creator/README.md` and `skills/issue-creator/SKILL.md` are free of language asserting `/issue-creator` scans the codebase, predicts affected files, or generates implementation notes. | `FAIL` |
-| 2 | Issue-template fields | Issue templates under `skills/issue-creator/templates/` and `.github/ISSUE_TEMPLATE/` (if present) do not request predicted affected files, generated technical notes, root cause, or implementation hints. | `FAIL` |
+| 1 | Stale skill claims | `src/skills/issue-creator/README.md` and `src/skills/issue-creator/SKILL.md` are free of language asserting `/issue-creator` scans the codebase, predicts affected files, or generates implementation notes. | `FAIL` |
+| 2 | Issue-template fields | Issue templates under `src/skills/issue-creator/templates/` and `.github/ISSUE_TEMPLATE/` (if present) do not request predicted affected files, generated technical notes, root cause, or implementation hints. | `FAIL` |
 | 3 | Autopilot mode set | If `.gitissue.yml` exists in the repo root, it contains an `autopilot.mode` key. | `FAIL` (only when `.gitissue.yml` exists) |
 | 4 | Squash-merge default | The repository's default merge strategy is squash (squash allowed AND merge-commit and rebase-merge disallowed). | `WARN` |
 
@@ -103,8 +103,8 @@ Scan the `/issue-creator` skill's `README.md` and `SKILL.md` for stale claims ab
 ### What to scan
 
 ```
-skills/issue-creator/README.md
-skills/issue-creator/SKILL.md
+src/skills/issue-creator/README.md
+src/skills/issue-creator/SKILL.md
 ```
 
 These are the only files in scope. Other skills (`/issue-analysis`, `/init-gitissue`, `/auto-pilot`, etc.) legitimately scan code as part of their work; flagging them would be a false positive. Do **not** scan `references/`, `templates/`, `docs/`, the top-level `README.md`, or any other skill's files.
@@ -158,7 +158,7 @@ Scan issue-template files for field labels that ask the reporter (or normalizer)
 ### What to scan
 
 ```
-skills/issue-creator/templates/*.md
+src/skills/issue-creator/templates/*.md
 .github/ISSUE_TEMPLATE/*.md     # only if the directory exists
 .github/ISSUE_TEMPLATE/*.yml    # GitHub form templates
 .github/ISSUE_TEMPLATE/*.yaml
@@ -193,7 +193,7 @@ The match is **substring**, case-insensitive. A literal phrase like `Affected Fi
 
 Per-finding format (same as Check 1).
 
-If no template files exist at all (neither `skills/issue-creator/templates/` nor `.github/ISSUE_TEMPLATE/`), the check passes with `✓ [2/4] Issue-template fields no template files found — nothing to check`.
+If no template files exist at all (neither `src/skills/issue-creator/templates/` nor `.github/ISSUE_TEMPLATE/`), the check passes with `✓ [2/4] Issue-template fields no template files found — nothing to check`.
 
 ---
 
@@ -360,11 +360,11 @@ All errors use the rich format from `references/error-messages.md`:
 - **`.gitissue.yml` has `autopilot.mode` set to a non-canonical value** (e.g., `mode: yolo`) — Check 3 still passes (any non-empty value satisfies the "key set" requirement); a future v2 may add value validation.
 - **A skill README contains the forbidden pattern inside a code block or fenced quote** — Check 1 still flags it. The intent of v1 is mechanical strictness, not contextual nuance.
 - **GitHub Enterprise repos without `gh` auth** — Check 4 is skipped, never failed.
-- **`/issue-creator` skill is missing** — Check 1 fails with a clear `skills/issue-creator/README.md not found` finding (the `/issue-creator` skill is required for an IDD repo).
+- **`/issue-creator` skill is missing** — Check 1 fails with a clear `src/skills/issue-creator/README.md not found` finding (the `/issue-creator` skill is required for an IDD repo).
 
 ## Additional Resources
 
 - **`references/error-messages.md`** — Complete error catalog with triggers and exact output
-- **`docs/naming-conventions.md`** — Branch, commit, PR, and issue naming conventions (referenced for context)
-- **`docs/config-schema.md`** — Full configuration schema (Check 3 references the `autopilot.mode` field)
+- **`src/docs/naming-conventions.md`** — Branch, commit, PR, and issue naming conventions (referenced for context)
+- **`src/docs/config-schema.md`** — Full configuration schema (Check 3 references the `autopilot.mode` field)
 - **`DESIGN.md`** — Terminal output style guide (repo root)

--- a/src/internal-skills/idd-doctor/references/error-messages.md
+++ b/src/internal-skills/idd-doctor/references/error-messages.md
@@ -29,7 +29,7 @@ All errors follow the rich error format: what went wrong + fix command (+ docs l
 ```
   ✓ [1/4] Stale skill claims    no stale language in /issue-creator
 ```
-**Trigger:** `skills/issue-creator/README.md` and `skills/issue-creator/SKILL.md` are both clean.
+**Trigger:** `src/skills/issue-creator/README.md` and `src/skills/issue-creator/SKILL.md` are both clean.
 
 ### Fail
 ```
@@ -39,14 +39,14 @@ All errors follow the rich error format: what went wrong + fix command (+ docs l
         line:    {trimmed_line_text}
         ...
 ```
-**Trigger:** At least one line in `skills/issue-creator/README.md` or `skills/issue-creator/SKILL.md` matches a forbidden pattern without a negation marker on the same line.
+**Trigger:** At least one line in `src/skills/issue-creator/README.md` or `src/skills/issue-creator/SKILL.md` matches a forbidden pattern without a negation marker on the same line.
 
 **Fix hint** (printed once after the per-finding block):
 ```
         Fix: rewrite the offending lines to remove claims that /issue-creator
              scans the codebase, predicts affected files, or generates
              implementation notes. See docs §1a or
-             /Users/.../skills/issue-creator/README.md for the intent-only contract.
+             /Users/.../src/skills/issue-creator/README.md for the intent-only contract.
 ```
 
 ---
@@ -63,7 +63,7 @@ All errors follow the rich error format: what went wrong + fix command (+ docs l
 ```
   ✓ [2/4] Issue-template fields no template files found — nothing to check
 ```
-**Trigger:** Neither `skills/issue-creator/templates/` nor `.github/ISSUE_TEMPLATE/` contain any files.
+**Trigger:** Neither `src/skills/issue-creator/templates/` nor `.github/ISSUE_TEMPLATE/` contain any files.
 
 ### Fail
 ```


### PR DESCRIPTION
Closes #50

## Summary

Rewrite `idd-doctor` source-only path references to scan the new `src/` layout introduced by v10 refactor PR 1 (#48) and #49. `idd-doctor` remains internal — not built into `dist/`.

## Approach

Mechanical path-substring rewrites across the doctor's docs, plus a README adjustment to reflect that `/idd-doctor` is internal:

- `skills/issue-creator/README.md` → `src/skills/issue-creator/README.md`
- `skills/issue-creator/SKILL.md` → `src/skills/issue-creator/SKILL.md`
- `skills/issue-creator/templates/` → `src/skills/issue-creator/templates/`
- `docs/config-schema.md` → `src/docs/config-schema.md`
- `docs/naming-conventions.md` → `src/docs/naming-conventions.md`

The doctor's check algorithms and read-only guarantees are unchanged. Only the documented file paths it scans are updated.

## Decision Record

- **Why this scope:** §10 step 3 of `refactor-plan-v10.md` calls for a path-only rewrite of `idd-doctor` to match the new source tree. AC #1 (test path update) and AC #3 (source-only smoke test exists) were already satisfied in earlier PRs (#48/#49 and the existing `tests/test-idd-doctor.sh`); this PR completes AC #1 (doctor source paths) and AC #2 (README internal-tooling section).
- **Why minimal change:** The doctor is report-only and its logic is tied to mechanical pattern matching; only the path strings need to move. No version bump because external behavior is identical for any consumer running it against the post-#48 layout.
- **README placement:** added a dedicated "Internal tooling" subsection right after the public skills table to keep the public index focused while still documenting the existence and location of internal skills.

## Changes

| File | Change |
|---|---|
| `src/internal-skills/idd-doctor/SKILL.md` | Rewrite scoped paths in scan lists, scope tables, edge cases, and Additional Resources to the `src/...` layout |
| `src/internal-skills/idd-doctor/references/error-messages.md` | Rewrite trigger references and the fix-hint example path |
| `src/internal-skills/idd-doctor/README.md` | Update Scope (v1) row 2 to reference `src/skills/issue-creator/templates/*.md` |
| `README.md` | Remove `/idd-doctor` from the public skills table; add an "Internal tooling" subsection; reorder the per-skill folder index so `/idd-doctor` is grouped under internal |

## Test Results

`tests/test-idd-doctor.sh` — 61 passed, 0 failed (unchanged from baseline).

Spot-checked unrelated suites to confirm no regressions:

- `tests/test-autopilot-modes.sh` — 34 passed, 0 failed
- `tests/test-config-schema-38.sh` — 36 passed, 0 failed
- `tests/test-issue-pr-review-traceability.sh` — 50 passed, 0 failed
- `tests/test-projects-sync.sh` — 42 passed, 0 failed
- `tests/test-issue-pr-review-fix-loop-deprecation.sh` — 24 passed, 0 failed

## Acceptance Criteria Verification

| AC | Status | Evidence |
|---|---|---|
| `tests/test-idd-doctor.sh` updated to use `src/internal-skills/idd-doctor/` and `src/skills/issue-creator/...` | met (prior PR) | `$SKILL_DIR="$REPO_ROOT/src/internal-skills/idd-doctor"`; AC fixtures use `$REPO_ROOT/src/skills/issue-creator/...` (already on main from #49) |
| `README.md`: remove `/idd-doctor` from public skills list; add "Internal tooling" section pointing to `src/internal-skills/idd-doctor/` | met | Public skills table no longer lists `/idd-doctor`; new "Internal tooling" subsection links to the folder |
| Source-only smoke test runs the doctor and reports against `src/skills/...` paths | met | `tests/test-idd-doctor.sh` T11 self-check inspects `$REPO_ROOT/src/skills/issue-creator/...`; SKILL.md and error-messages.md now consistently document `src/skills/...` and `src/docs/...` paths |

## Test plan

- [x] `bash tests/test-idd-doctor.sh` passes locally
- [x] No regressions in `test-autopilot-modes`, `test-config-schema-38`, `test-issue-pr-review-traceability`, `test-projects-sync`, `test-issue-pr-review-fix-loop-deprecation`