### PR TITLE
docs: fix broken cross-references to relocated docs

### DIFF
--- a/docs/TODOS.md
+++ b/docs/TODOS.md
@@ -1,6 +1,6 @@
 # TODOS — gitissue / IDD
 
-> **Historical document.** All P1 items in this file shipped in Sprints 1-3 (2026-03) and the lean-issue / methodology updates from issues #31-#38 (2026-04). For current open work, see GitHub issues. For methodology, see [`idd-methodology.md`](idd-methodology.md). For the configuration schema, see [`config-schema.md`](config-schema.md).
+> **Historical document.** All P1 items in this file shipped in Sprints 1-3 (2026-03) and the lean-issue / methodology updates from issues #31-#38 (2026-04). For current open work, see GitHub issues. For methodology, see [`src/docs/idd-methodology.md`](../src/docs/idd-methodology.md). For the configuration schema, see [`src/docs/config-schema.md`](../src/docs/config-schema.md).
 
 Generated from /plan-ceo-review on 2026-03-20.
 Updated from /plan-eng-review on 2026-03-20.

--- a/docs/idea.md
+++ b/docs/idea.md
@@ -1,7 +1,7 @@
 # Idea: GitIssue — Issue-Driven Development (IDD)
 
-> **Historical document — superseded by [`docs/idd-methodology.md`](idd-methodology.md).**
-> This file captures the original product concept (early 2026) when the design assumed `/issue-creator` would auto-enrich issues with codebase context. That direction was reversed: issues now capture **intent only**, and codebase analysis lives in `/issue-analysis`, `/issue-triage`, and `/issue-resolver` against current code. Phrases like "codebase-aware issues", "auto-enriched", or "affected files in the issue body" are historical and do **not** describe the shipped behavior. See `docs/idd-methodology.md` for the current intent-code boundary.
+> **Historical document — superseded by [`src/docs/idd-methodology.md`](../src/docs/idd-methodology.md).**
+> This file captures the original product concept (early 2026) when the design assumed `/issue-creator` would auto-enrich issues with codebase context. That direction was reversed: issues now capture **intent only**, and codebase analysis lives in `/issue-analysis`, `/issue-triage`, and `/issue-resolver` against current code. Phrases like "codebase-aware issues", "auto-enriched", or "affected files in the issue body" are historical and do **not** describe the shipped behavior. See [`src/docs/idd-methodology.md`](../src/docs/idd-methodology.md) for the current intent-code boundary.
 
 ## Original Concept
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,7 +1,7 @@
 # PRD: gitissue
 
-> **Historical document — superseded by [`docs/idd-methodology.md`](idd-methodology.md) for the current methodology.**
-> This PRD (v1.1, 2026-03-20) describes the early product direction in which `/issue-creator` was specified to scan the codebase and embed affected files, technical notes, and architecture constraints into the issue body. That direction was reversed: issues now capture **intent only**. References in this document to "codebase-aware issues", "issue enrichment with codebase context", "affected files in the template", or "auto-enriched issues" are historical and do **not** describe the shipped behavior. The shipped behavior is described in skill READMEs and `docs/idd-methodology.md` (intent-code boundary).
+> **Historical document — superseded by [`src/docs/idd-methodology.md`](../src/docs/idd-methodology.md) for the current methodology.**
+> This PRD (v1.1, 2026-03-20) describes the early product direction in which `/issue-creator` was specified to scan the codebase and embed affected files, technical notes, and architecture constraints into the issue body. That direction was reversed: issues now capture **intent only**. References in this document to "codebase-aware issues", "issue enrichment with codebase context", "affected files in the template", or "auto-enriched issues" are historical and do **not** describe the shipped behavior. The shipped behavior is described in skill READMEs and [`src/docs/idd-methodology.md`](../src/docs/idd-methodology.md) (intent-code boundary).
 
 ## Table of Contents
 1. [Document Info](#document-info)

--- a/docs/validate.md
+++ b/docs/validate.md
@@ -1,6 +1,6 @@
 # Validation: GitIssue — Issue-Driven Development (IDD)
 
-> **Historical document — superseded by [`docs/idd-methodology.md`](idd-methodology.md).**
+> **Historical document — superseded by [`src/docs/idd-methodology.md`](../src/docs/idd-methodology.md).**
 > This early validation memo describes a direction in which `/issue-creator` was assumed to perform "codebase-aware issue enrichment at creation time". That direction was reversed: issues now capture **intent only**. The differentiator versus competing tools today is structured intent capture plus separate, on-demand current-code analysis (`/issue-analysis`, `/issue-triage`, `/issue-resolver`) — not in-issue codebase enrichment. Treat any "codebase-aware issue" or "auto-enriched issue" wording below as historical, not as a description of the shipped product.
 
 ## Quick Verdict

--- a/src/deprecated-skills/issue-pr-review-fix-loop/SKILL.md
+++ b/src/deprecated-skills/issue-pr-review-fix-loop/SKILL.md
@@ -19,7 +19,7 @@ metadata:
 >
 > This skill is deprecated as of version 0.4.0. All review-fix loop capabilities,
 > including review-fix cycles and traceability checks, are now part of
-> [`/issue-pr-review`](../issue-pr-review/SKILL.md).
+> [`/issue-pr-review`](../../skills/issue-pr-review/SKILL.md).
 >
 > ### Migration
 >


### PR DESCRIPTION
## Summary
- Fixed 6 broken markdown links across 5 files. Historical `docs/*.md` banners (idea, prd, validate, TODOS) linked to `idd-methodology.md`/`config-schema.md` as siblings, but those live under `src/docs/`. The deprecated `issue-pr-review-fix-loop` SKILL.md linked to `/issue-pr-review` as a sibling, but it now lives under `src/skills/`.
- Full-tree markdown link audit now reports **0 broken references** (was 6).
- No file moves, no content rewrites — link-target updates only. README, ARCHITECTURE, DEVELOPMENT, and CHANGELOG already reflect current state and were left untouched.
- Deliberately did not move `refactor-plan-v10.md`: it is referenced by section number from `docs/CHANGELOG.md`, `scripts/build.sh`, `docs/decisions/`, `docs/experiments/`, and `scripts/plugin-schema.provenance.md`. Moving it would create more broken links than it fixes.

## Test plan
- [x] Run full-tree markdown link audit — 0 broken links
- [ ] Spot-check rendered banners on `docs/idea.md`, `docs/prd.md`, `docs/validate.md`, `docs/TODOS.md` resolve to `src/docs/idd-methodology.md`
- [ ] Spot-check `src/deprecated-skills/issue-pr-review-fix-loop/SKILL.md` migration link resolves to `src/skills/issue-pr-review/SKILL.md`