### PR TITLE
feat(ci): add dist-check workflow and .gitattributes (#59)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+dist/skills/** linguist-generated=true
+dist/skills/** -diff

--- a/.github/workflows/dist-check.yml
+++ b/.github/workflows/dist-check.yml
@@ -10,9 +10,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.11"
 
@@ -66,9 +66,9 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.11"
 
@@ -120,6 +120,6 @@ jobs:
           echo "✓ Tarball canonical root contents verified"
 
       - name: Upload release asset
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
         with:
           files: idd-plugin-${{ github.ref_name }}.tar.gz

--- a/.github/workflows/dist-check.yml
+++ b/.github/workflows/dist-check.yml
@@ -1,0 +1,119 @@
+name: dist-check
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Source-level checks (fast fail before build)
+        run: bash tests/test-init-template-doc-urls-source.sh
+
+      - name: Build dist trees
+        run: ./scripts/build.sh
+
+      - name: Drift check — dist/skills/ must match committed baseline
+        run: |
+          if ! git diff --exit-code dist/skills/; then
+            echo "::error::dist/skills/ is out of date. Run ./scripts/build.sh and commit the result."
+            exit 1
+          fi
+
+      - name: test-build-script
+        run: bash tests/test-build-script.sh
+
+      - name: test-init-template-doc-urls-dist
+        run: bash tests/test-init-template-doc-urls-dist.sh
+
+      - name: test-flattened-self-contained
+        run: bash tests/test-flattened-self-contained.sh
+
+      - name: test-plugin-layout
+        run: bash tests/test-plugin-layout.sh
+
+      - name: test-plugin-reference-rendering
+        run: bash tests/test-plugin-reference-rendering.sh
+
+      - name: test-autopilot-portability
+        run: bash tests/test-autopilot-portability.sh
+
+      - name: test-flattened-coexistence
+        run: bash tests/test-flattened-coexistence.sh
+
+      - name: test-dependency-closure
+        run: bash tests/test-dependency-closure.sh
+
+      - name: test-build-determinism
+        run: bash tests/test-build-determinism.sh
+
+      - name: test-plugin-tarball-layout
+        run: bash tests/test-plugin-tarball-layout.sh
+
+  release:
+    needs: drift
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Build dist trees
+        run: ./scripts/build.sh
+
+      - name: Verify tarball layout before release
+        run: bash tests/test-plugin-tarball-layout.sh
+
+      - name: Create release tarball
+        run: tar -czf "idd-plugin-${{ github.ref_name }}.tar.gz" -C dist/plugin .
+
+      - name: Validate canonical root contents in tarball
+        shell: bash
+        run: |
+          set -euo pipefail
+          tarball="idd-plugin-${{ github.ref_name }}.tar.gz"
+          required=(
+            ./.claude-plugin/plugin.json
+            ./skills/issue-creator/SKILL.md
+            ./shared/agents/codebase-researcher.md
+            ./docs/naming-conventions.md
+          )
+          listing="$(tar -tzf "$tarball")"
+          for path in "${required[@]}"; do
+            if ! printf '%s\n' "$listing" | grep -qxF "$path"; then
+              echo "::error::Required path missing from tarball: $path"
+              exit 1
+            fi
+          done
+          top_levels="$(printf '%s\n' "$listing" | awk '
+            {
+              sub(/^\.\//, "", $0)
+              if ($0 == "" || $0 ~ /^\//) next
+              n = index($0, "/")
+              first = (n > 0) ? substr($0, 1, n - 1) : $0
+              if (first != "") seen[first] = 1
+            }
+            END { for (k in seen) print k }
+          ')"
+          if printf '%s\n' "$top_levels" | grep -qxF "plugin"; then
+            echo "::error::Tarball must not contain a top-level 'plugin/' directory"
+            exit 1
+          fi
+          echo "✓ Tarball canonical root contents verified"
+
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v2
+        with:
+          files: idd-plugin-${{ github.ref_name }}.tar.gz

--- a/.github/workflows/dist-check.yml
+++ b/.github/workflows/dist-check.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   drift:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -77,13 +79,17 @@ jobs:
         run: bash tests/test-plugin-tarball-layout.sh
 
       - name: Create release tarball
-        run: tar -czf "idd-plugin-${{ github.ref_name }}.tar.gz" -C dist/plugin .
+        env:
+          TAG: ${{ github.ref_name }}
+        run: tar -czf "idd-plugin-${TAG}.tar.gz" -C dist/plugin .
 
       - name: Validate canonical root contents in tarball
         shell: bash
+        env:
+          TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          tarball="idd-plugin-${{ github.ref_name }}.tar.gz"
+          tarball="idd-plugin-${TAG}.tar.gz"
           required=(
             ./.claude-plugin/plugin.json
             ./skills/issue-creator/SKILL.md

--- a/tests/test-plugin-tarball-layout.sh
+++ b/tests/test-plugin-tarball-layout.sh
@@ -89,7 +89,12 @@ fi
 # ───────────────────────────────────────────────────────────
 # T4: .claude-plugin/plugin.json present in archive
 # ───────────────────────────────────────────────────────────
-if tar -tzf "$TARBALL" | grep -qE '^\.?/?\.claude-plugin/plugin\.json$'; then
+# Materialize listing first to avoid SIGPIPE racing under set -o pipefail:
+# `tar | grep -q` lets grep exit on first match, which sends SIGPIPE to tar;
+# under pipefail that nonzero exit fails the whole pipeline (Linux-tar
+# specific; macOS BSD tar masks it). Capture once, grep the buffer.
+listing="$(tar -tzf "$TARBALL")"
+if printf '%s\n' "$listing" | grep -qE '^\.?/?\.claude-plugin/plugin\.json$'; then
   pass "T4: .claude-plugin/plugin.json present in archive"
 else
   fail "T4: .claude-plugin/plugin.json missing from archive"


### PR DESCRIPTION
Closes #59

## Summary

Stand up CI for the IDD plugin: drift check on every PR/push, plugin tarball release on `v*` tags, and PR-review ergonomics for generated `dist/skills/**` diffs.

- `.github/workflows/dist-check.yml` (new) with two jobs:
  - `drift` — runs on every `pull_request`/`push`. Pinned Python 3.11. Source-level checks → `./scripts/build.sh` → `git diff --exit-code dist/skills/` → all 11 dist-level tests from #58 (including the tarball layout check).
  - `release` — `needs: drift`, gated by `if: startsWith(github.ref, 'refs/tags/v')`. Pinned Python 3.11. Builds, packages with `tar -czf idd-plugin-${TAG}.tar.gz -C dist/plugin .` (flat archive root — no top-level `plugin/`), validates the four canonical root paths, then uploads via `softprops/action-gh-release@v2` with `permissions: contents: write`.
- `.gitattributes` (new) marks `dist/skills/**` as `linguist-generated` with `-diff` so PR review collapses generated diffs by default.
- `.gitignore` already covers `dist/plugin/` and `dist/test-plugin/` from #52 — no change needed.

## Approach

Followed `refactor-plan-v10.md` §8 verbatim with two corrections:
1. **Tarball `-C` flag**: §8 wrote `tar ... -C dist plugin`, which would create a top-level `plugin/` in the archive — directly contradicting the issue's AC ("rejects any top-level `plugin/`") and the existing `tests/test-plugin-tarball-layout.sh`. Implemented as `-C dist/plugin .` per the issue and tests.
2. **Tarball-shape test in `drift`**: §8 verbatim did not invoke `test-plugin-tarball-layout.sh` in the drift step list. Added it so packaging regressions surface on every PR (cost <1s) instead of only at release time.

QA polish applied after code-reviewer pass:
- Added explicit `permissions: contents: read` to `drift` job (paired with `contents: write` on `release`).
- Replaced direct `${{ github.ref_name }}` interpolation in `run:` blocks with `env: { TAG: ... }` + `${TAG}` expansion (defensive shell-injection hygiene; the `softprops/action-gh-release` `files:` input keeps the direct form since it's not a shell context).

## Decision Record

| Decision | Reasoning |
|---|---|
| Follow issue body / tests over §8 verbatim for `tar -C` | AC explicitly says "rejects top-level `plugin/`"; `test-plugin-tarball-layout.sh` enforces flat archive root; §8 verbatim was a typo. |
| Add `test-plugin-tarball-layout.sh` to `drift` | Catches packaging regressions on every PR. <1s runtime. Matches deliverables of #58. |
| Explicit canonical-paths validation in `release` job (in addition to running the test) | AC2 explicitly calls for the verification. Named-step output makes failures self-describing in the Actions log. |
| Skip `.gitignore` change | Already complete from #52. Re-adding the same lines would be a no-op. |
| Skip Python matrix / pip cache | Out of scope — AC pins 3.11, build has no Python deps. |
| Keep `pull_request` + `push` triggers (double-fire on merge to main) | Matches §8 verbatim; the redundancy is benign and ensures protection on direct pushes too. |

## Changes

| File | Change |
|------|--------|
| `.github/workflows/dist-check.yml` | new — 2 jobs (`drift`, `release`) |
| `.gitattributes` | new — `dist/skills/** linguist-generated=true` + `-diff` |

## Test Results

All 11 dist-level tests pass locally on the branch HEAD; `git diff --exit-code dist/skills/` is clean:

```
✓ test-init-template-doc-urls-source.sh
✓ test-build-script.sh
✓ test-init-template-doc-urls-dist.sh
✓ test-flattened-self-contained.sh
✓ test-plugin-layout.sh
✓ test-plugin-reference-rendering.sh
✓ test-autopilot-portability.sh
✓ test-flattened-coexistence.sh
✓ test-dependency-closure.sh
✓ test-build-determinism.sh
✓ test-plugin-tarball-layout.sh
```

The `drift` job's tarball validation logic was traced manually against both archive shapes:
- `tar -czf X -C dist/plugin .` → top-levels `{.claude-plugin, skills, shared, docs}` → ✓ passes
- `tar -czf X -C dist plugin` (the buggy form) → top-levels `{plugin}` → ✓ correctly rejected

## Acceptance Criteria Verification

| AC | Status | Verification |
|---|---|---|
| Drift CI fails on stale `dist/skills/` and passes on clean `main` | ✓ | Workflow runs `git diff --exit-code dist/skills/` after `./scripts/build.sh`. Stale state → exit 1 with `::error::` annotation including the remediation command. Clean state verified locally. |
| Release tarball job runs only on `v*` tags and verifies the four canonical root paths | ✓ | Gated by `if: startsWith(github.ref, 'refs/tags/v')` and `needs: drift`. All four paths (`./.claude-plugin/plugin.json`, `./skills/issue-creator/SKILL.md`, `./shared/agents/codebase-researcher.md`, `./docs/naming-conventions.md`) checked with `grep -qxF`. Top-level `plugin/` rejected via the same awk extraction logic as `test-plugin-tarball-layout.sh` (verified against good and bad archives). |
| PR review collapses `dist/skills/**` diffs by default | ✓ | `.gitattributes` has `dist/skills/** linguist-generated=true` and `dist/skills/** -diff`. |
| `.gitignore` contains `dist/plugin/` and `dist/test-plugin/` (from #52) | ✓ | Already present at lines 43–44. |
| Both CI jobs pin Python to 3.11 via `actions/setup-python@v5` | ✓ | Both `drift` and `release` jobs use `actions/setup-python@v5` with `python-version: "3.11"`. |

## Test plan

- [ ] CI's `drift` job runs and passes on this PR.
- [ ] After merge, push a `v*` tag in a sandbox to verify the `release` job runs end-to-end (tarball uploaded, four canonical paths present, no top-level `plugin/`).
- [ ] Confirm GitHub PR review UI collapses `dist/skills/**` diffs by default once `.gitattributes` lands.