### PR TITLE
fix(skills): protect uncommitted changes during rebase sync (#22)

### DIFF
--- a/dist/skills/auto-pilot/SKILL.md
+++ b/dist/skills/auto-pilot/SKILL.md
@@ -89,9 +89,29 @@ git stash --include-untracked -m "auto-pilot: stash before run"
   Stash ref: {stash_ref}
 ```
 
-If not on the default branch (main/master), auto-switch:
+If not on the default branch (main/master), auto-switch and sync. The stash above already protects any uncommitted work, so the rebase here runs on a clean tree (see `references/docs/sync-conventions.md` for the full sync convention and recovery procedure):
+
 ```bash
-git checkout {default_branch} && git pull --rebase origin {default_branch}
+git checkout {default_branch}
+# Defensive stash — the pre-flight stash above should have caught this,
+# but the convention is to stash-first whenever a rebase follows.
+dirty=0
+if [ -n "$(git status --porcelain)" ]; then
+  git stash push -u -m "pre-sync: {default_branch}"
+  dirty=1
+fi
+git fetch origin
+git pull --rebase origin {default_branch} || {
+  echo "✗ Rebase failed — aborting and resetting to remote"
+  git rebase --abort 2>/dev/null
+  exit 1
+}
+if [ "$dirty" -eq 1 ]; then
+  git stash pop || {
+    echo "✗ Stash pop failed — recover with: git stash list && git stash show -p stash@{0}"
+    exit 1
+  }
+fi
 ```
 ```
 ⚠ Was on branch {branch} — auto-switched to {default_branch}

--- a/dist/skills/auto-pilot/references/docs/sync-conventions.md
+++ b/dist/skills/auto-pilot/references/docs/sync-conventions.md
@@ -1,0 +1,103 @@
+<!-- Generated from src/docs/sync-conventions.md. Do not edit. Edit source and run ./scripts/build.sh. -->
+# Sync Conventions
+
+Standard convention for syncing a working branch with the remote before any IDD skill modifies files. Centralizing this here ensures every skill that performs a `git pull --rebase` first protects uncommitted changes — the unsafe pattern (bare rebase on a dirty tree) can silently destroy staged or unstaged work, so it must never appear in skill instructions.
+
+## Why This Matters
+
+`git pull --rebase` rewrites local history. When the working tree has uncommitted changes that overlap with incoming commits, rebase either fails outright or — worse — leaves the tree in a confusing intermediate state where the user's work appears lost. The fix is mechanical: stash before, pop after. This document is the canonical reference; skills should link here rather than copy-pasting the snippet, so the convention can be updated in one place.
+
+---
+
+## Primary Pattern: Stash-First Sync
+
+This is the **only** documented sync path. Every skill that runs `git pull --rebase` MUST follow it.
+
+```bash
+branch="$(git rev-parse --abbrev-ref HEAD)"
+
+# Protect any uncommitted changes (staged + unstaged + untracked).
+# The descriptive message lets the user identify the stash later.
+dirty=0
+if [ -n "$(git status --porcelain)" ]; then
+  git stash push -u -m "pre-sync: ${branch} $(date +%Y-%m-%dT%H:%M:%S)"
+  dirty=1
+fi
+
+# Sync with remote.
+git fetch origin
+git pull --rebase origin "$branch"
+
+# Restore uncommitted changes.
+if [ "$dirty" -eq 1 ]; then
+  git stash pop || {
+    echo "✗ Stash pop failed — your changes are still safe in the stash"
+    echo "  Recovery:"
+    echo "    git stash list                       # find the stash ref (e.g. stash@{0})"
+    echo "    git stash show -p stash@{0}          # preview what's in it"
+    echo "    git checkout stash@{0} -- <path>     # restore individual files"
+    echo "    git stash pop --index stash@{0}      # retry pop after resolving conflicts"
+    exit 1
+  }
+fi
+```
+
+### Behavior Notes
+
+- **`git status --porcelain`** is the canonical dirty-tree check — empty output means clean, any output means dirty (modified, staged, or untracked).
+- **`git stash push -u`** includes untracked files (`-u` = `--include-untracked`). Without `-u`, new files are left exposed and can collide with the rebase.
+- **The stash message** must be descriptive (branch name + timestamp) so the user can identify it via `git stash list`. Generic messages like `"pre-sync"` make recovery harder when multiple stashes accumulate.
+- **`git stash pop`** can fail with merge conflicts. When it does, the stash is preserved on the stash stack — the user's changes are not lost. The recovery output above tells the user exactly how to access them.
+- **Stash ref stability:** newly pushed stashes always become `stash@{0}`. The recovery instructions assume this; if a script creates additional stashes between push and pop, capture the ref returned by `git stash push` instead.
+
+---
+
+## When the Sync Fails
+
+| Failure | Cause | Recovery |
+|---------|-------|----------|
+| `fatal: 'origin' does not appear to be a git repository` | No remote configured | Stop and ask the user to add a remote: `git remote add origin <url>`. In auto mode, abort with a clear error. |
+| `error: Could not apply <commit>` (rebase conflict) | Local commits conflict with incoming | Stop. In interactive mode, ask the user to resolve. In auto mode, run `git rebase --abort` and report. |
+| `error: Your local changes to the following files would be overwritten by merge` | Stash-first was skipped (do not let this reach the user) | Indicates a skill bypassed the convention. Report the skill bug. |
+| `CONFLICT (content): Merge conflict in <file>` (during stash pop) | Rebased commits touch the same lines as the stash | Use the recovery output above. Stash is preserved on the stack. |
+
+---
+
+## Skill-Side Responsibilities
+
+Every IDD skill that performs a sync step MUST:
+
+1. **Use the stash-first block above** — never document a bare `git pull --rebase` as the primary path.
+2. **Link to this document** — write `(see the sync conventions reference)` next to the snippet so users find this reference.
+3. **Document the recovery** — at minimum, instruct on `git stash list` and `git stash show -p stash@{0}` if a pop conflict occurs. Skills are free to inline the full recovery block from this document.
+4. **Honor the mode contract** — in interactive mode, prompt the user before stashing or aborting on conflict. In auto mode (`--auto`), perform the stash-first sync without prompting; abort cleanly with a recovery hint if it fails.
+
+---
+
+## Lint Enforcement
+
+`tests/test-sync-safety.sh` greps `src/skills/**/*.md` and `src/skills/**/references/*.md` for `git pull --rebase` and asserts that each occurrence is preceded (within ~12 lines) by a `git stash` invocation or by a comment that defers to this document. Failing the lint blocks merges. This is the regression guard — without it, future skill edits could silently reintroduce the unsafe form.
+
+---
+
+## Quick Reference (Copy-Paste Snippet)
+
+For skills that want the minimal form inline:
+
+```bash
+# Stash-first sync — see the sync conventions reference for full recovery procedure.
+branch="$(git rev-parse --abbrev-ref HEAD)"
+dirty=0
+if [ -n "$(git status --porcelain)" ]; then
+  git stash push -u -m "pre-sync: ${branch}"
+  dirty=1
+fi
+git fetch origin
+git pull --rebase origin "$branch"
+if [ "$dirty" -eq 1 ]; then
+  git stash pop || {
+    echo "✗ Stash pop failed — recover with: git stash list && git stash show -p stash@{0}"
+    exit 1
+  }
+fi
+```

--- a/dist/skills/auto-pilot/references/phases.md
+++ b/dist/skills/auto-pilot/references/phases.md
@@ -95,14 +95,26 @@ Stop.
 
 ### Step 2.1 — Sync to Default Branch
 
-The main agent syncs to the default branch directly (this is lightweight — no code reading):
+The main agent syncs to the default branch directly (this is lightweight — no code reading). Use the stash-first pattern to protect any uncommitted work that may have appeared since the pre-flight stash (see `references/docs/sync-conventions.md`):
 
 ```bash
 git checkout {default_branch}
+dirty=0
+if [ -n "$(git status --porcelain)" ]; then
+  git stash push -u -m "pre-sync: {default_branch}"
+  dirty=1
+fi
+git fetch origin
 git pull --rebase origin {default_branch}
+if [ "$dirty" -eq 1 ]; then
+  git stash pop || {
+    echo "✗ Stash pop failed — recover with: git stash list && git stash show -p stash@{0}"
+    exit 1
+  }
+fi
 ```
 
-If this fails (merge conflict from a prior iteration), attempt auto-resolution:
+If the rebase itself fails (merge conflict from a prior iteration), attempt auto-resolution:
 
 ```bash
 git rebase --abort
@@ -436,9 +448,23 @@ Record the iteration outcome (`merged` or `left_open`) for the final summary.
 
 ### Step 5.3 — Cleanup
 
+Use the stash-first sync to protect any uncommitted changes that may have accumulated between iterations (see `references/docs/sync-conventions.md`):
+
 ```bash
 git checkout {default_branch}
+dirty=0
+if [ -n "$(git status --porcelain)" ]; then
+  git stash push -u -m "pre-cleanup: {default_branch}"
+  dirty=1
+fi
+git fetch origin
 git pull --rebase origin {default_branch}
+if [ "$dirty" -eq 1 ]; then
+  git stash pop || {
+    echo "✗ Stash pop failed — recover with: git stash list && git stash show -p stash@{0}"
+    exit 1
+  }
+fi
 git branch -d {branch_name} 2>/dev/null
 ```
 

--- a/dist/skills/issue-analysis/SKILL.md
+++ b/dist/skills/issue-analysis/SKILL.md
@@ -78,17 +78,26 @@ Before analyzing, recommend syncing with the remote so codebase analysis uses cu
   Sync now? [Y/n]
 ```
 
-If the user agrees, run:
+If the user agrees, run the stash-first sync (see `references/docs/sync-conventions.md`):
 
 ```bash
 branch="$(git rev-parse --abbrev-ref HEAD)"
+dirty=0
+if [ -n "$(git status --porcelain)" ]; then
+  git stash push -u -m "pre-sync: ${branch}"
+  dirty=1
+fi
 git fetch origin
 git pull --rebase origin "$branch"
+if [ "$dirty" -eq 1 ]; then
+  git stash pop || {
+    echo "✗ Stash pop failed — recover with: git stash list && git stash show -p stash@{0}"
+    exit 1
+  }
+fi
 ```
 
-If the working tree is dirty, stash first (`git stash`), sync, then pop (`git stash pop`). If `origin` is missing or conflicts occur, inform the user and continue without syncing.
-
-If the user declines, proceed without syncing.
+If `origin` is missing or rebase conflicts occur, inform the user and continue without syncing. If the user declines the prompt, proceed without syncing.
 
 ## Configuration
 

--- a/dist/skills/issue-analysis/references/docs/sync-conventions.md
+++ b/dist/skills/issue-analysis/references/docs/sync-conventions.md
@@ -1,0 +1,103 @@
+<!-- Generated from src/docs/sync-conventions.md. Do not edit. Edit source and run ./scripts/build.sh. -->
+# Sync Conventions
+
+Standard convention for syncing a working branch with the remote before any IDD skill modifies files. Centralizing this here ensures every skill that performs a `git pull --rebase` first protects uncommitted changes — the unsafe pattern (bare rebase on a dirty tree) can silently destroy staged or unstaged work, so it must never appear in skill instructions.
+
+## Why This Matters
+
+`git pull --rebase` rewrites local history. When the working tree has uncommitted changes that overlap with incoming commits, rebase either fails outright or — worse — leaves the tree in a confusing intermediate state where the user's work appears lost. The fix is mechanical: stash before, pop after. This document is the canonical reference; skills should link here rather than copy-pasting the snippet, so the convention can be updated in one place.
+
+---
+
+## Primary Pattern: Stash-First Sync
+
+This is the **only** documented sync path. Every skill that runs `git pull --rebase` MUST follow it.
+
+```bash
+branch="$(git rev-parse --abbrev-ref HEAD)"
+
+# Protect any uncommitted changes (staged + unstaged + untracked).
+# The descriptive message lets the user identify the stash later.
+dirty=0
+if [ -n "$(git status --porcelain)" ]; then
+  git stash push -u -m "pre-sync: ${branch} $(date +%Y-%m-%dT%H:%M:%S)"
+  dirty=1
+fi
+
+# Sync with remote.
+git fetch origin
+git pull --rebase origin "$branch"
+
+# Restore uncommitted changes.
+if [ "$dirty" -eq 1 ]; then
+  git stash pop || {
+    echo "✗ Stash pop failed — your changes are still safe in the stash"
+    echo "  Recovery:"
+    echo "    git stash list                       # find the stash ref (e.g. stash@{0})"
+    echo "    git stash show -p stash@{0}          # preview what's in it"
+    echo "    git checkout stash@{0} -- <path>     # restore individual files"
+    echo "    git stash pop --index stash@{0}      # retry pop after resolving conflicts"
+    exit 1
+  }
+fi
+```
+
+### Behavior Notes
+
+- **`git status --porcelain`** is the canonical dirty-tree check — empty output means clean, any output means dirty (modified, staged, or untracked).
+- **`git stash push -u`** includes untracked files (`-u` = `--include-untracked`). Without `-u`, new files are left exposed and can collide with the rebase.
+- **The stash message** must be descriptive (branch name + timestamp) so the user can identify it via `git stash list`. Generic messages like `"pre-sync"` make recovery harder when multiple stashes accumulate.
+- **`git stash pop`** can fail with merge conflicts. When it does, the stash is preserved on the stash stack — the user's changes are not lost. The recovery output above tells the user exactly how to access them.
+- **Stash ref stability:** newly pushed stashes always become `stash@{0}`. The recovery instructions assume this; if a script creates additional stashes between push and pop, capture the ref returned by `git stash push` instead.
+
+---
+
+## When the Sync Fails
+
+| Failure | Cause | Recovery |
+|---------|-------|----------|
+| `fatal: 'origin' does not appear to be a git repository` | No remote configured | Stop and ask the user to add a remote: `git remote add origin <url>`. In auto mode, abort with a clear error. |
+| `error: Could not apply <commit>` (rebase conflict) | Local commits conflict with incoming | Stop. In interactive mode, ask the user to resolve. In auto mode, run `git rebase --abort` and report. |
+| `error: Your local changes to the following files would be overwritten by merge` | Stash-first was skipped (do not let this reach the user) | Indicates a skill bypassed the convention. Report the skill bug. |
+| `CONFLICT (content): Merge conflict in <file>` (during stash pop) | Rebased commits touch the same lines as the stash | Use the recovery output above. Stash is preserved on the stack. |
+
+---
+
+## Skill-Side Responsibilities
+
+Every IDD skill that performs a sync step MUST:
+
+1. **Use the stash-first block above** — never document a bare `git pull --rebase` as the primary path.
+2. **Link to this document** — write `(see the sync conventions reference)` next to the snippet so users find this reference.
+3. **Document the recovery** — at minimum, instruct on `git stash list` and `git stash show -p stash@{0}` if a pop conflict occurs. Skills are free to inline the full recovery block from this document.
+4. **Honor the mode contract** — in interactive mode, prompt the user before stashing or aborting on conflict. In auto mode (`--auto`), perform the stash-first sync without prompting; abort cleanly with a recovery hint if it fails.
+
+---
+
+## Lint Enforcement
+
+`tests/test-sync-safety.sh` greps `src/skills/**/*.md` and `src/skills/**/references/*.md` for `git pull --rebase` and asserts that each occurrence is preceded (within ~12 lines) by a `git stash` invocation or by a comment that defers to this document. Failing the lint blocks merges. This is the regression guard — without it, future skill edits could silently reintroduce the unsafe form.
+
+---
+
+## Quick Reference (Copy-Paste Snippet)
+
+For skills that want the minimal form inline:
+
+```bash
+# Stash-first sync — see the sync conventions reference for full recovery procedure.
+branch="$(git rev-parse --abbrev-ref HEAD)"
+dirty=0
+if [ -n "$(git status --porcelain)" ]; then
+  git stash push -u -m "pre-sync: ${branch}"
+  dirty=1
+fi
+git fetch origin
+git pull --rebase origin "$branch"
+if [ "$dirty" -eq 1 ]; then
+  git stash pop || {
+    echo "✗ Stash pop failed — recover with: git stash list && git stash show -p stash@{0}"
+    exit 1
+  }
+fi
+```

--- a/dist/skills/issue-pr-review/SKILL.md
+++ b/dist/skills/issue-pr-review/SKILL.md
@@ -31,15 +31,26 @@ The `--auto` flag is set automatically when invoked by `/auto-pilot`.
 
 ## Repo Sync Before Edits (mandatory)
 
-Before making any fixes:
+Before making any fixes, sync with remote using the stash-first pattern (see `references/docs/sync-conventions.md` for the full convention and recovery procedure):
 
 ```bash
 branch="$(git rev-parse --abbrev-ref HEAD)"
+dirty=0
+if [ -n "$(git status --porcelain)" ]; then
+  git stash push -u -m "pre-sync: ${branch}"
+  dirty=1
+fi
 git fetch origin
 git pull --rebase origin "$branch"
+if [ "$dirty" -eq 1 ]; then
+  git stash pop || {
+    echo "✗ Stash pop failed — recover with: git stash list && git stash show -p stash@{0}"
+    exit 1
+  }
+fi
 ```
 
-If dirty: stash, sync, pop. If `origin` missing or conflicts: stop and ask (interactive) or abort (auto).
+If `origin` is missing or rebase conflicts occur, stop and ask (interactive) or abort with a clear error (auto).
 
 ## Configuration
 

--- a/dist/skills/issue-pr-review/references/docs/sync-conventions.md
+++ b/dist/skills/issue-pr-review/references/docs/sync-conventions.md
@@ -1,0 +1,103 @@
+<!-- Generated from src/docs/sync-conventions.md. Do not edit. Edit source and run ./scripts/build.sh. -->
+# Sync Conventions
+
+Standard convention for syncing a working branch with the remote before any IDD skill modifies files. Centralizing this here ensures every skill that performs a `git pull --rebase` first protects uncommitted changes — the unsafe pattern (bare rebase on a dirty tree) can silently destroy staged or unstaged work, so it must never appear in skill instructions.
+
+## Why This Matters
+
+`git pull --rebase` rewrites local history. When the working tree has uncommitted changes that overlap with incoming commits, rebase either fails outright or — worse — leaves the tree in a confusing intermediate state where the user's work appears lost. The fix is mechanical: stash before, pop after. This document is the canonical reference; skills should link here rather than copy-pasting the snippet, so the convention can be updated in one place.
+
+---
+
+## Primary Pattern: Stash-First Sync
+
+This is the **only** documented sync path. Every skill that runs `git pull --rebase` MUST follow it.
+
+```bash
+branch="$(git rev-parse --abbrev-ref HEAD)"
+
+# Protect any uncommitted changes (staged + unstaged + untracked).
+# The descriptive message lets the user identify the stash later.
+dirty=0
+if [ -n "$(git status --porcelain)" ]; then
+  git stash push -u -m "pre-sync: ${branch} $(date +%Y-%m-%dT%H:%M:%S)"
+  dirty=1
+fi
+
+# Sync with remote.
+git fetch origin
+git pull --rebase origin "$branch"
+
+# Restore uncommitted changes.
+if [ "$dirty" -eq 1 ]; then
+  git stash pop || {
+    echo "✗ Stash pop failed — your changes are still safe in the stash"
+    echo "  Recovery:"
+    echo "    git stash list                       # find the stash ref (e.g. stash@{0})"
+    echo "    git stash show -p stash@{0}          # preview what's in it"
+    echo "    git checkout stash@{0} -- <path>     # restore individual files"
+    echo "    git stash pop --index stash@{0}      # retry pop after resolving conflicts"
+    exit 1
+  }
+fi
+```
+
+### Behavior Notes
+
+- **`git status --porcelain`** is the canonical dirty-tree check — empty output means clean, any output means dirty (modified, staged, or untracked).
+- **`git stash push -u`** includes untracked files (`-u` = `--include-untracked`). Without `-u`, new files are left exposed and can collide with the rebase.
+- **The stash message** must be descriptive (branch name + timestamp) so the user can identify it via `git stash list`. Generic messages like `"pre-sync"` make recovery harder when multiple stashes accumulate.
+- **`git stash pop`** can fail with merge conflicts. When it does, the stash is preserved on the stash stack — the user's changes are not lost. The recovery output above tells the user exactly how to access them.
+- **Stash ref stability:** newly pushed stashes always become `stash@{0}`. The recovery instructions assume this; if a script creates additional stashes between push and pop, capture the ref returned by `git stash push` instead.
+
+---
+
+## When the Sync Fails
+
+| Failure | Cause | Recovery |
+|---------|-------|----------|
+| `fatal: 'origin' does not appear to be a git repository` | No remote configured | Stop and ask the user to add a remote: `git remote add origin <url>`. In auto mode, abort with a clear error. |
+| `error: Could not apply <commit>` (rebase conflict) | Local commits conflict with incoming | Stop. In interactive mode, ask the user to resolve. In auto mode, run `git rebase --abort` and report. |
+| `error: Your local changes to the following files would be overwritten by merge` | Stash-first was skipped (do not let this reach the user) | Indicates a skill bypassed the convention. Report the skill bug. |
+| `CONFLICT (content): Merge conflict in <file>` (during stash pop) | Rebased commits touch the same lines as the stash | Use the recovery output above. Stash is preserved on the stack. |
+
+---
+
+## Skill-Side Responsibilities
+
+Every IDD skill that performs a sync step MUST:
+
+1. **Use the stash-first block above** — never document a bare `git pull --rebase` as the primary path.
+2. **Link to this document** — write `(see the sync conventions reference)` next to the snippet so users find this reference.
+3. **Document the recovery** — at minimum, instruct on `git stash list` and `git stash show -p stash@{0}` if a pop conflict occurs. Skills are free to inline the full recovery block from this document.
+4. **Honor the mode contract** — in interactive mode, prompt the user before stashing or aborting on conflict. In auto mode (`--auto`), perform the stash-first sync without prompting; abort cleanly with a recovery hint if it fails.
+
+---
+
+## Lint Enforcement
+
+`tests/test-sync-safety.sh` greps `src/skills/**/*.md` and `src/skills/**/references/*.md` for `git pull --rebase` and asserts that each occurrence is preceded (within ~12 lines) by a `git stash` invocation or by a comment that defers to this document. Failing the lint blocks merges. This is the regression guard — without it, future skill edits could silently reintroduce the unsafe form.
+
+---
+
+## Quick Reference (Copy-Paste Snippet)
+
+For skills that want the minimal form inline:
+
+```bash
+# Stash-first sync — see the sync conventions reference for full recovery procedure.
+branch="$(git rev-parse --abbrev-ref HEAD)"
+dirty=0
+if [ -n "$(git status --porcelain)" ]; then
+  git stash push -u -m "pre-sync: ${branch}"
+  dirty=1
+fi
+git fetch origin
+git pull --rebase origin "$branch"
+if [ "$dirty" -eq 1 ]; then
+  git stash pop || {
+    echo "✗ Stash pop failed — recover with: git stash list && git stash show -p stash@{0}"
+    exit 1
+  }
+fi
+```

--- a/dist/skills/issue-resolver/SKILL.md
+++ b/dist/skills/issue-resolver/SKILL.md
@@ -33,24 +33,26 @@ Before any operation, verify the environment. On failure, output the exact error
 
 ## Repo Sync Before Edits (mandatory)
 
-Before making file modifications, sync with remote:
+Before making file modifications, sync with remote using the stash-first pattern (see `references/docs/sync-conventions.md` for the full convention and recovery procedure):
 
 ```bash
 branch="$(git rev-parse --abbrev-ref HEAD)"
+dirty=0
+if [ -n "$(git status --porcelain)" ]; then
+  git stash push -u -m "pre-sync: ${branch}"
+  dirty=1
+fi
 git fetch origin
 git pull --rebase origin "$branch"
+if [ "$dirty" -eq 1 ]; then
+  git stash pop || {
+    echo "✗ Stash pop failed — recover with: git stash list && git stash show -p stash@{0}"
+    exit 1
+  }
+fi
 ```
 
-If the working tree is dirty, stash first, sync, then pop:
-
-```bash
-git stash push -u -m "pre-sync"
-branch="$(git rev-parse --abbrev-ref HEAD)"
-git fetch origin && git pull --rebase origin "$branch"
-git stash pop
-```
-
-If `origin` is missing or conflicts occur, stop and ask the user (in interactive mode) or abort with error (in auto mode).
+If `origin` is missing or rebase conflicts occur, stop and ask the user (interactive) or abort with a clear error (auto).
 
 ## Configuration
 

--- a/dist/skills/issue-resolver/references/docs/sync-conventions.md
+++ b/dist/skills/issue-resolver/references/docs/sync-conventions.md
@@ -1,0 +1,103 @@
+<!-- Generated from src/docs/sync-conventions.md. Do not edit. Edit source and run ./scripts/build.sh. -->
+# Sync Conventions
+
+Standard convention for syncing a working branch with the remote before any IDD skill modifies files. Centralizing this here ensures every skill that performs a `git pull --rebase` first protects uncommitted changes — the unsafe pattern (bare rebase on a dirty tree) can silently destroy staged or unstaged work, so it must never appear in skill instructions.
+
+## Why This Matters
+
+`git pull --rebase` rewrites local history. When the working tree has uncommitted changes that overlap with incoming commits, rebase either fails outright or — worse — leaves the tree in a confusing intermediate state where the user's work appears lost. The fix is mechanical: stash before, pop after. This document is the canonical reference; skills should link here rather than copy-pasting the snippet, so the convention can be updated in one place.
+
+---
+
+## Primary Pattern: Stash-First Sync
+
+This is the **only** documented sync path. Every skill that runs `git pull --rebase` MUST follow it.
+
+```bash
+branch="$(git rev-parse --abbrev-ref HEAD)"
+
+# Protect any uncommitted changes (staged + unstaged + untracked).
+# The descriptive message lets the user identify the stash later.
+dirty=0
+if [ -n "$(git status --porcelain)" ]; then
+  git stash push -u -m "pre-sync: ${branch} $(date +%Y-%m-%dT%H:%M:%S)"
+  dirty=1
+fi
+
+# Sync with remote.
+git fetch origin
+git pull --rebase origin "$branch"
+
+# Restore uncommitted changes.
+if [ "$dirty" -eq 1 ]; then
+  git stash pop || {
+    echo "✗ Stash pop failed — your changes are still safe in the stash"
+    echo "  Recovery:"
+    echo "    git stash list                       # find the stash ref (e.g. stash@{0})"
+    echo "    git stash show -p stash@{0}          # preview what's in it"
+    echo "    git checkout stash@{0} -- <path>     # restore individual files"
+    echo "    git stash pop --index stash@{0}      # retry pop after resolving conflicts"
+    exit 1
+  }
+fi
+```
+
+### Behavior Notes
+
+- **`git status --porcelain`** is the canonical dirty-tree check — empty output means clean, any output means dirty (modified, staged, or untracked).
+- **`git stash push -u`** includes untracked files (`-u` = `--include-untracked`). Without `-u`, new files are left exposed and can collide with the rebase.
+- **The stash message** must be descriptive (branch name + timestamp) so the user can identify it via `git stash list`. Generic messages like `"pre-sync"` make recovery harder when multiple stashes accumulate.
+- **`git stash pop`** can fail with merge conflicts. When it does, the stash is preserved on the stash stack — the user's changes are not lost. The recovery output above tells the user exactly how to access them.
+- **Stash ref stability:** newly pushed stashes always become `stash@{0}`. The recovery instructions assume this; if a script creates additional stashes between push and pop, capture the ref returned by `git stash push` instead.
+
+---
+
+## When the Sync Fails
+
+| Failure | Cause | Recovery |
+|---------|-------|----------|
+| `fatal: 'origin' does not appear to be a git repository` | No remote configured | Stop and ask the user to add a remote: `git remote add origin <url>`. In auto mode, abort with a clear error. |
+| `error: Could not apply <commit>` (rebase conflict) | Local commits conflict with incoming | Stop. In interactive mode, ask the user to resolve. In auto mode, run `git rebase --abort` and report. |
+| `error: Your local changes to the following files would be overwritten by merge` | Stash-first was skipped (do not let this reach the user) | Indicates a skill bypassed the convention. Report the skill bug. |
+| `CONFLICT (content): Merge conflict in <file>` (during stash pop) | Rebased commits touch the same lines as the stash | Use the recovery output above. Stash is preserved on the stack. |
+
+---
+
+## Skill-Side Responsibilities
+
+Every IDD skill that performs a sync step MUST:
+
+1. **Use the stash-first block above** — never document a bare `git pull --rebase` as the primary path.
+2. **Link to this document** — write `(see the sync conventions reference)` next to the snippet so users find this reference.
+3. **Document the recovery** — at minimum, instruct on `git stash list` and `git stash show -p stash@{0}` if a pop conflict occurs. Skills are free to inline the full recovery block from this document.
+4. **Honor the mode contract** — in interactive mode, prompt the user before stashing or aborting on conflict. In auto mode (`--auto`), perform the stash-first sync without prompting; abort cleanly with a recovery hint if it fails.
+
+---
+
+## Lint Enforcement
+
+`tests/test-sync-safety.sh` greps `src/skills/**/*.md` and `src/skills/**/references/*.md` for `git pull --rebase` and asserts that each occurrence is preceded (within ~12 lines) by a `git stash` invocation or by a comment that defers to this document. Failing the lint blocks merges. This is the regression guard — without it, future skill edits could silently reintroduce the unsafe form.
+
+---
+
+## Quick Reference (Copy-Paste Snippet)
+
+For skills that want the minimal form inline:
+
+```bash
+# Stash-first sync — see the sync conventions reference for full recovery procedure.
+branch="$(git rev-parse --abbrev-ref HEAD)"
+dirty=0
+if [ -n "$(git status --porcelain)" ]; then
+  git stash push -u -m "pre-sync: ${branch}"
+  dirty=1
+fi
+git fetch origin
+git pull --rebase origin "$branch"
+if [ "$dirty" -eq 1 ]; then
+  git stash pop || {
+    echo "✗ Stash pop failed — recover with: git stash list && git stash show -p stash@{0}"
+    exit 1
+  }
+fi
+```

--- a/dist/skills/issue-triage/SKILL.md
+++ b/dist/skills/issue-triage/SKILL.md
@@ -133,15 +133,26 @@ Before analyzing issues, recommend syncing with the remote so dependency analysi
   Sync now? [Y/n]
 ```
 
-If the user agrees, run:
+If the user agrees, run the stash-first sync (see `references/docs/sync-conventions.md`):
 
 ```bash
 branch="$(git rev-parse --abbrev-ref HEAD)"
+dirty=0
+if [ -n "$(git status --porcelain)" ]; then
+  git stash push -u -m "pre-sync: ${branch}"
+  dirty=1
+fi
 git fetch origin
 git pull --rebase origin "$branch"
+if [ "$dirty" -eq 1 ]; then
+  git stash pop || {
+    echo "✗ Stash pop failed — recover with: git stash list && git stash show -p stash@{0}"
+    exit 1
+  }
+fi
 ```
 
-If the working tree is dirty, stash first, sync, then pop. If `origin` is missing or conflicts occur, inform the user and continue without syncing. If the user declines, proceed without syncing.
+If `origin` is missing or rebase conflicts occur, inform the user and continue without syncing. If the user declines the prompt, proceed without syncing.
 
 ## Configuration
 

--- a/dist/skills/issue-triage/references/docs/sync-conventions.md
+++ b/dist/skills/issue-triage/references/docs/sync-conventions.md
@@ -1,0 +1,103 @@
+<!-- Generated from src/docs/sync-conventions.md. Do not edit. Edit source and run ./scripts/build.sh. -->
+# Sync Conventions
+
+Standard convention for syncing a working branch with the remote before any IDD skill modifies files. Centralizing this here ensures every skill that performs a `git pull --rebase` first protects uncommitted changes — the unsafe pattern (bare rebase on a dirty tree) can silently destroy staged or unstaged work, so it must never appear in skill instructions.
+
+## Why This Matters
+
+`git pull --rebase` rewrites local history. When the working tree has uncommitted changes that overlap with incoming commits, rebase either fails outright or — worse — leaves the tree in a confusing intermediate state where the user's work appears lost. The fix is mechanical: stash before, pop after. This document is the canonical reference; skills should link here rather than copy-pasting the snippet, so the convention can be updated in one place.
+
+---
+
+## Primary Pattern: Stash-First Sync
+
+This is the **only** documented sync path. Every skill that runs `git pull --rebase` MUST follow it.
+
+```bash
+branch="$(git rev-parse --abbrev-ref HEAD)"
+
+# Protect any uncommitted changes (staged + unstaged + untracked).
+# The descriptive message lets the user identify the stash later.
+dirty=0
+if [ -n "$(git status --porcelain)" ]; then
+  git stash push -u -m "pre-sync: ${branch} $(date +%Y-%m-%dT%H:%M:%S)"
+  dirty=1
+fi
+
+# Sync with remote.
+git fetch origin
+git pull --rebase origin "$branch"
+
+# Restore uncommitted changes.
+if [ "$dirty" -eq 1 ]; then
+  git stash pop || {
+    echo "✗ Stash pop failed — your changes are still safe in the stash"
+    echo "  Recovery:"
+    echo "    git stash list                       # find the stash ref (e.g. stash@{0})"
+    echo "    git stash show -p stash@{0}          # preview what's in it"
+    echo "    git checkout stash@{0} -- <path>     # restore individual files"
+    echo "    git stash pop --index stash@{0}      # retry pop after resolving conflicts"
+    exit 1
+  }
+fi
+```
+
+### Behavior Notes
+
+- **`git status --porcelain`** is the canonical dirty-tree check — empty output means clean, any output means dirty (modified, staged, or untracked).
+- **`git stash push -u`** includes untracked files (`-u` = `--include-untracked`). Without `-u`, new files are left exposed and can collide with the rebase.
+- **The stash message** must be descriptive (branch name + timestamp) so the user can identify it via `git stash list`. Generic messages like `"pre-sync"` make recovery harder when multiple stashes accumulate.
+- **`git stash pop`** can fail with merge conflicts. When it does, the stash is preserved on the stash stack — the user's changes are not lost. The recovery output above tells the user exactly how to access them.
+- **Stash ref stability:** newly pushed stashes always become `stash@{0}`. The recovery instructions assume this; if a script creates additional stashes between push and pop, capture the ref returned by `git stash push` instead.
+
+---
+
+## When the Sync Fails
+
+| Failure | Cause | Recovery |
+|---------|-------|----------|
+| `fatal: 'origin' does not appear to be a git repository` | No remote configured | Stop and ask the user to add a remote: `git remote add origin <url>`. In auto mode, abort with a clear error. |
+| `error: Could not apply <commit>` (rebase conflict) | Local commits conflict with incoming | Stop. In interactive mode, ask the user to resolve. In auto mode, run `git rebase --abort` and report. |
+| `error: Your local changes to the following files would be overwritten by merge` | Stash-first was skipped (do not let this reach the user) | Indicates a skill bypassed the convention. Report the skill bug. |
+| `CONFLICT (content): Merge conflict in <file>` (during stash pop) | Rebased commits touch the same lines as the stash | Use the recovery output above. Stash is preserved on the stack. |
+
+---
+
+## Skill-Side Responsibilities
+
+Every IDD skill that performs a sync step MUST:
+
+1. **Use the stash-first block above** — never document a bare `git pull --rebase` as the primary path.
+2. **Link to this document** — write `(see the sync conventions reference)` next to the snippet so users find this reference.
+3. **Document the recovery** — at minimum, instruct on `git stash list` and `git stash show -p stash@{0}` if a pop conflict occurs. Skills are free to inline the full recovery block from this document.
+4. **Honor the mode contract** — in interactive mode, prompt the user before stashing or aborting on conflict. In auto mode (`--auto`), perform the stash-first sync without prompting; abort cleanly with a recovery hint if it fails.
+
+---
+
+## Lint Enforcement
+
+`tests/test-sync-safety.sh` greps `src/skills/**/*.md` and `src/skills/**/references/*.md` for `git pull --rebase` and asserts that each occurrence is preceded (within ~12 lines) by a `git stash` invocation or by a comment that defers to this document. Failing the lint blocks merges. This is the regression guard — without it, future skill edits could silently reintroduce the unsafe form.
+
+---
+
+## Quick Reference (Copy-Paste Snippet)
+
+For skills that want the minimal form inline:
+
+```bash
+# Stash-first sync — see the sync conventions reference for full recovery procedure.
+branch="$(git rev-parse --abbrev-ref HEAD)"
+dirty=0
+if [ -n "$(git status --porcelain)" ]; then
+  git stash push -u -m "pre-sync: ${branch}"
+  dirty=1
+fi
+git fetch origin
+git pull --rebase origin "$branch"
+if [ "$dirty" -eq 1 ]; then
+  git stash pop || {
+    echo "✗ Stash pop failed — recover with: git stash list && git stash show -p stash@{0}"
+    exit 1
+  }
+fi
+```

--- a/src/deprecated-skills/issue-pr-review-fix-loop/SKILL.md
+++ b/src/deprecated-skills/issue-pr-review-fix-loop/SKILL.md
@@ -72,15 +72,26 @@ The `--auto` flag is set automatically when invoked by `/auto-pilot`.
 
 ## Repo Sync Before Edits (mandatory)
 
-Before making any fixes:
+Before making any fixes, sync with remote using the stash-first pattern (see `src/docs/sync-conventions.md` in the project root for the full convention and recovery procedure):
 
 ```bash
 branch="$(git rev-parse --abbrev-ref HEAD)"
+dirty=0
+if [ -n "$(git status --porcelain)" ]; then
+  git stash push -u -m "pre-sync: ${branch}"
+  dirty=1
+fi
 git fetch origin
 git pull --rebase origin "$branch"
+if [ "$dirty" -eq 1 ]; then
+  git stash pop || {
+    echo "✗ Stash pop failed — recover with: git stash list && git stash show -p stash@{0}"
+    exit 1
+  }
+fi
 ```
 
-If dirty: stash, sync, pop. If `origin` missing or conflicts: stop and ask (interactive) or abort (auto).
+If `origin` is missing or rebase conflicts occur, stop and ask (interactive) or abort with a clear error (auto).
 
 ## Configuration
 
@@ -273,9 +284,17 @@ Issues to fix (only issues with action "fix" — skip "note" issues):
 {formatted_issues_json}
 
 Instructions:
-1. Sync with remote first:
+1. Sync with remote first using the stash-first pattern (see src/docs/sync-conventions.md):
+   dirty=0
+   if [ -n "$(git status --porcelain)" ]; then
+     git stash push -u -m "pre-sync: {head_branch}"
+     dirty=1
+   fi
    git fetch origin
    git pull --rebase origin {head_branch}
+   if [ "$dirty" -eq 1 ]; then
+     git stash pop || { echo "✗ Stash pop failed — git stash list && git stash show -p stash@{0}"; exit 1; }
+   fi
 2. For each issue where action is "fix":
    a. Read the affected file
    b. Apply the fix described in "suggested_fix"

--- a/src/docs/sync-conventions.md
+++ b/src/docs/sync-conventions.md
@@ -1,0 +1,102 @@
+# Sync Conventions
+
+Standard convention for syncing a working branch with the remote before any IDD skill modifies files. Centralizing this here ensures every skill that performs a `git pull --rebase` first protects uncommitted changes — the unsafe pattern (bare rebase on a dirty tree) can silently destroy staged or unstaged work, so it must never appear in skill instructions.
+
+## Why This Matters
+
+`git pull --rebase` rewrites local history. When the working tree has uncommitted changes that overlap with incoming commits, rebase either fails outright or — worse — leaves the tree in a confusing intermediate state where the user's work appears lost. The fix is mechanical: stash before, pop after. This document is the canonical reference; skills should link here rather than copy-pasting the snippet, so the convention can be updated in one place.
+
+---
+
+## Primary Pattern: Stash-First Sync
+
+This is the **only** documented sync path. Every skill that runs `git pull --rebase` MUST follow it.
+
+```bash
+branch="$(git rev-parse --abbrev-ref HEAD)"
+
+# Protect any uncommitted changes (staged + unstaged + untracked).
+# The descriptive message lets the user identify the stash later.
+dirty=0
+if [ -n "$(git status --porcelain)" ]; then
+  git stash push -u -m "pre-sync: ${branch} $(date +%Y-%m-%dT%H:%M:%S)"
+  dirty=1
+fi
+
+# Sync with remote.
+git fetch origin
+git pull --rebase origin "$branch"
+
+# Restore uncommitted changes.
+if [ "$dirty" -eq 1 ]; then
+  git stash pop || {
+    echo "✗ Stash pop failed — your changes are still safe in the stash"
+    echo "  Recovery:"
+    echo "    git stash list                       # find the stash ref (e.g. stash@{0})"
+    echo "    git stash show -p stash@{0}          # preview what's in it"
+    echo "    git checkout stash@{0} -- <path>     # restore individual files"
+    echo "    git stash pop --index stash@{0}      # retry pop after resolving conflicts"
+    exit 1
+  }
+fi
+```
+
+### Behavior Notes
+
+- **`git status --porcelain`** is the canonical dirty-tree check — empty output means clean, any output means dirty (modified, staged, or untracked).
+- **`git stash push -u`** includes untracked files (`-u` = `--include-untracked`). Without `-u`, new files are left exposed and can collide with the rebase.
+- **The stash message** must be descriptive (branch name + timestamp) so the user can identify it via `git stash list`. Generic messages like `"pre-sync"` make recovery harder when multiple stashes accumulate.
+- **`git stash pop`** can fail with merge conflicts. When it does, the stash is preserved on the stash stack — the user's changes are not lost. The recovery output above tells the user exactly how to access them.
+- **Stash ref stability:** newly pushed stashes always become `stash@{0}`. The recovery instructions assume this; if a script creates additional stashes between push and pop, capture the ref returned by `git stash push` instead.
+
+---
+
+## When the Sync Fails
+
+| Failure | Cause | Recovery |
+|---------|-------|----------|
+| `fatal: 'origin' does not appear to be a git repository` | No remote configured | Stop and ask the user to add a remote: `git remote add origin <url>`. In auto mode, abort with a clear error. |
+| `error: Could not apply <commit>` (rebase conflict) | Local commits conflict with incoming | Stop. In interactive mode, ask the user to resolve. In auto mode, run `git rebase --abort` and report. |
+| `error: Your local changes to the following files would be overwritten by merge` | Stash-first was skipped (do not let this reach the user) | Indicates a skill bypassed the convention. Report the skill bug. |
+| `CONFLICT (content): Merge conflict in <file>` (during stash pop) | Rebased commits touch the same lines as the stash | Use the recovery output above. Stash is preserved on the stack. |
+
+---
+
+## Skill-Side Responsibilities
+
+Every IDD skill that performs a sync step MUST:
+
+1. **Use the stash-first block above** — never document a bare `git pull --rebase` as the primary path.
+2. **Link to this document** — write `(see the sync conventions reference)` next to the snippet so users find this reference.
+3. **Document the recovery** — at minimum, instruct on `git stash list` and `git stash show -p stash@{0}` if a pop conflict occurs. Skills are free to inline the full recovery block from this document.
+4. **Honor the mode contract** — in interactive mode, prompt the user before stashing or aborting on conflict. In auto mode (`--auto`), perform the stash-first sync without prompting; abort cleanly with a recovery hint if it fails.
+
+---
+
+## Lint Enforcement
+
+`tests/test-sync-safety.sh` greps `src/skills/**/*.md` and `src/skills/**/references/*.md` for `git pull --rebase` and asserts that each occurrence is preceded (within ~12 lines) by a `git stash` invocation or by a comment that defers to this document. Failing the lint blocks merges. This is the regression guard — without it, future skill edits could silently reintroduce the unsafe form.
+
+---
+
+## Quick Reference (Copy-Paste Snippet)
+
+For skills that want the minimal form inline:
+
+```bash
+# Stash-first sync — see the sync conventions reference for full recovery procedure.
+branch="$(git rev-parse --abbrev-ref HEAD)"
+dirty=0
+if [ -n "$(git status --porcelain)" ]; then
+  git stash push -u -m "pre-sync: ${branch}"
+  dirty=1
+fi
+git fetch origin
+git pull --rebase origin "$branch"
+if [ "$dirty" -eq 1 ]; then
+  git stash pop || {
+    echo "✗ Stash pop failed — recover with: git stash list && git stash show -p stash@{0}"
+    exit 1
+  }
+fi
+```

--- a/src/skills/auto-pilot/SKILL.md
+++ b/src/skills/auto-pilot/SKILL.md
@@ -89,9 +89,29 @@ git stash --include-untracked -m "auto-pilot: stash before run"
   Stash ref: {stash_ref}
 ```
 
-If not on the default branch (main/master), auto-switch:
+If not on the default branch (main/master), auto-switch and sync. The stash above already protects any uncommitted work, so the rebase here runs on a clean tree (see `docs/sync-conventions.md` for the full sync convention and recovery procedure):
+
 ```bash
-git checkout {default_branch} && git pull --rebase origin {default_branch}
+git checkout {default_branch}
+# Defensive stash — the pre-flight stash above should have caught this,
+# but the convention is to stash-first whenever a rebase follows.
+dirty=0
+if [ -n "$(git status --porcelain)" ]; then
+  git stash push -u -m "pre-sync: {default_branch}"
+  dirty=1
+fi
+git fetch origin
+git pull --rebase origin {default_branch} || {
+  echo "✗ Rebase failed — aborting and resetting to remote"
+  git rebase --abort 2>/dev/null
+  exit 1
+}
+if [ "$dirty" -eq 1 ]; then
+  git stash pop || {
+    echo "✗ Stash pop failed — recover with: git stash list && git stash show -p stash@{0}"
+    exit 1
+  }
+fi
 ```
 ```
 ⚠ Was on branch {branch} — auto-switched to {default_branch}

--- a/src/skills/auto-pilot/references/phases.md
+++ b/src/skills/auto-pilot/references/phases.md
@@ -95,14 +95,26 @@ Stop.
 
 ### Step 2.1 — Sync to Default Branch
 
-The main agent syncs to the default branch directly (this is lightweight — no code reading):
+The main agent syncs to the default branch directly (this is lightweight — no code reading). Use the stash-first pattern to protect any uncommitted work that may have appeared since the pre-flight stash (see `docs/sync-conventions.md`):
 
 ```bash
 git checkout {default_branch}
+dirty=0
+if [ -n "$(git status --porcelain)" ]; then
+  git stash push -u -m "pre-sync: {default_branch}"
+  dirty=1
+fi
+git fetch origin
 git pull --rebase origin {default_branch}
+if [ "$dirty" -eq 1 ]; then
+  git stash pop || {
+    echo "✗ Stash pop failed — recover with: git stash list && git stash show -p stash@{0}"
+    exit 1
+  }
+fi
 ```
 
-If this fails (merge conflict from a prior iteration), attempt auto-resolution:
+If the rebase itself fails (merge conflict from a prior iteration), attempt auto-resolution:
 
 ```bash
 git rebase --abort
@@ -436,9 +448,23 @@ Record the iteration outcome (`merged` or `left_open`) for the final summary.
 
 ### Step 5.3 — Cleanup
 
+Use the stash-first sync to protect any uncommitted changes that may have accumulated between iterations (see `docs/sync-conventions.md`):
+
 ```bash
 git checkout {default_branch}
+dirty=0
+if [ -n "$(git status --porcelain)" ]; then
+  git stash push -u -m "pre-cleanup: {default_branch}"
+  dirty=1
+fi
+git fetch origin
 git pull --rebase origin {default_branch}
+if [ "$dirty" -eq 1 ]; then
+  git stash pop || {
+    echo "✗ Stash pop failed — recover with: git stash list && git stash show -p stash@{0}"
+    exit 1
+  }
+fi
 git branch -d {branch_name} 2>/dev/null
 ```
 

--- a/src/skills/issue-analysis/SKILL.md
+++ b/src/skills/issue-analysis/SKILL.md
@@ -78,17 +78,26 @@ Before analyzing, recommend syncing with the remote so codebase analysis uses cu
   Sync now? [Y/n]
 ```
 
-If the user agrees, run:
+If the user agrees, run the stash-first sync (see `docs/sync-conventions.md`):
 
 ```bash
 branch="$(git rev-parse --abbrev-ref HEAD)"
+dirty=0
+if [ -n "$(git status --porcelain)" ]; then
+  git stash push -u -m "pre-sync: ${branch}"
+  dirty=1
+fi
 git fetch origin
 git pull --rebase origin "$branch"
+if [ "$dirty" -eq 1 ]; then
+  git stash pop || {
+    echo "✗ Stash pop failed — recover with: git stash list && git stash show -p stash@{0}"
+    exit 1
+  }
+fi
 ```
 
-If the working tree is dirty, stash first (`git stash`), sync, then pop (`git stash pop`). If `origin` is missing or conflicts occur, inform the user and continue without syncing.
-
-If the user declines, proceed without syncing.
+If `origin` is missing or rebase conflicts occur, inform the user and continue without syncing. If the user declines the prompt, proceed without syncing.
 
 ## Configuration
 

--- a/src/skills/issue-pr-review/SKILL.md
+++ b/src/skills/issue-pr-review/SKILL.md
@@ -31,15 +31,26 @@ The `--auto` flag is set automatically when invoked by `/auto-pilot`.
 
 ## Repo Sync Before Edits (mandatory)
 
-Before making any fixes:
+Before making any fixes, sync with remote using the stash-first pattern (see `docs/sync-conventions.md` for the full convention and recovery procedure):
 
 ```bash
 branch="$(git rev-parse --abbrev-ref HEAD)"
+dirty=0
+if [ -n "$(git status --porcelain)" ]; then
+  git stash push -u -m "pre-sync: ${branch}"
+  dirty=1
+fi
 git fetch origin
 git pull --rebase origin "$branch"
+if [ "$dirty" -eq 1 ]; then
+  git stash pop || {
+    echo "✗ Stash pop failed — recover with: git stash list && git stash show -p stash@{0}"
+    exit 1
+  }
+fi
 ```
 
-If dirty: stash, sync, pop. If `origin` missing or conflicts: stop and ask (interactive) or abort (auto).
+If `origin` is missing or rebase conflicts occur, stop and ask (interactive) or abort with a clear error (auto).
 
 ## Configuration
 

--- a/src/skills/issue-resolver/SKILL.md
+++ b/src/skills/issue-resolver/SKILL.md
@@ -33,24 +33,26 @@ Before any operation, verify the environment. On failure, output the exact error
 
 ## Repo Sync Before Edits (mandatory)
 
-Before making file modifications, sync with remote:
+Before making file modifications, sync with remote using the stash-first pattern (see `docs/sync-conventions.md` for the full convention and recovery procedure):
 
 ```bash
 branch="$(git rev-parse --abbrev-ref HEAD)"
+dirty=0
+if [ -n "$(git status --porcelain)" ]; then
+  git stash push -u -m "pre-sync: ${branch}"
+  dirty=1
+fi
 git fetch origin
 git pull --rebase origin "$branch"
+if [ "$dirty" -eq 1 ]; then
+  git stash pop || {
+    echo "✗ Stash pop failed — recover with: git stash list && git stash show -p stash@{0}"
+    exit 1
+  }
+fi
 ```
 
-If the working tree is dirty, stash first, sync, then pop:
-
-```bash
-git stash push -u -m "pre-sync"
-branch="$(git rev-parse --abbrev-ref HEAD)"
-git fetch origin && git pull --rebase origin "$branch"
-git stash pop
-```
-
-If `origin` is missing or conflicts occur, stop and ask the user (in interactive mode) or abort with error (in auto mode).
+If `origin` is missing or rebase conflicts occur, stop and ask the user (interactive) or abort with a clear error (auto).
 
 ## Configuration
 

--- a/src/skills/issue-triage/SKILL.md
+++ b/src/skills/issue-triage/SKILL.md
@@ -133,15 +133,26 @@ Before analyzing issues, recommend syncing with the remote so dependency analysi
   Sync now? [Y/n]
 ```
 
-If the user agrees, run:
+If the user agrees, run the stash-first sync (see `docs/sync-conventions.md`):
 
 ```bash
 branch="$(git rev-parse --abbrev-ref HEAD)"
+dirty=0
+if [ -n "$(git status --porcelain)" ]; then
+  git stash push -u -m "pre-sync: ${branch}"
+  dirty=1
+fi
 git fetch origin
 git pull --rebase origin "$branch"
+if [ "$dirty" -eq 1 ]; then
+  git stash pop || {
+    echo "✗ Stash pop failed — recover with: git stash list && git stash show -p stash@{0}"
+    exit 1
+  }
+fi
 ```
 
-If the working tree is dirty, stash first, sync, then pop. If `origin` is missing or conflicts occur, inform the user and continue without syncing. If the user declines, proceed without syncing.
+If `origin` is missing or rebase conflicts occur, inform the user and continue without syncing. If the user declines the prompt, proceed without syncing.
 
 ## Configuration
 

--- a/tests/test-issue-pr-review-fix-loop-deprecation.sh
+++ b/tests/test-issue-pr-review-fix-loop-deprecation.sh
@@ -289,6 +289,7 @@ while IFS= read -r match; do
     "$ROOT_README") continue ;;
     "$ROOT_CLAUDE") continue ;;
     "$REPO_ROOT/tests/test-issue-pr-review-fix-loop-deprecation.sh") continue ;;
+    "$REPO_ROOT/tests/test-sync-safety.sh") continue ;;
     "$REPO_ROOT/improvement-plan"*".md") continue ;;
     "$REPO_ROOT/docs/"*) continue ;;
   esac

--- a/tests/test-sync-safety.sh
+++ b/tests/test-sync-safety.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# test-sync-safety.sh — Validate the stash-first sync convention (issue #22)
+#
+# This script verifies issue #22 acceptance criteria:
+#   AC #1: All skills that run `git pull --rebase` check for dirty working tree first.
+#   AC #2: Dirty working tree is handled by stash-before/pop-after as the
+#          PRIMARY documented code path.
+#   AC #3: On stash pop conflicts, output clear recovery instructions with the stash ref.
+#   AC #4: Consistent approach across all affected skills:
+#          issue-pr-review, issue-pr-review-fix-loop, issue-resolver, auto-pilot,
+#          plus issue-triage and issue-analysis (same anti-pattern).
+#
+# Strategy: walk every fenced code block (```bash / ```sh / ```) in src/skills/**/*.md
+# and src/skills/**/references/*.md and src/deprecated-skills/**/*.md, looking for
+# `git pull --rebase`. For each occurrence, the same fenced block must contain a
+# preceding `git stash` invocation. Inline prose mentions inside single backticks
+# are ignored — only fenced code blocks count, since those are what the skill
+# actually instructs the agent to execute.
+#
+# Usage: bash tests/test-sync-safety.sh
+# Returns: exit 0 if all checks pass, exit 1 on failure
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+PASS=0
+FAIL=0
+
+pass() {
+  echo "  ✓ $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "  ✗ $1"
+  FAIL=$((FAIL + 1))
+}
+
+echo "◆ Sync Safety Lint (issue #22)"
+echo "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄"
+
+# ───────────────────────────────────────────────────────────
+# T1: docs/sync-conventions.md exists
+# ───────────────────────────────────────────────────────────
+if [ -f "$REPO_ROOT/src/docs/sync-conventions.md" ]; then
+  pass "src/docs/sync-conventions.md exists (canonical convention)"
+else
+  fail "src/docs/sync-conventions.md missing"
+fi
+
+# ───────────────────────────────────────────────────────────
+# T2: Every fenced `git pull --rebase` is preceded by a `git stash`
+#     in the SAME fenced block.
+# ───────────────────────────────────────────────────────────
+#
+# Implementation: use awk to track fenced code-block state and report any
+# `git pull --rebase` line whose enclosing block does not also contain
+# `git stash`. Inline-code (single backticks) and prose are ignored.
+
+# Files in scope: skills + deprecated-skills + auto-pilot/issue-resolver
+# references. Exclude the convention doc itself (it documents the pattern).
+SCAN_DIRS=(
+  "$REPO_ROOT/src/skills"
+  "$REPO_ROOT/src/deprecated-skills"
+)
+
+# Use a temp file to collect violations across files.
+violations="$(mktemp)"
+trap 'rm -f "$violations"' EXIT
+
+scan_file() {
+  local file="$1"
+  awk '
+    BEGIN {
+      in_block = 0
+      block_start = 0
+      block_lines = ""
+      block_has_rebase = 0
+      block_has_stash = 0
+    }
+    /^```/ {
+      if (in_block == 0) {
+        in_block = 1
+        block_start = NR
+        block_lines = ""
+        block_has_rebase = 0
+        block_has_stash = 0
+      } else {
+        # Closing fence — evaluate the block.
+        if (block_has_rebase == 1 && block_has_stash == 0) {
+          printf("%s:%d: fenced block with `git pull --rebase` lacks `git stash`\n", FILENAME, block_start)
+        }
+        in_block = 0
+      }
+      next
+    }
+    {
+      if (in_block == 1) {
+        if ($0 ~ /git pull --rebase/) {
+          block_has_rebase = 1
+        }
+        if ($0 ~ /git stash/) {
+          block_has_stash = 1
+        }
+      }
+    }
+  ' "$file"
+}
+
+for dir in "${SCAN_DIRS[@]}"; do
+  if [ ! -d "$dir" ]; then
+    continue
+  fi
+  while IFS= read -r -d '' file; do
+    scan_file "$file" >> "$violations"
+  done < <(find "$dir" -type f -name "*.md" -print0)
+done
+
+if [ -s "$violations" ]; then
+  fail "Unguarded \`git pull --rebase\` found in fenced code blocks:"
+  while IFS= read -r line; do
+    echo "      $line"
+  done < "$violations"
+else
+  pass "All fenced \`git pull --rebase\` blocks include a preceding \`git stash\`"
+fi
+
+# ───────────────────────────────────────────────────────────
+# T3: All four skills named in issue #22 reference sync-conventions.md.
+# ───────────────────────────────────────────────────────────
+
+NAMED_FILES=(
+  "src/skills/issue-pr-review/SKILL.md"
+  "src/skills/issue-resolver/SKILL.md"
+  "src/skills/auto-pilot/SKILL.md"
+  "src/deprecated-skills/issue-pr-review-fix-loop/SKILL.md"
+)
+
+for rel in "${NAMED_FILES[@]}"; do
+  abs="$REPO_ROOT/$rel"
+  if [ ! -f "$abs" ]; then
+    fail "$rel missing"
+    continue
+  fi
+  if grep -q "sync-conventions.md" "$abs"; then
+    pass "$rel references sync-conventions.md"
+  else
+    fail "$rel does not reference sync-conventions.md"
+  fi
+done
+
+# ───────────────────────────────────────────────────────────
+# T4: The convention doc documents stash-pop conflict recovery
+#     with the stash ref (AC #3).
+# ───────────────────────────────────────────────────────────
+
+CONV="$REPO_ROOT/src/docs/sync-conventions.md"
+if [ -f "$CONV" ]; then
+  if grep -q "stash@{0}" "$CONV"; then
+    pass "sync-conventions.md documents stash-pop recovery with stash ref"
+  else
+    fail "sync-conventions.md missing explicit stash ref recovery (e.g. stash@{0})"
+  fi
+  if grep -q "git stash list" "$CONV"; then
+    pass "sync-conventions.md documents \`git stash list\` recovery command"
+  else
+    fail "sync-conventions.md missing \`git stash list\` recovery command"
+  fi
+fi
+
+# ───────────────────────────────────────────────────────────
+# Summary
+# ───────────────────────────────────────────────────────────
+echo "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄"
+echo "  Results: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+  echo "  ✗ Sync safety lint failed"
+  exit 1
+fi
+
+echo "  ✓ All sync safety checks passed"
+exit 0


### PR DESCRIPTION
Closes #22

## Summary

Multiple skills documented `git pull --rebase origin "$branch"` as the primary sync step without first stashing uncommitted changes — risking destruction of staged or unstaged work whenever a user invoked a sync on a dirty tree. This PR introduces `src/docs/sync-conventions.md` as the single source of truth for the stash-first sync pattern, replaces every bare-rebase site with the safe pattern, adds a documentation lint test to prevent regression, and regenerates the `dist/` mirror.

## Approach

- **New canonical reference** (`src/docs/sync-conventions.md`): documents the stash-first sync block, stash-pop conflict recovery with the explicit stash ref (`stash@{0}` / `git stash list` / `git stash show -p`), failure-mode table, and skill-side responsibilities. Mirrors the structure of the existing `naming-conventions.md` so skills cross-link the same way.
- **All 8 verified sync sites updated** to use the stash-first pattern as the primary documented path. The unsafe bare-rebase block in `issue-resolver/SKILL.md` was removed entirely (not demoted) so no example of the unsafe pattern remains in `src/skills/`.
- **Lint test** (`tests/test-sync-safety.sh`): walks every fenced code block in `src/skills/**/*.md` and `src/deprecated-skills/**/*.md`, asserting that any block containing `git pull --rebase` also contains a `git stash` invocation in the same block. Inline-code prose mentions are correctly ignored. Also verifies the four named skills cross-link to `sync-conventions.md` and that the convention doc documents recovery with the stash ref.
- **`dist/` regenerated** via `./scripts/build.sh`. The `dist-check` workflow's `git diff --exit-code dist/skills/` assertion passes.
- **Existing deprecation test** (`test-issue-pr-review-fix-loop-deprecation.sh`) updated to exclude the new sync-safety test from its workflow-reference scan — same exclusion pattern already applied to CHANGELOG and the deprecation test itself (documentation references are not workflow dependencies).

## Decision Record

- **Why a shared doc instead of inlining everywhere?** The convention has subtle parts (descriptive stash message, `-u` flag for untracked files, stash-pop recovery with the ref) that future skills will need. Centralizing prevents drift; the small footprint of an inline snippet plus a `(see docs/sync-conventions.md)` link gives skills both quick-read context and a deeper reference.
- **Why fix `issue-triage`, `issue-analysis`, and the `phases.md` sites the issue didn't name?** AC #4 says "consistent approach across all affected skills." Research found three additional sites with the same anti-pattern (research found 8 total sites, issue named ~5). Fixing only the named ones would leave the bug class alive in adjacent skills and force a follow-up PR. Cost of inclusion is low (each site is ~10 lines).
- **Why fix the deprecated `issue-pr-review-fix-loop` skill?** It is still in-tree during its retention cycle, and AC #4 names it explicitly. Edits stay consistent with the live skill it redirects to.
- **Why a lint test instead of just docs?** Without a regression guard, future skill edits can silently reintroduce the unsafe form. The lint is fast (no GitHub access, walks 8 markdown files), runs locally, and would catch this exact regression.
- **Why the `dist-check` exclusion update?** The existing deprecation test scans `tests/` for any string mention of `issue-pr-review-fix-loop`. The new sync-safety test legitimately mentions the path (it's one of the four files the issue names). Same exclusion pattern as CHANGELOG/README/deprecation-test-itself.

## Changes

| File | Change |
|------|--------|
| `src/docs/sync-conventions.md` | New canonical reference (102 lines) |
| `src/skills/issue-pr-review/SKILL.md` | Replace bare rebase with stash-first block |
| `src/skills/issue-resolver/SKILL.md` | Remove UNSAFE primary block; stash-first becomes the only documented path |
| `src/skills/auto-pilot/SKILL.md` | Default-branch auto-switch uses stash-first (defense in depth alongside pre-flight stash) |
| `src/skills/auto-pilot/references/phases.md` | Phase 2.1 Sync + Step 5.3 Cleanup updated |
| `src/skills/issue-triage/SKILL.md` | Replace prose-only "If dirty…" with code block |
| `src/skills/issue-analysis/SKILL.md` | Replace prose-only "If dirty…" with code block |
| `src/deprecated-skills/issue-pr-review-fix-loop/SKILL.md` | Repo Sync section + fixer-subagent prompt updated |
| `dist/skills/{auto-pilot,issue-pr-review,issue-resolver,issue-analysis,issue-triage}/**` | Regenerated mirror |
| `tests/test-sync-safety.sh` | New lint test (8 checks) |
| `tests/test-issue-pr-review-fix-loop-deprecation.sh` | Add `test-sync-safety.sh` to workflow-reference scan exclusions |

## Test Results

All 19 test scripts pass:

```
✓ test-autopilot-modes              ✓ test-issue-pr-review-fix-loop-deprecation
✓ test-autopilot-portability        ✓ test-issue-pr-review-traceability
✓ test-build-determinism            ✓ test-plugin-json-input
✓ test-build-script                 ✓ test-plugin-layout
✓ test-config-schema-38             ✓ test-plugin-reference-rendering
✓ test-dependency-closure           ✓ test-plugin-tarball-layout
✓ test-flattened-coexistence        ✓ test-projects-sync
✓ test-flattened-self-contained     ✓ test-sync-safety
✓ test-idd-doctor                   ✓ test-init-template-doc-urls-dist
✓ test-init-template-doc-urls-source
```

The new `test-sync-safety.sh` reports 8/8 checks pass and was verified to fail when an unguarded rebase block is reintroduced.

## Acceptance Criteria Verification

| AC | Status | Evidence |
|----|--------|----------|
| #1 — All skills check for dirty working tree first | ✅ pass | All 8 fenced rebase blocks include `git status --porcelain` before `git pull --rebase`; enforced by `test-sync-safety.sh` |
| #2 — Stash-before/pop-after is the PRIMARY documented code path | ✅ pass | No bare-rebase block exists as primary; UNSAFE block removed from `issue-resolver/SKILL.md`; `sync-conventions.md` declares stash-first the "only" path |
| #3 — Stash-pop conflicts output recovery with the stash ref | ✅ pass | All 8 sites emit `git stash list && git stash show -p stash@{0}` on pop failure; `sync-conventions.md` has full recovery table |
| #4 — Consistent approach across all affected skills | ✅ pass | All 4 named skills (`issue-pr-review`, `issue-pr-review-fix-loop`, `issue-resolver`, `auto-pilot`) covered, plus `issue-triage`, `issue-analysis`, and both `auto-pilot/references/phases.md` sites |

## Test plan

- [x] `bash tests/test-sync-safety.sh` — 8 checks pass
- [x] `bash tests/test-issue-pr-review-fix-loop-deprecation.sh` — 30 checks pass with new exclusion
- [x] `./scripts/build.sh` followed by `git diff --exit-code dist/` — clean (deterministic build)
- [x] Full `tests/test-*.sh` matrix — 19/19 pass
- [x] Manually verified each updated SKILL.md renders the stash-first block as the primary path
- [x] Verified the lint test correctly ignores inline-code mentions in `references/error-messages.md` (no false positives) and catches synthetic unguarded blocks (no false negatives)