### PR TITLE
chore(distribution): remove fix-loop public listing (#54)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@
 <p align="center">
   <a href="https://github.com/luongnv89/idd/releases/latest"><img src="https://img.shields.io/badge/version-0.7.0-blue.svg" alt="Version 0.7.0"></a>
   <a href="https://github.com/luongnv89/idd/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="MIT License"></a>
-  <a href="https://github.com/luongnv89/idd"><img src="https://img.shields.io/badge/skills-9-blue.svg" alt="9 skills"></a>
+  <a href="https://github.com/luongnv89/idd"><img src="https://img.shields.io/badge/commands-8-blue.svg" alt="8 commands"></a>
   <a href="https://github.com/luongnv89/idd/blob/main/CONTRIBUTING.md"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome"></a>
 </p>
 
 # Turn GitHub Issues Into Structured, Agent-Ready Work Orders
 
-Nine terminal commands that structure, analyze, triage, resolve, review, and self-check GitHub issue workflows — so any developer or AI agent can pick up an issue and ship a tested PR.
+Eight terminal commands that structure, analyze, triage, resolve, review, and self-check GitHub issue workflows — so any developer or AI agent can pick up an issue and ship a tested PR.
 
 [**Get Started**](#get-started) · [**What is IDD?**](#what-is-idd) · [**Intention-Driven Development**](#idd-as-intention-driven-development) · [**Why Good Issues & Commits Matter**](#why-good-issues-and-commit-messages-matter) · [**Works With Any Tool**](#works-with-any-tool)
 
@@ -60,7 +60,6 @@ graph LR
 | `/init-gitissue` | Auto-detect language/framework/test runner, generate `.gitissue.yml` | 0.3.2 | low |
 | `/auto-pilot` | Triage → resolve → review → merge loop. Conservative-by-default merge modes (`conservative`/`balanced`/`aggressive`) and explicit issue lists for targeted runs | 2.2.0 | max |
 | `/issue-pr-review` | Review PR end-to-end: script pre-pass (lint/format/test auto-fix), per-criterion AC verification, five-dimension scoring (correctness, acceptance_criteria, traceability, maintainability, safety), reuses reviewer/fixer agents across cycles | 0.4.1 | high |
-| `/issue-pr-review-fix-loop` | _Deprecated v0.4.0 — use `/issue-pr-review`._ The outer review-fix loop is now part of `/issue-pr-review`. Retained one release cycle for backward-compat references; will be removed from this index. | 0.4.0 (deprecated) | high |
 
 ### Internal tooling
 
@@ -204,7 +203,6 @@ You can also install individual skills. See each skill folder for per-skill comm
 | `/issue-triage` | [`src/skills/issue-triage/`](src/skills/issue-triage/) |
 | `/auto-pilot` | [`src/skills/auto-pilot/`](src/skills/auto-pilot/) |
 | `/issue-pr-review` | [`src/skills/issue-pr-review/`](src/skills/issue-pr-review/) |
-| `/issue-pr-review-fix-loop` _(deprecated)_ | [`src/deprecated-skills/issue-pr-review-fix-loop/`](src/deprecated-skills/issue-pr-review-fix-loop/) |
 | `/init-gitissue` | [`src/skills/init-gitissue/`](src/skills/init-gitissue/) |
 | `/idd-doctor` _(internal)_ | [`src/internal-skills/idd-doctor/`](src/internal-skills/idd-doctor/) |
 
@@ -422,39 +420,6 @@ Pipeline:
 
 Max 3 review-fix cycles with stagnation detection.
 
-### /issue-pr-review-fix-loop -- Outer Review-Fix Loop _(deprecated)_
-
-> **Deprecated in v0.4.0** — use `/issue-pr-review` instead. The capabilities below now live in `/issue-pr-review`. This skill is retained for one release cycle to keep existing references resolvable; it will then be removed from the public skill index.
-
-Wraps `/issue-pr-review` in an outer loop that reuses the same reviewer and fixer agents across cycles for efficiency. A fresh confirmation pass runs at the end to provide an unbiased final check after all fixes are applied.
-
-```
-/issue-pr-review-fix-loop 87       # review-fix loop for PR #87
-/issue-pr-review-fix-loop          # auto-detect PR for current branch
-/issue-pr-review-fix-loop 87 --auto  # review-fix + auto-merge when clean
-```
-
-Loop:
-
-```
-Cycle 1/3
-  [Review]   ⟶ /issue-pr-review --review-only (reused reviewer agent)
-  [Result]   ✗ NEEDS_FIX — 3 issues
-  [Fix]      ✓ fixed 3 issues (reused fixer agent)
-  [Commit]   ✓ fix(auth): address review feedback (#42)
-  [Push]     ✓ pushed to origin
-
-Cycle 2/3
-  [Review]   ⟶ /issue-pr-review --review-only (reused reviewer agent)
-  [Result]   ✓ PASS — 0 issues
-
-Confirmation
-  [Review]   ⟶ Fresh reviewer (independent final check)
-  [Result]   ✓ PASS — confirmed clean
-```
-
-Max 3 cycles with stagnation detection. Each cycle creates an atomic commit.
-
 ### /init-gitissue -- Generate Config
 
 Scans your repository and generates `.gitissue.yml` with sensible defaults: detects language, framework, test runner, existing templates, and adjusts timeouts based on repo size.
@@ -554,7 +519,7 @@ src/
 │   └── idd-doctor/         # /idd-doctor — read-only repo health check
 │
 ├── deprecated-skills/
-│   └── issue-pr-review-fix-loop/  # DEPRECATED v0.4.0 — redirects to /issue-pr-review
+│   └── issue-pr-review-fix-loop/  # Retained deprecated source only; not distributed
 │
 └── docs/                         # Runtime docs (consumed by skills at runtime)
     ├── config-schema.md          # Full .gitissue.yml schema (autopilot + review)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,7 +25,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - Human-authored PRs without a Decision Record are reported as `traceability: partial`, not `fail`, while `Closes #N` and acceptance-criteria checks still apply at full strength
 
 ### Deprecated
-- `/issue-pr-review-fix-loop` (v0.4.0) — its outer review-fix loop, agent reuse, and fresh confirmation pass are all part of `/issue-pr-review` now (since v0.3.0), and Phase 2 acceptance-criteria + traceability checks landed there in v0.4.0. The skill file is retained for one release cycle so existing references resolve; after that release cycle it will be removed from the public skill index. Migration: replace any `/issue-pr-review-fix-loop` invocation with `/issue-pr-review` (same PR number, same `--auto` flag). Tracking issue: #37.
+- `/issue-pr-review-fix-loop` (v0.4.0) — its outer review-fix loop, agent reuse, and fresh confirmation pass are all part of `/issue-pr-review` now (since v0.3.0), and Phase 2 acceptance-criteria + traceability checks landed there in v0.4.0. Migration: replace any `/issue-pr-review-fix-loop` invocation with `/issue-pr-review` (same PR number, same `--auto` flag). Source remains under `src/deprecated-skills/issue-pr-review-fix-loop/` for repository history and migration references. Tracking issue: #37.
+
+### Removed
+- `/issue-pr-review-fix-loop` is removed from the public README command index and standalone install table. Its source remains under `src/deprecated-skills/issue-pr-review-fix-loop/` for repository history and migration references, but it is no longer publicly distributed unless a future compatibility release explicitly opts it in with a `distribute:` flag. Tracking issue: #54.
 
 ## [0.7.0] - 2026-03-27
 

--- a/tests/test-issue-pr-review-fix-loop-deprecation.sh
+++ b/tests/test-issue-pr-review-fix-loop-deprecation.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
 # test-issue-pr-review-fix-loop-deprecation.sh — Validate the /issue-pr-review-fix-loop deprecation
 #
-# This script verifies issue #37 acceptance criteria:
+# This script verifies issue #37 and issue #54 acceptance criteria:
 #   AC #1: Audit confirms no workflow depends on /issue-pr-review-fix-loop.
 #   AC #2: skills/issue-pr-review-fix-loop/SKILL.md carries a deprecation
 #          notice and redirect to /issue-pr-review.
 #   AC #3: Tracking note added for removal from the public skill index after
 #          one release cycle.
+#   AC #54.1: Deprecated source remains under src/deprecated-skills/.
+#   AC #54.2: Root README no longer advertises /issue-pr-review-fix-loop as a
+#             public command or installable skill.
+#   AC #54.3: Public distribution excludes /issue-pr-review-fix-loop unless a
+#             future explicit distribution flag is added.
 #
 # Usage: bash tests/test-issue-pr-review-fix-loop-deprecation.sh
 # Returns: exit 0 if all tests pass, exit 1 on failure
@@ -20,6 +25,8 @@ README="$SKILL_DIR/README.md"
 ROOT_README="$REPO_ROOT/README.md"
 ROOT_CLAUDE="$REPO_ROOT/CLAUDE.md"
 CHANGELOG="$REPO_ROOT/docs/CHANGELOG.md"
+DIST_SKILL="$REPO_ROOT/dist/skills/issue-pr-review-fix-loop"
+PLUGIN_MANIFEST="$REPO_ROOT/dist/plugin/.claude-plugin/plugin.json"
 
 PASS=0
 FAIL=0
@@ -34,7 +41,7 @@ fail() {
   FAIL=$((FAIL + 1))
 }
 
-echo "◆ /issue-pr-review-fix-loop Deprecation Tests (issue #37)"
+echo "◆ /issue-pr-review-fix-loop Deprecation Tests (issues #37, #54)"
 echo "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄"
 
 # ───────────────────────────────────────────────────────────
@@ -169,18 +176,24 @@ case "$readme_lower" in
 esac
 
 # ───────────────────────────────────────────────────────────
-# T7: Root README marks the skill as deprecated (AC #2 + AC #3)
+# T7: Root README no longer advertises the skill publicly (issue #54)
 # ───────────────────────────────────────────────────────────
-if grep -qE '^\|.*\`/issue-pr-review-fix-loop\`.*[Dd]eprecated' "$ROOT_README"; then
-  pass "T7.1: AC #2 — Root README skill table marks /issue-pr-review-fix-loop deprecated"
+if grep -qE '^\|[[:space:]]*`/issue-pr-review-fix-loop`' "$ROOT_README"; then
+  fail "T7.1: AC #54 — Root README still has a public table row for /issue-pr-review-fix-loop"
 else
-  fail "T7.1: AC #2 — Root README skill table does not mark /issue-pr-review-fix-loop deprecated"
+  pass "T7.1: AC #54 — Root README has no public table row for /issue-pr-review-fix-loop"
 fi
 
-if grep -qE '^### /issue-pr-review-fix-loop.*[Dd]eprecated' "$ROOT_README"; then
-  pass "T7.2: AC #2 — Root README section header marks skill deprecated"
+if grep -qE '^### /issue-pr-review-fix-loop' "$ROOT_README"; then
+  fail "T7.2: AC #54 — Root README still has a command reference section for /issue-pr-review-fix-loop"
 else
-  fail "T7.2: AC #2 — Root README section header missing deprecation marker"
+  pass "T7.2: AC #54 — Root README has no command reference section for /issue-pr-review-fix-loop"
+fi
+
+if grep -qE '^/issue-pr-review-fix-loop([[:space:]]|$)' "$ROOT_README"; then
+  fail "T7.3: AC #54 — Root README still contains runnable /issue-pr-review-fix-loop examples"
+else
+  pass "T7.3: AC #54 — Root README has no runnable /issue-pr-review-fix-loop examples"
 fi
 
 # ───────────────────────────────────────────────────────────
@@ -219,10 +232,10 @@ if awk '
   /^## \[Unreleased\]/ {in_unrel=1; next}
   /^## \[/ && in_unrel {exit}
   in_unrel
-' "$CHANGELOG" | grep -qiE 'one release cycle'; then
-  pass "T9.3: AC #3 — CHANGELOG entry references one-release-cycle window"
+' "$CHANGELOG" | grep -qE 'src/deprecated-skills/issue-pr-review-fix-loop'; then
+  pass "T9.3: AC #3/#54 — CHANGELOG documents retained deprecated source path"
 else
-  fail "T9.3: AC #3 — CHANGELOG entry missing one-release-cycle reference"
+  fail "T9.3: AC #3/#54 — CHANGELOG missing retained deprecated source path"
 fi
 
 if awk '
@@ -233,6 +246,26 @@ if awk '
   pass "T9.4: AC #3 — CHANGELOG entry links tracking issue #37"
 else
   fail "T9.4: AC #3 — CHANGELOG entry missing #37 tracking reference"
+fi
+
+if awk '
+  /^## \[Unreleased\]/ {in_unrel=1; next}
+  /^## \[/ && in_unrel {exit}
+  in_unrel
+' "$CHANGELOG" | grep -qE '^### Removed[[:space:]]*$'; then
+  pass "T9.5: AC #54 — CHANGELOG [Unreleased] has Removed subsection"
+else
+  fail "T9.5: AC #54 — CHANGELOG [Unreleased] missing Removed subsection"
+fi
+
+if awk '
+  /^## \[Unreleased\]/ {in_unrel=1; next}
+  /^## \[/ && in_unrel {exit}
+  in_unrel
+' "$CHANGELOG" | grep -qE '#54'; then
+  pass "T9.6: AC #54 — CHANGELOG documents the public distribution removal decision"
+else
+  fail "T9.6: AC #54 — CHANGELOG missing issue #54 removal decision"
 fi
 
 # ───────────────────────────────────────────────────────────
@@ -282,6 +315,27 @@ else
 fi
 
 # ───────────────────────────────────────────────────────────
+# T11: AC #54 — public distribution excludes the deprecated skill
+# ───────────────────────────────────────────────────────────
+if grep -qE '^[[:space:]]*distribute:' "$SKILL"; then
+  fail "T11.1: AC #54 — deprecated SKILL.md has a distribute flag"
+else
+  pass "T11.1: AC #54 — deprecated SKILL.md has no distribute flag"
+fi
+
+if [ -e "$DIST_SKILL" ]; then
+  fail "T11.2: AC #54 — dist/skills contains issue-pr-review-fix-loop"
+else
+  pass "T11.2: AC #54 — dist/skills excludes issue-pr-review-fix-loop"
+fi
+
+if [ -f "$PLUGIN_MANIFEST" ] && grep -q 'issue-pr-review-fix-loop' "$PLUGIN_MANIFEST"; then
+  fail "T11.3: AC #54 — public plugin manifest includes issue-pr-review-fix-loop"
+else
+  pass "T11.3: AC #54 — public plugin manifest excludes issue-pr-review-fix-loop"
+fi
+
+# ───────────────────────────────────────────────────────────
 # Summary
 # ───────────────────────────────────────────────────────────
 echo "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄"
@@ -293,5 +347,5 @@ if [ "$FAIL" -gt 0 ]; then
   exit 1
 fi
 
-echo "  ✓ Deprecation spec for /issue-pr-review-fix-loop satisfies issue #37 ACs"
+echo "  ✓ Deprecation spec for /issue-pr-review-fix-loop satisfies issue #37 and #54 ACs"
 exit 0


### PR DESCRIPTION
Closes #54

## Summary

Removes `/issue-pr-review-fix-loop` from the public README surfaces now that the deprecation cycle has completed, while retaining the deprecated source under `src/deprecated-skills/issue-pr-review-fix-loop/` for repository history and migration references.

## Approach

Selected the balanced docs/test policy update: remove public advertising, document the removal decision, and convert the existing deprecation regression test from “advertised as deprecated” to “source retained, public distribution excluded.”

## Decision Record

- **Root cause:** The deprecated `issue-pr-review-fix-loop` source had already moved under `src/deprecated-skills/`, but README still advertised the command as public and the regression test still encoded the old “listed as deprecated” policy.
- **Options considered:** Option 1 — minimal README/test removal; Option 2 — balanced README/changelog/test policy update; Option 3 — comprehensive policy documentation update.
- **Options rejected:** Option 1 — did not leave a durable changelog decision; Option 3 — broader than needed for the immediate distribution decision.
- **Selected option:** Option 2 — balanced README/changelog/test policy update.
- **Residual risk:** The production `dist/plugin` build does not exist yet; the regression test guards the expected public manifest path when it is introduced and verifies current `dist/skills` absence.

Analyzed at: `chore/54-fix-loop-distribution @ e6571dd` (2026-04-28)

## Changes

| File | Change |
|------|--------|
| `README.md` | Removed `/issue-pr-review-fix-loop` from public command table, standalone install table, and command reference section; updated command count to 8; retained only a source-tree note that it is not distributed. |
| `docs/CHANGELOG.md` | Documented the #54 removal decision and clarified that deprecated source remains only for history/migration references. |
| `tests/test-issue-pr-review-fix-loop-deprecation.sh` | Updated regression coverage for #54: README no longer advertises the command, no `distribute:` opt-in exists, `dist/skills` excludes it, and the public plugin manifest excludes it when present. |

## Test Results

- Unit tests: 224 shell assertions passed across `tests/test-*.sh`
- Integration tests: covered by repository shell tests
- E2e tests: skipped (none configured)
- Build: skipped (no production build script exists in this checkout)
- QA cycles: 1 reviewer cycle; 2 findings fixed

Commands run:

```bash
bash tests/test-issue-pr-review-fix-loop-deprecation.sh
for t in tests/test-*.sh; do bash "$t"; done
for t in tests/test-*.sh; do bash "$t" >/tmp/idd-test.out || { cat /tmp/idd-test.out; exit 1; }; done
```

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Decision documented in `docs/CHANGELOG.md`. | pass | `docs/CHANGELOG.md` has a `Removed` entry for #54 and retained-source wording. |
| `tests/test-issue-pr-review-fix-loop-deprecation.sh` passes against the new path. | pass | Targeted test passed: 30 passed, 0 failed; `SKILL_DIR` points to `src/deprecated-skills/issue-pr-review-fix-loop`. |
| README no longer advertises the skill as public. | pass | README public command table, install table, and command reference section no longer include `/issue-pr-review-fix-loop`; T7.1-T7.3 verify this. |
