### PR TITLE
docs(install): document that `claude plugin install <tarball-url>` is unsupported (#79)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,7 @@ IDD ships through two distribution paths. Pick the one that matches your harness
 
 #### Plugin path (Claude Code)
 
-> **Note:** Plugin tarballs ship with the first tagged release that runs the release pipeline. Until then, use the [Standalone path](#standalone-path-any-skillmd-compatible-harness) below.
-
-Once a release is published, grab the `idd-plugin-<tag>.tar.gz` asset from the [releases page](https://github.com/luongnv89/idd/releases/latest) and extract it into your Claude Code plugins directory:
+Grab the `idd-plugin-<tag>.tar.gz` asset from the [latest release](https://github.com/luongnv89/idd/releases/latest) and extract it into your Claude Code plugins directory:
 
 ```bash
 mkdir -p ~/.claude/plugins/idd
@@ -170,6 +168,8 @@ tar -xzf idd-plugin-<tag>.tar.gz -C ~/.claude/plugins/idd
 ```
 
 The tarball unpacks to `.claude-plugin/plugin.json`, `skills/`, `shared/`, and `docs/` at its root. Restart Claude Code to load the new plugin.
+
+> **Heads up — `claude plugin install <tarball-url>` is not supported.** Claude Code's `claude plugin install` only accepts `plugin@marketplace` references and resolves them through configured marketplaces, not direct tarball URLs or paths. Running `claude plugin install https://github.com/luongnv89/idd/releases/download/<tag>/idd-plugin-<tag>.tar.gz` returns `not found in any configured marketplace` and does nothing. Use the manual `tar -xzf` extract above — that is the supported install path today. (Tracked in [#79](https://github.com/luongnv89/idd/issues/79).)
 
 #### Standalone path (any SKILL.md-compatible harness)
 

--- a/docs/release-notes/v0.7.0-smoke-tests.md
+++ b/docs/release-notes/v0.7.0-smoke-tests.md
@@ -134,7 +134,7 @@ tar -xzf /tmp/idd-smoke-<pid>/idd-plugin-v0.7.0.tar.gz -C /tmp/idd-smoke-<pid>/t
 - `docs/` carries four runtime docs at the plugin root. ✓
 - `auto-pilot/references/subagent-prompts.md` uses the plugin form `../../<name>/SKILL.md` (e.g., `../../issue-resolver/SKILL.md`), matching the §6 ADR row `(A-fail, B-fail, C-1)` "Plugin" cell. ✓
 
-**Note on "invoke `/<plugin-slug>:issue-creator`":** A literal in-Claude-Code invocation requires installing the plugin via `claude plugin install` and restarting the harness, which is a release-tag-time check, not a pre-tag check. This test confirms the artifact is installable: schema validates, manifest validates via the official `claude plugin validate` command, layout matches the spec, and all internal references match the ADR-decided forms.
+**Note on "invoke `/<plugin-slug>:issue-creator`":** A literal in-Claude-Code invocation requires installing the plugin (today: extract `idd-plugin-<tag>.tar.gz` into `~/.claude/plugins/idd/` per [README → Install](../../README.md#plugin-path-claude-code); `claude plugin install <tarball-url>` is **not** supported by Claude Code, see [#79](https://github.com/luongnv89/idd/issues/79)) and restarting the harness — a release-tag-time check, not a pre-tag check. This test confirms the artifact is installable: schema validates, manifest validates via the official `claude plugin validate` command, layout matches the spec, and all internal references match the ADR-decided forms.
 
 **Result:** ✓ PASS — tarball is install-ready and conforms to the §14 spec.
 


### PR DESCRIPTION
Closes #79

## Summary

Doc-only fix. The README's plugin-install section invited users (by natural reading) to run `claude plugin install <tarball-url>`, which fails with `not found in any configured marketplace`. This PR adds an explicit "Heads up" callout that states the tarball-URL form is unsupported, explains *why* (Claude Code's `claude plugin install` only accepts `plugin@marketplace` references, per `claude plugin install --help`), and points users to the working manual `tar -xzf` extract path.

It also drops a now-stale note ("Plugin tarballs ship with the first tagged release that runs the release pipeline") because v0.7.0 already ships `idd-plugin-v0.7.0.tar.gz`, and clarifies a parallel reference in the v0.7.0 smoke-tests doc.

## Approach

Narrowed the change to two user-facing locations that directly invalidate or misframe the failing command:

1. **`README.md` → Install → Plugin path (Claude Code)** — replaced the stale tarball-availability note with an explicit "Heads up" callout citing the exact error message and the discriminating fact (`plugin@marketplace` only). The supported `tar -xzf` extract block is unchanged.
2. **`docs/release-notes/v0.7.0-smoke-tests.md`** line 137 — clarified the test note that previously said "requires installing the plugin via `claude plugin install`" so it now references the supported manual extract path and links to #79 for the unsupported-form caveat.

Deliberately **not** changed in this PR (out of scope for #79):

- `refactor-plan-v10.md` — historical planning doc, not user-facing install guidance.
- `docs/DEVELOPMENT.md` — already correctly says "See README → Install for the full command", so the README fix flows through.
- No `asm install` documentation added (that belongs to #76).
- No one-line install script added (that belongs to #80).

## Decision Record

**Why doc-only over a marketplace setup?** `claude plugin install` resolves names through configured marketplaces. Making `claude plugin install idd@<source>` work would require authoring and publishing a `marketplace.json` (the repo currently has only `dist/plugin/.claude-plugin/plugin.json`, no marketplace). That is a separate, larger change with its own design decisions about scope, hosting, and discoverability — out of scope for a bug labeled "fix or document the failing command" in conservative-mode auto-pilot.

**Why mention the discriminating fact?** "Unsupported" alone leaves users guessing whether it's a typo, a flag, or a missing scheme. Naming the actual constraint (`plugin@marketplace` references resolved through configured marketplaces) closes the door cleanly so users don't keep trying variations.

## Changes

| File | Change |
|------|--------|
| `README.md` | Replace stale "tarballs ship with..." note; add "Heads up" callout for unsupported `claude plugin install <tarball-url>` form. |
| `docs/release-notes/v0.7.0-smoke-tests.md` | Reword note that previously implied `claude plugin install` was the install command; reference manual extract + link to #79. |

## Test Results

Doc-only change. No skill behavior, no source under `src/`, and no `dist/` drift after a fresh `scripts/build.sh` run. No automated tests cover this README copy.

## Acceptance Criteria Verification

| # | Criterion | Result | Evidence |
|---|-----------|--------|----------|
| 1 | README's Install section gives a `claude plugin install`-compatible path that completes, OR explicitly documents that `claude plugin install <tarball-url>` is unsupported and points to the working install path. | pass | README's new callout (line 172) explicitly states the tarball-URL form is unsupported and points to the manual `tar -xzf` extract above it. |
| 2 | Release notes / install docs no longer invite a command that fails with the marketplace error. | pass | `docs/release-notes/v0.7.0-smoke-tests.md` line 137 reworded; README stale "tarballs ship with..." note removed. |
| 3 | If a `claude plugin install`-compatible path is added, it installs the same plugin contents as the manual extract path. | n/a | This PR does not add a new install path; intentionally deferred (see Decision Record). |
| 4 | After install via the documented path, restarting Claude Code loads the plugin and `/issue-creator`, `/issue-resolver`, `/issue-triage`, `/issue-pr-review`, `/auto-pilot`, `/issue-analysis`, `/init-gitissue` are invocable. | partial — verified by docs review | The documented manual extract path is the same path used in v0.7.0 smoke tests where `claude plugin validate` passed and the plugin layout matches the spec. A live install + restart was not exercised inside this PR. |