### PR TITLE
docs(install): replace broken bulk asm command with per-skill loop (#85)

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,11 +165,16 @@ Standalone is the recommended default. Each skill ships as a self-contained dire
 # One skill (most common):
 asm install github:luongnv89/idd#main:dist/skills/issue-resolver
 
-# Every public skill in one call:
-asm install github:luongnv89/idd#main:dist/skills --all -p claude
+# Every public skill in one loop:
+for skill in issue-creator issue-analysis issue-resolver issue-triage \
+             issue-pr-review auto-pilot init-gitissue; do
+  asm install "github:luongnv89/idd#main:dist/skills/$skill" -p claude -y
+done
 ```
 
 `asm` is idempotent — re-running the same command updates the skill in place with no duplicate files. Target Claude Code explicitly with `-p claude` (or `-p all` for every supported tool).
+
+> **Why a loop?** A single `asm install …:dist/skills --all` would be nicer, but `--all` is currently ignored when the source includes a subpath (tracked in [luongnv89/asm#251](https://github.com/luongnv89/asm/issues/251)). The per-skill loop above exercises the working single-skill path. Once asm #251 lands we'll switch back to the one-liner. If you'd rather not loop, the [from-source alternative](#from-source-alternative-no-asm-required) installs all skills with a single command today.
 
 After install, restart Claude Code so it picks up the new skill(s). The full list of skills lives under [`dist/skills/`](dist/skills/) — substitute any name (`issue-creator`, `issue-resolver`, `issue-triage`, `issue-pr-review`, `auto-pilot`, `issue-analysis`, `init-gitissue`) into the command above.
 


### PR DESCRIPTION
Closes #85

## Summary

The README's bulk `asm install` example was broken — `asm install …:dist/skills --all -p claude` fails on asm v2.5.0 because `--all` is ignored when the source path includes a subpath (tracked upstream in [luongnv89/asm#251](https://github.com/luongnv89/asm/issues/251)). This PR replaces it with a per-skill loop that exercises the working single-skill path, and adds a short callout explaining why the loop exists today.

## Approach

Minimal documentation fix to `README.md` only. Two changes in the install section:

1. The `--all` one-liner becomes a `for` loop over the seven public skills, each invoked via the single-skill `asm install` form that is known to work on v2.5.0.
2. A new "Why a loop?" blockquote links to asm #251, points readers at the from-source alternative as a one-command escape hatch, and signals the intent to revert once upstream lands.

The single-skill example (line 167) and the from-source `./scripts/install.sh` instructions were not touched.

## Decision Record

- **Why this fix and not waiting on asm #251?** Anyone copy-pasting the bulk command today hits an opaque `No SKILL.md found at path "dist/skills"` error. Cost of an interim README change is one revert; cost of leaving the broken command in place is silent friction for every new user until upstream ships.
- **Why a `for` loop and not a script?** A loop in the README is self-contained (no extra file to maintain, version, or document) and reverts cleanly to the one-liner once asm #251 lands. A helper script would add a new install path users have to learn and that we have to delete later.
- **Why list the seven skills explicitly?** The list mirrors the existing skill enumeration two paragraphs down (`issue-creator`, `issue-resolver`, …). Keeping the names visible makes the loop self-documenting and gives the reader an obvious place to drop a name they don't want.
- **Provenance note for the reviewer:** the `README.md` edit was already present in the working tree when `/issue-resolver 85` ran. The pipeline verified the diff against all four acceptance criteria, branched from current `HEAD`, and packaged it into this PR rather than re-authoring from scratch.

## Changes

| File | Change |
|------|--------|
| `README.md` | Replace broken `asm … --all` one-liner with per-skill `for` loop; add "Why a loop?" callout linking to asm #251 |

Net diff: `+7 / -2`.

## Test Results

This is a documentation-only change with no executable code paths. Verification was manual:

- The proposed loop was exercised conceptually against the working single-skill form (`asm install github:luongnv89/idd#main:dist/skills/issue-resolver`), which is documented as functional in asm v2.5.0.
- No build, test, or lint surface is affected (`README.md` is not consumed by `scripts/build.py` for skill bundling).

## Acceptance Criteria Verification

| AC | Status | Evidence |
|----|--------|----------|
| README's "every public skill in one call" example succeeds against asm v2.5.0 | ✓ | The loop calls `asm install github:luongnv89/idd#main:dist/skills/<name> -p claude -y` per skill — the form the issue itself confirms works |
| A short note links to asm #251 | ✓ | New blockquote on line 177: "*…tracked in [luongnv89/asm#251](https://github.com/luongnv89/asm/issues/251)*" |
| Single-skill example is unchanged | ✓ | Line 167 (`asm install github:luongnv89/idd#main:dist/skills/issue-resolver`) is unmodified in the diff |
| From-source `./scripts/install.sh` instructions are unchanged | ✓ | Lines 181–192 (the "From-source alternative" section) are outside the diff range |