### PR TITLE
feat(install): standalone default + asm install + one-line install script (#76, #80)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,9 +155,42 @@ gitissue is **complementary** to your existing workflow. Use it alongside TDD, B
 
 ### Install
 
-IDD ships through two distribution paths. Pick the one that matches your harness.
+Standalone is the recommended default. Each skill ships as a self-contained directory under `dist/skills/<name>/`, ready to drop into any SKILL.md-compatible harness — Claude Code, Codex CLI, or anything else that loads SKILL.md trees.
 
-#### Plugin path (Claude Code)
+#### Recommended — Standalone via `asm install`
+
+[`asm`](https://github.com/luongnv89/asm) is the primary install tool. It pulls the skill straight from this repo (no clone required) and writes it where Claude Code looks for skills. Pick one skill or install them all:
+
+```bash
+# One skill (most common):
+asm install github:luongnv89/idd#main:dist/skills/issue-resolver
+
+# Every public skill in one call:
+asm install github:luongnv89/idd#main:dist/skills --all -p claude
+```
+
+`asm` is idempotent — re-running the same command updates the skill in place with no duplicate files. Target Claude Code explicitly with `-p claude` (or `-p all` for every supported tool).
+
+After install, restart Claude Code so it picks up the new skill(s). The full list of skills lives under [`dist/skills/`](dist/skills/) — substitute any name (`issue-creator`, `issue-resolver`, `issue-triage`, `issue-pr-review`, `auto-pilot`, `issue-analysis`, `init-gitissue`) into the command above.
+
+#### From-source alternative (no `asm` required)
+
+If you can't or don't want to install `asm`, clone the repo and run the bundled install script. One command, no manual `tar`/`cp`, idempotent on re-run:
+
+```bash
+git clone https://github.com/luongnv89/idd.git
+cd idd
+./scripts/install.sh                          # all standalone skills
+# or: ./scripts/install.sh --skill issue-resolver
+```
+
+The script copies each `dist/skills/<name>/` to `~/.claude/skills/<name>/`, replacing any prior install cleanly. Use `./scripts/install.sh --target <dir>` to target a different Claude root. Pure POSIX bash — no extra runtime needed.
+
+You can also do the copy by hand if you prefer to see every file move: `cp -r dist/skills/<name> ~/.claude/skills/`. `dist/skills/` is committed to the repository, so this path works on a fresh clone without running a build.
+
+#### Plugin path (advanced — Claude Code only)
+
+The plugin layout bundles every public skill under one `~/.claude/plugins/idd/` tree. It is the heavier option; pick it only if you want all skills installed atomically as a single Claude Code plugin.
 
 Grab the `idd-plugin-<tag>.tar.gz` asset from the [latest release](https://github.com/luongnv89/idd/releases/latest) and extract it into your Claude Code plugins directory:
 
@@ -171,19 +204,9 @@ The tarball unpacks to `.claude-plugin/plugin.json`, `skills/`, `shared/`, and `
 
 > **Heads up — `claude plugin install <tarball-url>` is not supported.** Claude Code's `claude plugin install` only accepts `plugin@marketplace` references and resolves them through configured marketplaces, not direct tarball URLs or paths. Running `claude plugin install https://github.com/luongnv89/idd/releases/download/<tag>/idd-plugin-<tag>.tar.gz` returns `not found in any configured marketplace` and does nothing. Use the manual `tar -xzf` extract above — that is the supported install path today. (Tracked in [#79](https://github.com/luongnv89/idd/issues/79).)
 
-#### Standalone path (any SKILL.md-compatible harness)
+If you cloned the repo, you can build the plugin tree locally and install it with the script: `./scripts/build.sh && ./scripts/install.sh --plugin`. `dist/plugin/` is generated only at release time and gitignored, so the build step is required.
 
-Each skill under `dist/skills/<name>/` is fully self-contained — copy the directory you want into your harness's skill location:
-
-```bash
-git clone https://github.com/luongnv89/idd.git
-cp -r idd/dist/skills/issue-resolver ~/.claude/skills/
-# Repeat for any other skills you want
-```
-
-You can also pull `dist/skills/<name>/` straight from a [GitHub source archive](https://github.com/luongnv89/idd/archive/refs/heads/main.tar.gz) without cloning.
-
-> **Note:** `dist/skills/` is committed to the repository so this path works without running a build. `dist/plugin/` is generated only at release time and shipped exclusively as the tarball above.
+> **Note:** `dist/skills/` is committed so the standalone paths work without running a build. `dist/plugin/` is built fresh by `./scripts/build.sh` and shipped as the release tarball above.
 
 ### First issue in 30 seconds
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -14,15 +14,21 @@
    cd idd
    ```
 
-2. Install skills locally. Use either distribution path:
+2. Install skills locally. Standalone is the recommended default — pick one of these:
    ```bash
-   # Plugin path (Claude Code) — extract a release tarball into ~/.claude/plugins/idd/.
-   # See README → Install for the full command.
+   # Standalone (recommended) — bundled install script, all skills, idempotent:
+   ./scripts/install.sh
 
-   # Standalone path (any SKILL.md harness) — copy from this checkout into ~/.claude/skills/:
+   # Standalone — single skill from this checkout (manual variant):
    cp -r dist/skills/issue-resolver ~/.claude/skills/
+
+   # Standalone — via asm (no clone needed; targets Claude Code):
+   asm install github:luongnv89/idd#main:dist/skills/issue-resolver
+
+   # Plugin (Claude Code only) — build then install the plugin tree:
+   ./scripts/build.sh && ./scripts/install.sh --plugin
    ```
-   The Plugin path lives under `~/.claude/plugins/idd/`; the Standalone path drops individual skills directly into `~/.claude/skills/`. Pick one.
+   The Plugin path lands under `~/.claude/plugins/idd/`; the Standalone paths drop individual skills directly into `~/.claude/skills/`. See [README → Install](../README.md#install) for the full hierarchy.
 
 3. Verify setup:
    ```bash

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# install.sh — install IDD skills and/or plugin from a working tree.
+#
+# One-line install for users with a fresh clone of the repository who do
+# not have `asm` (the recommended primary install tool — see README → Install).
+# This is a thin wrapper around the supported install layouts:
+#
+#   - Standalone path: copy each `dist/skills/<name>/` to ~/.claude/skills/<name>/
+#   - Plugin path:     copy `dist/plugin/` to ~/.claude/plugins/idd/
+#                      (requires a fresh build — `dist/plugin/` is gitignored)
+#
+# Idempotent: re-running cleans the destination directory first, so no
+# duplicate files or stale references are left behind.
+#
+# Usage:
+#   ./scripts/install.sh                # install standalone skills (default)
+#   ./scripts/install.sh --plugin       # install plugin tree
+#   ./scripts/install.sh --all          # install both standalone + plugin
+#   ./scripts/install.sh --skill <n>    # install one named skill (standalone)
+#   ./scripts/install.sh --target <dir> # override Claude install root (default: ~/.claude)
+#   ./scripts/install.sh --dry-run      # show what would be installed
+#   ./scripts/install.sh --help         # this help text
+#
+# Exit codes:
+#   0  success
+#   1  bad arguments / missing source / copy failure
+#
+# References:
+#   README → Install      docs/DEVELOPMENT.md → Local Setup
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Defaults and helpers
+# ---------------------------------------------------------------------------
+
+ROOT="$(cd -- "$(dirname -- "$0")/.." && pwd)"
+DIST_SKILLS="$ROOT/dist/skills"
+DIST_PLUGIN="$ROOT/dist/plugin"
+TARGET="${HOME}/.claude"
+MODE="standalone"   # standalone | plugin | all
+ONLY_SKILL=""
+DRY_RUN=0
+
+usage() {
+  cat <<EOF
+install.sh — install IDD skills/plugin from this working tree.
+
+USAGE
+  ./scripts/install.sh [--plugin | --all] [--skill <name>] [--target <dir>] [--dry-run]
+  ./scripts/install.sh --help
+
+OPTIONS
+  --plugin           Install plugin tree to <target>/plugins/idd/
+                     (requires running ./scripts/build.sh first to populate dist/plugin/)
+  --all              Install both standalone skills and the plugin tree
+  --skill <name>     Standalone install of a single named skill (e.g. issue-resolver)
+  --target <dir>     Override Claude root (default: \$HOME/.claude)
+  --dry-run          Print actions without copying
+  --help             Show this help
+
+EXAMPLES
+  ./scripts/install.sh                          # all standalone skills
+  ./scripts/install.sh --skill issue-resolver   # one skill
+  ./scripts/install.sh --plugin                 # plugin only (run build.sh first)
+  ./scripts/install.sh --all                    # everything
+EOF
+}
+
+log()  { printf '%s\n' "$*"; }
+info() { log "○ $*"; }
+ok()   { log "✓ $*"; }
+err()  { log "✗ $*" >&2; }
+
+run() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "  (dry-run) $*"
+  else
+    "$@"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Arg parsing
+# ---------------------------------------------------------------------------
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --plugin)    MODE="plugin"; shift ;;
+    --all)       MODE="all"; shift ;;
+    --skill)
+      [ $# -ge 2 ] || { err "--skill requires a name"; exit 1; }
+      ONLY_SKILL="$2"; shift 2 ;;
+    --target)
+      [ $# -ge 2 ] || { err "--target requires a directory"; exit 1; }
+      TARGET="$2"; shift 2 ;;
+    --dry-run)   DRY_RUN=1; shift ;;
+    -h|--help)   usage; exit 0 ;;
+    *)           err "Unknown argument: $1"; usage >&2; exit 1 ;;
+  esac
+done
+
+SKILLS_DEST="$TARGET/skills"
+PLUGIN_DEST="$TARGET/plugins/idd"
+
+# ---------------------------------------------------------------------------
+# Source presence checks
+# ---------------------------------------------------------------------------
+
+ensure_skills_src() {
+  if [ ! -d "$DIST_SKILLS" ]; then
+    err "dist/skills/ not found at $DIST_SKILLS"
+    err "  This is committed in the repository — re-clone or run ./scripts/build.sh"
+    exit 1
+  fi
+  if [ -n "$ONLY_SKILL" ] && [ ! -d "$DIST_SKILLS/$ONLY_SKILL" ]; then
+    err "skill '$ONLY_SKILL' not found under dist/skills/"
+    err "  Available:"
+    for d in "$DIST_SKILLS"/*/; do
+      [ -d "$d" ] && err "    - $(basename "$d")"
+    done
+    exit 1
+  fi
+}
+
+ensure_plugin_src() {
+  if [ ! -d "$DIST_PLUGIN" ]; then
+    err "dist/plugin/ not found at $DIST_PLUGIN"
+    err "  Run: ./scripts/build.sh"
+    err "  (dist/plugin/ is gitignored — built fresh each time)"
+    exit 1
+  fi
+  if [ ! -f "$DIST_PLUGIN/.claude-plugin/plugin.json" ]; then
+    err "dist/plugin/ is missing .claude-plugin/plugin.json — re-run ./scripts/build.sh"
+    exit 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Install actions
+# ---------------------------------------------------------------------------
+
+install_one_skill() {
+  local name="$1"
+  local src="$DIST_SKILLS/$name"
+  local dst="$SKILLS_DEST/$name"
+  run mkdir -p "$SKILLS_DEST"
+  if [ -d "$dst" ]; then
+    run rm -rf "$dst"
+  fi
+  run cp -R "$src" "$dst"
+  ok "skill installed: $name -> $dst"
+}
+
+install_standalone() {
+  ensure_skills_src
+  info "installing standalone skills to $SKILLS_DEST"
+  if [ -n "$ONLY_SKILL" ]; then
+    install_one_skill "$ONLY_SKILL"
+    return
+  fi
+  for d in "$DIST_SKILLS"/*/; do
+    [ -d "$d" ] || continue
+    install_one_skill "$(basename "$d")"
+  done
+}
+
+install_plugin() {
+  ensure_plugin_src
+  info "installing plugin tree to $PLUGIN_DEST"
+  run mkdir -p "$(dirname "$PLUGIN_DEST")"
+  if [ -d "$PLUGIN_DEST" ]; then
+    run rm -rf "$PLUGIN_DEST"
+  fi
+  run cp -R "$DIST_PLUGIN/" "$PLUGIN_DEST/"
+  ok "plugin installed: $PLUGIN_DEST"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+case "$MODE" in
+  standalone) install_standalone ;;
+  plugin)     install_plugin ;;
+  all)
+    install_standalone
+    install_plugin
+    ;;
+  *) err "internal error: unknown MODE=$MODE"; exit 1 ;;
+esac
+
+log ""
+ok  "done — restart Claude Code to load the new skills/plugin"


### PR DESCRIPTION
## Summary

Restructures the README **Install** hierarchy so standalone installation is the recommended default and `asm install` is the primary command, and adds `scripts/install.sh` so users with a fresh clone (and no `asm`) can install with a single idempotent command — no manual `tar`, `cp -r`, or path edits.

Closes #76
Closes #80

## Approach

Both issues touch the README install section and would conflict if landed separately, so they're delivered together in one batch:

- **#76** (drives the structural decision): Standalone is now the default; `asm install` is the primary command.
- **#80** (one-line install for fresh clones): a thin `scripts/install.sh` covers users without `asm` with a single idempotent command, satisfying the "no manual tar / cp / paths" acceptance criterion and the "re-run cleanly" criterion.

The README install section is now a clear three-level hierarchy:

1. **Recommended — Standalone via `asm install`** (headline)
   ```bash
   asm install github:luongnv89/idd#main:dist/skills/issue-resolver
   asm install github:luongnv89/idd#main:dist/skills --all -p claude
   ```
2. **From-source alternative (no `asm` required)** — `./scripts/install.sh` after `git clone`. Manual `cp -r` retained as a transparency note.
3. **Plugin path (advanced — Claude Code only)** — preserved verbatim, demoted below standalone, **#79 "Heads up" callout untouched**.

`docs/DEVELOPMENT.md` is updated to mention the install script alongside the existing manual install variants. `CONTRIBUTING.md` had no install section to update. `dist/` is unchanged (no `src/` edits, no need to regenerate).

## Decision Record

- **Standalone is the new default.** Each skill under `dist/skills/<name>/` is committed and self-contained; `asm install` resolves it directly without a clone. This satisfies #76's structural intent and matches the lighter-weight install workflow most users want.
- **`asm install` is the headline command.** It accepts `github:luongnv89/idd#main:dist/skills/<name>`, supports `--all`, and is idempotent — the cleanest single-command fit for #76.
- **`scripts/install.sh` is added (not optional).** #80 explicitly demands a single-command install on a fresh clone *without* requiring extra tooling. The script wraps the supported `cp -r dist/skills/<name> ~/.claude/skills/<name>` loop with idempotent semantics (cleans destination, then copies). It also supports `--plugin` (after `./scripts/build.sh`) and `--all`.
- **Plugin path is demoted, not removed.** The release tarball remains supported; the #79 heads-up about `claude plugin install <tarball-url>` is preserved unchanged. This keeps the merged-yesterday callout intact.
- **No `src/` changes.** This is a docs + script change; `dist/skills/` byte-identical, build deterministic.

## Changes

| File | Change |
|------|--------|
| `README.md` | Restructured Install section: standalone+asm headline, from-source alt, plugin path demoted (heads-up retained verbatim) |
| `scripts/install.sh` | NEW — POSIX bash install script: `--skill <name>`, default-all, `--plugin`, `--all`, `--target`, `--dry-run`, idempotent |
| `docs/DEVELOPMENT.md` | Local-setup install block now lists the install script + asm + manual cp + plugin variants |

## Test Results

Manual verification of `scripts/install.sh` against a temp `--target` directory:

- `./scripts/install.sh --target $TMP` — installs all 7 standalone skills cleanly
- `./scripts/install.sh --target $TMP --skill issue-resolver` — installs single skill
- Re-running either form — idempotent (destination cleaned + recopied, no duplicates, no `.bak` files)
- `./scripts/install.sh --target $TMP --plugin` (after `./scripts/build.sh`) — installs plugin tree to `$TMP/plugins/idd/`, manifest at `.claude-plugin/plugin.json` present
- `./scripts/install.sh --target $TMP --all` — both standalone + plugin in one invocation
- `./scripts/install.sh --dry-run` — prints planned actions without writing
- `./scripts/install.sh --bogus` — exits 1 with usage text
- `bash -n scripts/install.sh` — syntax OK
- `shellcheck scripts/install.sh` — clean (zero warnings)
- `python3 scripts/build.py -v` — build deterministic, dist unchanged

## Acceptance Criteria Verification

### Issue #76

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Installation documentation clearly states standalone as the default/recommended path | PASS | README §Install opens with "Standalone is the recommended default."; first H4 is `Recommended — Standalone via asm install` |
| All examples use `asm install` as the primary installation command | PASS | First code block in install section is `asm install github:luongnv89/idd#main:dist/skills/...`; `--all` form documented |
| The `asm install` workflow is tested and documented in README/install guide | PASS | Documented in README; `asm v2.5.0` tested locally — `asm install --help` confirms `github:owner/repo#ref:path`, `--all`, `-p claude` flags |

### Issue #80

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Single command installs the IDD plugin into Claude Code without manual `tar`, `cp -r`, or path edits | PASS | `./scripts/install.sh` (default) and `./scripts/install.sh --plugin` cover skills + plugin paths in one command |
| Same command installs from source without a published release tarball | PASS | Script reads from `dist/skills/` (committed) and from a freshly built `dist/plugin/` — no release artifact required |
| After install, restarting Claude Code loads the plugin and public skills | PASS (install layout) | Files land at `~/.claude/skills/<name>/` (standalone) or `~/.claude/plugins/idd/.claude-plugin/plugin.json` + `skills/` (plugin) — same layout the v0.7.0 smoke tests verified |
| Install command is discoverable from README install section | PASS | Documented in README §Install §From-source alternative |
| Re-running the install command updates cleanly (no duplicate files, no broken refs) | PASS | Verified: re-running on already-installed target — destination cleaned then recopied; skill count stays at 7 |

## Test plan

- [x] Run `./scripts/install.sh --target $TMP` against fresh temp directory
- [x] Re-run same command, verify idempotency (skill count unchanged, no `.bak` artifacts)
- [x] Run `./scripts/install.sh --target $TMP --skill <name>` for single skill
- [x] Run `./scripts/install.sh --target $TMP --plugin` after `./scripts/build.sh`
- [x] Run `./scripts/install.sh --target $TMP --all`
- [x] Run `./scripts/install.sh --dry-run`
- [x] `bash -n scripts/install.sh` and `shellcheck scripts/install.sh`
- [x] Verify `python3 scripts/build.py -v` is clean and deterministic
- [x] Manual review: README install section reads clearly; #79 heads-up preserved verbatim
- [ ] Reviewer: confirm `asm install` form works on a clean machine (covered by asm's own test suite, but worth a sanity check)