### PR TITLE
refactor(docs): rewrite GitHub URLs for moved runtime docs (#51)

### DIFF
--- a/src/docs/config-schema.md
+++ b/src/docs/config-schema.md
@@ -440,7 +440,7 @@ Config is validated on load at the start of every skill invocation. Errors inclu
   Line 15: resolve.test_timeout must be between 30 and 3600
 
   To fix:  edit .gitissue.yml and correct the values above
-  Docs:    https://github.com/luongnv89/idd/blob/main/docs/config-schema.md
+  Docs:    https://github.com/luongnv89/idd/blob/main/src/docs/config-schema.md
 ```
 
 ## Defaults Table

--- a/src/skills/auto-pilot/references/error-messages.md
+++ b/src/skills/auto-pilot/references/error-messages.md
@@ -276,6 +276,6 @@ All errors follow the rich error format: what went wrong + fix command + docs li
   Line {N}: {field} {validation_message}
 
   To fix:  edit .gitissue.yml and correct the values above
-  Docs:    https://github.com/luongnv89/idd/blob/main/docs/config-schema.md
+  Docs:    https://github.com/luongnv89/idd/blob/main/src/docs/config-schema.md
 ```
 **Trigger:** Config file exists but contains invalid values (wrong type, out of range, unknown field).

--- a/src/skills/issue-analysis/references/error-messages.md
+++ b/src/skills/issue-analysis/references/error-messages.md
@@ -119,6 +119,6 @@ All errors follow the rich error format: what went wrong + fix command + docs li
   Line {N}: {field} {validation_message}
 
   To fix:  edit .gitissue.yml and correct the values above
-  Docs:    https://github.com/luongnv89/idd/blob/main/docs/config-schema.md
+  Docs:    https://github.com/luongnv89/idd/blob/main/src/docs/config-schema.md
 ```
 **Trigger:** Config file exists but contains invalid values (wrong type, out of range, unknown field).

--- a/src/skills/issue-creator/references/error-messages.md
+++ b/src/skills/issue-creator/references/error-messages.md
@@ -202,6 +202,6 @@ All errors follow the rich error format: what went wrong + fix command + docs li
   Line {N}: {field} {validation_message}
 
   To fix:  edit .gitissue.yml and correct the values above
-  Docs:    https://github.com/luongnv89/idd/blob/main/docs/config-schema.md
+  Docs:    https://github.com/luongnv89/idd/blob/main/src/docs/config-schema.md
 ```
 **Trigger:** Config file exists but contains invalid values (wrong type, out of range, unknown field).

--- a/src/skills/issue-resolver/references/error-messages.md
+++ b/src/skills/issue-resolver/references/error-messages.md
@@ -200,6 +200,6 @@ All errors follow the rich error format: what went wrong + fix command + docs li
   Line {N}: {field} {validation_message}
 
   To fix:  edit .gitissue.yml and correct the values above
-  Docs:    https://github.com/luongnv89/idd/blob/main/docs/config-schema.md
+  Docs:    https://github.com/luongnv89/idd/blob/main/src/docs/config-schema.md
 ```
 **Trigger:** Config file exists but contains invalid values (wrong type, out of range, unknown field).

--- a/src/skills/issue-triage/references/error-messages.md
+++ b/src/skills/issue-triage/references/error-messages.md
@@ -135,6 +135,6 @@ All errors follow the rich error format: what went wrong + fix command + docs li
   Line {N}: {field} {validation_message}
 
   To fix:  edit .gitissue.yml and correct the values above
-  Docs:    https://github.com/luongnv89/idd/blob/main/docs/config-schema.md
+  Docs:    https://github.com/luongnv89/idd/blob/main/src/docs/config-schema.md
 ```
 **Trigger:** Config file exists but contains invalid values (wrong type, out of range, unknown field).


### PR DESCRIPTION
Closes #51

## Summary

Rewrite every absolute GitHub URL pointing at the legacy `main/docs/<file>.md`
location to the new `main/src/docs/<file>.md` path that was created when PR #50
moved runtime docs into `src/docs/`.

## Approach

Single mechanical find-and-replace across `src/**` (Markdown and YAML files) for
the four moved files: `config-schema`, `github-projects-sync`, `idd-methodology`,
`naming-conventions`. In practice only `config-schema.md` URLs were present
in the codebase (in five `error-messages.md` references and one self-reference
in `src/docs/config-schema.md`). The init-gitissue template had no GitHub URLs
to rewrite.

## Decision Record

- **Option chosen:** Direct `perl -i` rewrite restricted to the four target
  filenames. No tool change, no link helper introduced.
- **Why:** The change is purely textual, deterministic, and verifiable with a
  single grep. Introducing a helper would expand scope beyond the issue and
  risks landing alongside unrelated refactors. Aligns with §3 of refactor-plan-v10
  resolved trade-off: keep absolute `main`-pinned URLs, just point at `src/docs/`.
- **Alternatives considered:**
  - *Replace absolute URLs with repo-relative links* — out of scope for step 4
    and would require auditing every error format.
  - *Introduce a `link()` helper / templated docs base URL* — adds runtime
    abstraction skills don't currently use; defer to a future issue if needed.

## Changes

| File | Change |
|------|--------|
| `src/docs/config-schema.md` | Self-reference URL updated |
| `src/skills/auto-pilot/references/error-messages.md` | Config docs URL updated |
| `src/skills/issue-analysis/references/error-messages.md` | Config docs URL updated |
| `src/skills/issue-creator/references/error-messages.md` | Config docs URL updated |
| `src/skills/issue-resolver/references/error-messages.md` | Config docs URL updated |
| `src/skills/issue-triage/references/error-messages.md` | Config docs URL updated |

## Test Results

This is a documentation URL refactor — no automated test suite covers it.
Verification is the acceptance grep itself:

```bash
$ grep -rE 'github\.com/luongnv89/idd/blob/main/docs/(config-schema|github-projects-sync|idd-methodology|naming-conventions)\.md' src/
# (no matches)
```

> **Note:** The acceptance regex as literally written in the issue body
> (`https://github\.com/luongnv89/idd/[^ )]*\bdocs/...`) also matches the new
> `src/docs/...` URLs because `[^ )]*` greedily covers `src/`. Verification
> against the semantic intent (no remaining `main/docs/` URLs) is shown above.

## Acceptance Criteria Verification

| Criterion | Status |
|-----------|--------|
| No remaining stale `main/docs/<file>.md` URLs in `src/**` | Pass — semantic grep returns no matches |
| Init template still uses absolute `main`-pinned URLs (now at `src/docs/`) | Pass — template had no GitHub URLs to begin with; remains absolute-only by design |
| Applies across `src/skills/**` and `src/docs/**` | Pass — all 6 affected files in those subtrees |

## Test plan

- [ ] Reviewer runs the strict semantic grep above and confirms zero matches
- [ ] Reviewer spot-checks one rewritten URL resolves on GitHub after merge