### PR TITLE
feat(security): enforce pre-commit security scan across commit-capable skills (#87)

### DIFF
--- a/dist/skills/issue-pr-review/SKILL.md
+++ b/dist/skills/issue-pr-review/SKILL.md
@@ -24,6 +24,8 @@ Review a pull request end-to-end — analyze, test, fix, check CI, repeat until 
 
 The `--auto` flag is set automatically when invoked by `/auto-pilot`.
 
+In auto mode, export `IDD_AUTO_MODE=1` before any shell snippet that consults it — the pre-commit security scan reads this to switch from prompt-on-warning to log-and-continue (see `references/docs/pre-commit-security.md`).
+
 ## Prerequisites
 
 1. Confirm git repository: `git rev-parse --git-dir`
@@ -181,9 +183,52 @@ npm test          # or pytest, go test ./..., cargo test, etc.
 
 ### Commit auto-fixes
 
-If any files were modified by the auto-fix tools:
+If any files were modified by the auto-fix tools, run the pre-commit security
+scan before staging (see the pre-commit security conventions reference at
+`references/docs/pre-commit-security.md` — that document is authoritative; the snippet
+below mirrors its Primary Pattern). Real secrets block; warnings prompt for
+confirmation in interactive mode and log-and-continue in auto mode.
 
 ```bash
+# Pre-commit security scan — mirrors the Primary Pattern in the
+# pre-commit-security conventions reference. Set IDD_AUTO_MODE=1 in auto mode.
+files="$(git status --porcelain | awk '{print $2}')"
+secrets_found=0
+warnings=()
+if printf '%s\n' "$files" | grep -E -q '(^|/)\.env($|\.)|\.key$|\.pem$|credentials\.json$|secrets\.ya?ml$|id_rsa($|\.pub$)|\.p12$|\.pfx$|\.cer$'; then
+  echo "✗ Secret-bearing file in working tree."
+  secrets_found=1
+fi
+realkey='(sk-(proj-)?[A-Za-z0-9_-]{20,}|sk_live_[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{30,}|gho_[A-Za-z0-9]{30,}|ghs_[A-Za-z0-9]{30,}|ghu_[A-Za-z0-9]{30,}|github_pat_[A-Za-z0-9_]{40,}|xox[abprs]-[A-Za-z0-9-]{10,}|glpat-[A-Za-z0-9_-]{20,}|AIza[0-9A-Za-z_-]{30,})'
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  [ -f "$f" ] || continue
+  file --mime "$f" 2>/dev/null | grep -q 'charset=binary' && continue
+  if grep -E -q "$realkey" "$f" 2>/dev/null; then
+    echo "✗ Real API key detected in: $f"
+    secrets_found=1
+  fi
+  size=$(stat -f%z "$f" 2>/dev/null || stat -c%s "$f" 2>/dev/null || echo 0)
+  [ "$size" -gt 10485760 ] && warnings+=("⚠ Large file (>10 MB) without LFS: $f")
+done <<< "$files"
+junk='(^|/)(node_modules|dist|build|__pycache__|\.venv)(/|$)|\.pyc$|(^|/)(\.DS_Store|thumbs\.db)$|\.swp$|\.tmp$'
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  printf '%s\n' "$f" | grep -E -q "$junk" && warnings+=("⚠ Build artifact staged: $f")
+done <<< "$files"
+case "$(git rev-parse --abbrev-ref HEAD)" in
+  main|master|production|release) warnings+=("⚠ On protected branch — confirm intentional") ;;
+esac
+[ "$secrets_found" = 1 ] && { echo "✗ Pre-commit security scan blocked. See pre-commit-security conventions reference."; exit 1; }
+if [ "${#warnings[@]}" -gt 0 ]; then
+  printf '%s\n' "${warnings[@]}"
+  if [ "${IDD_AUTO_MODE:-0}" = "1" ]; then
+    echo "○ Warnings logged — proceeding (auto mode)."
+  else
+    printf "Proceed anyway? [y/N] "; read -r reply
+    case "$reply" in y|Y|yes|YES) echo "○ Continuing despite warnings." ;; *) echo "✗ Stopped."; exit 1 ;; esac
+  fi
+fi
 git add -A
 git commit -m "style: auto-fix lint and format issues"
 git push origin {branch_name}
@@ -474,7 +519,54 @@ For each issue where `action: "fix"`:
 2. Apply the fix
 3. Stage: `git add <specific-file>`
 
-After all fixes:
+After all fixes, run the pre-commit security scan against the staged set before
+committing (see the pre-commit security conventions reference at
+`references/docs/pre-commit-security.md` — that document is authoritative; the snippet
+below mirrors its Primary Pattern). Real secrets block; warnings prompt for
+confirmation in interactive mode and log-and-continue in auto mode.
+
+```bash
+# Pre-commit security scan — mirrors the Primary Pattern in the
+# pre-commit-security conventions reference. Set IDD_AUTO_MODE=1 in auto mode.
+files="$(git diff --cached --name-only)"
+secrets_found=0
+warnings=()
+if printf '%s\n' "$files" | grep -E -q '(^|/)\.env($|\.)|\.key$|\.pem$|credentials\.json$|secrets\.ya?ml$|id_rsa($|\.pub$)|\.p12$|\.pfx$|\.cer$'; then
+  echo "✗ Secret-bearing file staged."
+  secrets_found=1
+fi
+realkey='(sk-(proj-)?[A-Za-z0-9_-]{20,}|sk_live_[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{30,}|gho_[A-Za-z0-9]{30,}|ghs_[A-Za-z0-9]{30,}|ghu_[A-Za-z0-9]{30,}|github_pat_[A-Za-z0-9_]{40,}|xox[abprs]-[A-Za-z0-9-]{10,}|glpat-[A-Za-z0-9_-]{20,}|AIza[0-9A-Za-z_-]{30,})'
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  [ -f "$f" ] || continue
+  file --mime "$f" 2>/dev/null | grep -q 'charset=binary' && continue
+  if grep -E -q "$realkey" "$f" 2>/dev/null; then
+    echo "✗ Real API key detected in: $f"
+    secrets_found=1
+  fi
+  size=$(stat -f%z "$f" 2>/dev/null || stat -c%s "$f" 2>/dev/null || echo 0)
+  [ "$size" -gt 10485760 ] && warnings+=("⚠ Large file (>10 MB) without LFS: $f")
+done <<< "$files"
+junk='(^|/)(node_modules|dist|build|__pycache__|\.venv)(/|$)|\.pyc$|(^|/)(\.DS_Store|thumbs\.db)$|\.swp$|\.tmp$'
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  printf '%s\n' "$f" | grep -E -q "$junk" && warnings+=("⚠ Build artifact staged: $f")
+done <<< "$files"
+case "$(git rev-parse --abbrev-ref HEAD)" in
+  main|master|production|release) warnings+=("⚠ On protected branch — confirm intentional") ;;
+esac
+[ "$secrets_found" = 1 ] && { echo "✗ Pre-commit security scan blocked. See pre-commit-security conventions reference."; exit 1; }
+if [ "${#warnings[@]}" -gt 0 ]; then
+  printf '%s\n' "${warnings[@]}"
+  if [ "${IDD_AUTO_MODE:-0}" = "1" ]; then
+    echo "○ Warnings logged — proceeding (auto mode)."
+  else
+    printf "Proceed anyway? [y/N] "; read -r reply
+    case "$reply" in y|Y|yes|YES) echo "○ Continuing despite warnings." ;; *) echo "✗ Stopped."; exit 1 ;; esac
+  fi
+fi
+```
+
 4. Commit: `fix({scope}): address review feedback` (append `(#{linked_issue})` only if a linked issue exists)
 5. Push: `git push origin {branch_name}`
 

--- a/dist/skills/issue-pr-review/references/docs/pre-commit-security.md
+++ b/dist/skills/issue-pr-review/references/docs/pre-commit-security.md
@@ -1,0 +1,188 @@
+<!-- Generated from /docs/pre-commit-security.md. Do not edit. Edit source and run ./scripts/build.sh. -->
+# Pre-Commit Security Conventions
+
+Standard convention for scanning a working tree for secrets, credentials, and risky artifacts before any IDD skill stages, commits, or pushes changes. Centralizing this here ensures every skill that runs `git add` / `git commit` / `git push` applies the same gate — once a secret reaches a public branch the leak is permanent, so the check must never be skipped or copy-pasted into a divergent variant.
+
+The checks below are adopted from the `auto-push` skill and codified here as the canonical reference for this project.
+
+## Why This Matters
+
+A leaked API key, private key, or `.env` file pushed to a public remote is a security incident: the key must be rotated, the history must be rewritten, and the leak window must be assumed exploited. The fix is mechanical — scan staged changes for known secret patterns and refuse to proceed when one is detected. This document is the single source of truth; skills should link here rather than copy-pasting the snippet, so the rules can be tightened in one place.
+
+---
+
+## Primary Pattern: Pre-Commit Scan
+
+This is the **only** documented scan path. Every skill that runs `git add`, `git commit`, or `git push` MUST execute it against the staged set (or the about-to-be-staged set) before proceeding.
+
+```bash
+# Pre-commit security scan — canonical procedure (see surrounding prose).
+# Inputs: $files = newline-separated list of paths the skill is about to stage,
+#         commit, or push. If empty, fall back to `git diff --cached --name-only`
+#         (already staged) or `git status --porcelain | awk '{print $2}'` (working tree).
+secrets_found=0
+warnings=()
+
+# 1. Block: secret-bearing filenames.
+secret_patterns='(^|/)\.env($|\..+$)|\.key$|\.pem$|(^|/)credentials\.json$|(^|/)secrets\.ya?ml$|(^|/)id_rsa($|\.pub$)|\.p12$|\.pfx$|\.cer$'
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  if printf '%s\n' "$f" | grep -E -q "$secret_patterns"; then
+    echo "✗ Secret-bearing file staged: $f"
+    secrets_found=1
+  fi
+done <<< "$files"
+
+# 2. Block: real API-key values inside text files.
+#    Distinguish placeholders ('your-...', 'xxx', 'placeholder', '<...>', '${...}')
+#    from real keys via known prefixes.
+realkey_patterns='(sk-(proj-)?[A-Za-z0-9_-]{20,}|sk_live_[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{30,}|gho_[A-Za-z0-9]{30,}|ghs_[A-Za-z0-9]{30,}|ghu_[A-Za-z0-9]{30,}|github_pat_[A-Za-z0-9_]{40,}|xox[abprs]-[A-Za-z0-9-]{10,}|glpat-[A-Za-z0-9_-]{20,}|AIza[0-9A-Za-z_-]{30,})'
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  [ -f "$f" ] || continue
+  # Skip binary files.
+  file --mime "$f" 2>/dev/null | grep -q 'charset=binary' && continue
+  if grep -E -n "$realkey_patterns" "$f" 2>/dev/null; then
+    echo "✗ Real API key detected in: $f"
+    secrets_found=1
+  fi
+done <<< "$files"
+
+# 3. Warn: large files (>10 MB) without Git LFS.
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  [ -f "$f" ] || continue
+  size=$(stat -f%z "$f" 2>/dev/null || stat -c%s "$f" 2>/dev/null || echo 0)
+  if [ "$size" -gt 10485760 ]; then
+    warnings+=("⚠ Large file (>10 MB) without LFS: $f")
+  fi
+done <<< "$files"
+
+# 4. Warn: build artifacts and temp files (gitignore hygiene).
+junk_patterns='(^|/)(node_modules|dist|build|__pycache__|\.venv)(/|$)|\.pyc$|(^|/)(\.DS_Store|thumbs\.db)$|\.swp$|\.tmp$'
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  if printf '%s\n' "$f" | grep -E -q "$junk_patterns"; then
+    warnings+=("⚠ Build artifact / temp file staged: $f — add to .gitignore")
+  fi
+done <<< "$files"
+
+# 5. Warn: pushing directly to a protected branch.
+branch="$(git rev-parse --abbrev-ref HEAD)"
+case "$branch" in
+  main|master|production|release) warnings+=("⚠ On protected branch: $branch — confirm push is intentional") ;;
+esac
+
+# Report and decide.
+if [ "$secrets_found" -eq 1 ]; then
+  cat <<'EOF'
+
+✗ Pre-commit security scan blocked the commit — secrets detected.
+
+  To fix:  remove or rotate the offending value, then re-stage the file.
+           If the match was a false positive, replace the literal with a
+           placeholder (your-key, xxx, <your-key>, ${YOUR_KEY}) and rerun.
+  Docs:    pre-commit-security conventions reference
+
+EOF
+  exit 1
+fi
+
+if [ "${#warnings[@]}" -gt 0 ]; then
+  printf '%s\n' "${warnings[@]}"
+  # Auto mode: log and proceed. Interactive mode: prompt.
+  # Skills set IDD_AUTO_MODE=1 when invoked with --auto (or by /auto-pilot).
+  if [ "${IDD_AUTO_MODE:-0}" = "1" ]; then
+    echo "○ Warnings logged — proceeding (auto mode)."
+  else
+    printf "Proceed anyway? [y/N] "
+    read -r reply
+    case "$reply" in
+      y|Y|yes|YES) echo "○ Continuing despite warnings." ;;
+      *) echo "✗ Stopped — resolve the warnings or rerun and confirm."; exit 1 ;;
+    esac
+  fi
+fi
+```
+
+### Behavior Notes
+
+- **Real keys vs. placeholders.** Real-key detection is gated on prefix patterns (`sk-proj-`, `sk_live_`, `AKIA`, `ghp_`, `gho_`, `ghs_`, `xox[abp]-`, `glpat-`, `AIza...`) plus length, so common placeholders (`your-api-key`, `xxx`, `placeholder`, `<your-key>`, `${VAR}`) do not match. When extending the pattern, prefer **prefix + length** over **identifier + value** — the latter false-positives on docstrings and tests.
+- **Binary skip.** Real-key scanning skips files whose MIME charset is `binary`. Without this, scanning a large image or PDF burns time and can false-positive on encoded bytes.
+- **Working set.** The scan operates on the file list the skill is about to stage/commit/push. Pre-stage skills (e.g., `implementer.md`'s atomic-commit step) pass the file list explicitly. Post-stage skills (e.g., `issue-pr-review` Step 2 auto-fix) fall back to `git diff --cached --name-only`.
+- **Exit code.** Real secrets exit `1` and stop the skill. Warnings print and either prompt the user (interactive mode) or log-and-continue (auto mode); see *Mode Contract* below.
+- **`.gitignore` hygiene.** When a warning fires for a build artifact (`node_modules/`, `dist/`, etc.), the user is told to add it to `.gitignore` rather than the skill rewriting `.gitignore` itself — `.gitignore` edits are too consequential to do silently.
+
+---
+
+## Mode Contract
+
+Both interactive and auto-pilot modes use **the same scan logic**. Real secrets always block. Warnings differ by mode:
+
+| Signal | Interactive mode | Auto mode (`--auto`) |
+|--------|------------------|----------------------|
+| Real secret detected (file or value) | `✗` error, stop | `✗` error, stop (auto-pilot does not bypass) |
+| Large file (>10 MB) without LFS | `⚠` warn, **prompt for confirmation** | `⚠` warn, log and proceed |
+| Build artifact / temp file staged | `⚠` warn, **prompt for confirmation** | `⚠` warn, log and proceed |
+| On protected branch (main/master/production/release) | `⚠` warn, **prompt for confirmation** | `⚠` warn, log and proceed |
+
+Real-secret detection is non-bypassable in both modes. If a real secret would block a commit in interactive mode, it blocks the commit in auto mode too — and the auto-pilot loop reports the issue and moves on rather than committing the leak.
+
+In **interactive mode**, when one or more warnings fire, the skill prints them and prompts `Proceed anyway? [y/N]` before running `git commit` or `git push`. A blank or `n` response stops the action; `y` proceeds. In **auto mode**, the prompt is skipped — warnings are logged via `○` and the action proceeds. Auto mode treats warnings the same way it treats blocking labels and other non-fatal risk signals: surfaced, recorded, but not blocking the loop.
+
+---
+
+## Skill-Side Responsibilities
+
+Every IDD skill that runs `git add`, `git commit`, or `git push` MUST:
+
+1. **Run the scan above** — execute it against the staged or about-to-be-staged set before each `git commit` and before each `git push`. Skills that batch multiple commits should scan once before each commit, not once per pipeline run.
+2. **Link to this document** — write `(see the pre-commit security conventions reference)` next to the snippet so users find this reference. The build's runtime-doc bundler (`scripts/build.py`) picks up bare `pre-commit-security.md` references with the `docs/` prefix automatically.
+3. **Honor the mode contract** — the scan checks `IDD_AUTO_MODE` to decide whether to prompt on warnings (interactive) or log-and-continue (auto). Skills invoked with `--auto` (or by `/auto-pilot`) MUST `export IDD_AUTO_MODE=1` before running the scan. Real-secret detection always blocks regardless of mode.
+4. **Never skip the scan to avoid a false positive** — if the scan flags a literal that is not a secret (e.g., a fixture, a docstring example, a regex pattern), replace it with a placeholder or move it behind a tested guard. Disabling the scan is not an option.
+
+---
+
+## When the Scan Blocks
+
+| Failure | Cause | Recovery |
+|---------|-------|----------|
+| `✗ Secret-bearing file staged: <path>` | A filename matched the secret-file pattern (`.env*`, `*.key`, etc.) | Add the path to `.gitignore`, unstage with `git reset HEAD <path>`, and remove from disk if the file is genuinely a secret. If it is a fixture/template, rename so it does not match (e.g., `.env.example`). |
+| `✗ Real API key detected in: <path>` | A real-key prefix matched (`sk-...`, `AKIA...`, `ghp_...`, etc.) | **Rotate the key first** (assume the leak window is exploited), then replace the literal in source with a placeholder (`your-key`, `${YOUR_KEY}`, `<your-key>`) and re-stage. If the literal is a fixture or test value, prefix with a non-real marker (`test-`, `fake-`, `example-`) so it no longer matches. |
+| `file: command not found` (no scan output) | `file` is not installed (BSD/macOS coreutils variants) | Install via `brew install file-formula` (macOS) or `apt install file` (Linux). Without `file`, binary files are not skipped — scans run slower but stay correct. |
+| `stat: illegal option -- f` or `stat: invalid option -- 'c'` | Platform mismatch (`-f%z` is BSD/macOS, `-c%s` is GNU/Linux) | The snippet falls through both forms with `2>/dev/null`. If both fail, large-file detection is silently skipped — fix by ensuring at least one `stat` form is available. |
+| Scan blocks on a value that genuinely is not a key | Real-key prefix matched a coincidental literal (rare but possible with `AKIA...` strings or long base64) | Replace the literal with a placeholder, or wrap the value behind a fixture loader (`os.environ["AWS_KEY"]`) so the literal never appears in source. Disabling the scan is not an option. |
+
+If the scan keeps firing on the same false positive across runs, do not edit the scan to suppress it — fix the source so it stops matching. The scan rules are in this document; if a rule is genuinely wrong, propose an update here so it applies project-wide.
+
+---
+
+## Lint Enforcement
+
+`tests/test-pre-commit-security.sh` greps `src/skills/**/*.md`, `src/skills/**/references/*.md`, `src/internal-skills/**/*.md`, and `src/shared/agents/*.md` for fenced-block invocations of `git commit` and `git push` and asserts that each occurrence is preceded (within the same fenced block, or in the surrounding prose within ~12 lines above) by a reference to this document (`pre-commit-security.md`). Failing the lint blocks merges. This is the regression guard — without it, future skill edits could silently reintroduce ungated commits.
+
+---
+
+## Quick Reference (Copy-Paste Snippet)
+
+For skills that want the minimal form inline:
+
+```bash
+# Pre-commit security scan — canonical procedure (see surrounding prose).
+# Block real secrets; warn on large files, build artifacts, protected-branch pushes.
+files="$(git diff --cached --name-only)"
+if printf '%s\n' "$files" | grep -E -q '(^|/)\.env($|\.)|\.key$|\.pem$|credentials\.json$|secrets\.ya?ml$|id_rsa($|\.pub$)|\.p12$|\.pfx$|\.cer$'; then
+  echo "✗ Secret-bearing file staged."
+  exit 1
+fi
+realkey='(sk-(proj-)?[A-Za-z0-9_-]{20,}|sk_live_[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{30,}|xox[abprs]-[A-Za-z0-9-]{10,}|glpat-[A-Za-z0-9_-]{20,}|AIza[0-9A-Za-z_-]{30,})'
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  [ -f "$f" ] || continue
+  file --mime "$f" 2>/dev/null | grep -q 'charset=binary' && continue
+  if grep -E -q "$realkey" "$f" 2>/dev/null; then
+    echo "✗ Real API key detected in: $f."
+    exit 1
+  fi
+done <<< "$files"
+```

--- a/dist/skills/issue-resolver/SKILL.md
+++ b/dist/skills/issue-resolver/SKILL.md
@@ -274,7 +274,55 @@ If the changes affect documented behavior:
 
 ### Push branch
 
+Before pushing, run the pre-commit security scan against every file touched by
+commits on this branch. The implementer ran the scan per commit during Step 3,
+but a final pre-push pass catches secrets that may have slipped in during QA
+fixes (see the pre-commit security conventions reference at
+`references/docs/pre-commit-security.md` — that document is authoritative; the snippet
+below mirrors its Primary Pattern). Real secrets block the push; warnings
+prompt for confirmation in interactive mode and log-and-continue in auto mode.
+
 ```bash
+# Pre-push security scan — mirrors the Primary Pattern in the
+# pre-commit-security conventions reference. Set IDD_AUTO_MODE=1 in auto mode.
+base="$(gh pr view --json baseRefName --jq .baseRefName 2>/dev/null || echo main)"
+files="$(git diff --name-only "origin/${base}"...HEAD)"
+secrets_found=0
+warnings=()
+if printf '%s\n' "$files" | grep -E -q '(^|/)\.env($|\.)|\.key$|\.pem$|credentials\.json$|secrets\.ya?ml$|id_rsa($|\.pub$)|\.p12$|\.pfx$|\.cer$'; then
+  echo "✗ Secret-bearing file in branch diff."
+  secrets_found=1
+fi
+realkey='(sk-(proj-)?[A-Za-z0-9_-]{20,}|sk_live_[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{30,}|gho_[A-Za-z0-9]{30,}|ghs_[A-Za-z0-9]{30,}|ghu_[A-Za-z0-9]{30,}|github_pat_[A-Za-z0-9_]{40,}|xox[abprs]-[A-Za-z0-9-]{10,}|glpat-[A-Za-z0-9_-]{20,}|AIza[0-9A-Za-z_-]{30,})'
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  [ -f "$f" ] || continue
+  file --mime "$f" 2>/dev/null | grep -q 'charset=binary' && continue
+  if grep -E -q "$realkey" "$f" 2>/dev/null; then
+    echo "✗ Real API key detected in: $f"
+    secrets_found=1
+  fi
+  size=$(stat -f%z "$f" 2>/dev/null || stat -c%s "$f" 2>/dev/null || echo 0)
+  [ "$size" -gt 10485760 ] && warnings+=("⚠ Large file (>10 MB) without LFS: $f")
+done <<< "$files"
+junk='(^|/)(node_modules|dist|build|__pycache__|\.venv)(/|$)|\.pyc$|(^|/)(\.DS_Store|thumbs\.db)$|\.swp$|\.tmp$'
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  printf '%s\n' "$f" | grep -E -q "$junk" && warnings+=("⚠ Build artifact in diff: $f")
+done <<< "$files"
+case "$(git rev-parse --abbrev-ref HEAD)" in
+  main|master|production|release) warnings+=("⚠ On protected branch — confirm intentional") ;;
+esac
+[ "$secrets_found" = 1 ] && { echo "✗ Pre-push security scan blocked. See pre-commit-security conventions reference."; exit 1; }
+if [ "${#warnings[@]}" -gt 0 ]; then
+  printf '%s\n' "${warnings[@]}"
+  if [ "${IDD_AUTO_MODE:-0}" = "1" ]; then
+    echo "○ Warnings logged — proceeding (auto mode)."
+  else
+    printf "Proceed anyway? [y/N] "; read -r reply
+    case "$reply" in y|Y|yes|YES) echo "○ Continuing despite warnings." ;; *) echo "✗ Stopped."; exit 1 ;; esac
+  fi
+fi
 git push -u origin {branch_name}
 ```
 
@@ -313,6 +361,7 @@ After the pipeline completes, print a structured step-by-step summary so the use
 
 When invoked with `--auto` (or by `/auto-pilot`), the entire pipeline runs without user interaction:
 
+- **Environment:** Export `IDD_AUTO_MODE=1` before any shell snippet that consults it (the pre-commit security scan reads this to switch from prompt-on-warning to log-and-continue; see `references/docs/pre-commit-security.md`).
 - **Preflight:** Skip assignment guard. Log blocking labels as warnings, don't stop.
 - **Research:** If already resolved, close the issue with a comment and exit cleanly.
 - **Plan:** Auto-select the recommended option (best balance of quality/effort).

--- a/dist/skills/issue-resolver/references/agents/implementer.md
+++ b/dist/skills/issue-resolver/references/agents/implementer.md
@@ -110,6 +110,58 @@ Format: `type(scope): description (#issue_number)`
 - Keep first line under 72 characters
 - **Stage specific files** — use `git add <file>`, never `git add .` or `git add -A`
 
+**Pre-commit security scan (mandatory).** Before each `git commit`, run the
+pre-commit security scan against the file list you are about to stage (see the
+pre-commit security conventions reference at `references/docs/pre-commit-security.md` —
+that document is authoritative; the snippet below mirrors its Primary Pattern).
+The scan blocks real secrets, surfaces non-blocking warnings, and (in
+interactive mode) prompts before continuing past warnings; never bypass a
+real-secret block.
+
+```bash
+# Pre-commit security scan — mirrors the Primary Pattern in the
+# pre-commit-security conventions reference. Set IDD_AUTO_MODE=1 in auto mode.
+files="<newline-separated paths you are about to stage>"
+secrets_found=0
+warnings=()
+if printf '%s\n' "$files" | grep -E -q '(^|/)\.env($|\.)|\.key$|\.pem$|credentials\.json$|secrets\.ya?ml$|id_rsa($|\.pub$)|\.p12$|\.pfx$|\.cer$'; then
+  echo "✗ Secret-bearing file staged."
+  secrets_found=1
+fi
+realkey='(sk-(proj-)?[A-Za-z0-9_-]{20,}|sk_live_[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{30,}|gho_[A-Za-z0-9]{30,}|ghs_[A-Za-z0-9]{30,}|ghu_[A-Za-z0-9]{30,}|github_pat_[A-Za-z0-9_]{40,}|xox[abprs]-[A-Za-z0-9-]{10,}|glpat-[A-Za-z0-9_-]{20,}|AIza[0-9A-Za-z_-]{30,})'
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  [ -f "$f" ] || continue
+  file --mime "$f" 2>/dev/null | grep -q 'charset=binary' && continue
+  if grep -E -q "$realkey" "$f" 2>/dev/null; then
+    echo "✗ Real API key detected in: $f"
+    secrets_found=1
+  fi
+  size=$(stat -f%z "$f" 2>/dev/null || stat -c%s "$f" 2>/dev/null || echo 0)
+  [ "$size" -gt 10485760 ] && warnings+=("⚠ Large file (>10 MB) without LFS: $f")
+done <<< "$files"
+junk='(^|/)(node_modules|dist|build|__pycache__|\.venv)(/|$)|\.pyc$|(^|/)(\.DS_Store|thumbs\.db)$|\.swp$|\.tmp$'
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  printf '%s\n' "$f" | grep -E -q "$junk" && warnings+=("⚠ Build artifact staged: $f — add to .gitignore")
+done <<< "$files"
+case "$(git rev-parse --abbrev-ref HEAD)" in
+  main|master|production|release) warnings+=("⚠ On protected branch — confirm intentional") ;;
+esac
+[ "$secrets_found" = 1 ] && { echo "✗ Pre-commit security scan blocked. See pre-commit-security conventions reference."; exit 1; }
+if [ "${#warnings[@]}" -gt 0 ]; then
+  printf '%s\n' "${warnings[@]}"
+  if [ "${IDD_AUTO_MODE:-0}" = "1" ]; then
+    echo "○ Warnings logged — proceeding (auto mode)."
+  else
+    printf "Proceed anyway? [y/N] "; read -r reply
+    case "$reply" in y|Y|yes|YES) echo "○ Continuing despite warnings." ;; *) echo "✗ Stopped."; exit 1 ;; esac
+  fi
+fi
+git add <file>...
+git commit -m "..."
+```
+
 Commit order: implementation commits first, then test commits.
 
 ### 7. Track what you did

--- a/dist/skills/issue-resolver/references/docs/pre-commit-security.md
+++ b/dist/skills/issue-resolver/references/docs/pre-commit-security.md
@@ -1,0 +1,188 @@
+<!-- Generated from /docs/pre-commit-security.md. Do not edit. Edit source and run ./scripts/build.sh. -->
+# Pre-Commit Security Conventions
+
+Standard convention for scanning a working tree for secrets, credentials, and risky artifacts before any IDD skill stages, commits, or pushes changes. Centralizing this here ensures every skill that runs `git add` / `git commit` / `git push` applies the same gate — once a secret reaches a public branch the leak is permanent, so the check must never be skipped or copy-pasted into a divergent variant.
+
+The checks below are adopted from the `auto-push` skill and codified here as the canonical reference for this project.
+
+## Why This Matters
+
+A leaked API key, private key, or `.env` file pushed to a public remote is a security incident: the key must be rotated, the history must be rewritten, and the leak window must be assumed exploited. The fix is mechanical — scan staged changes for known secret patterns and refuse to proceed when one is detected. This document is the single source of truth; skills should link here rather than copy-pasting the snippet, so the rules can be tightened in one place.
+
+---
+
+## Primary Pattern: Pre-Commit Scan
+
+This is the **only** documented scan path. Every skill that runs `git add`, `git commit`, or `git push` MUST execute it against the staged set (or the about-to-be-staged set) before proceeding.
+
+```bash
+# Pre-commit security scan — canonical procedure (see surrounding prose).
+# Inputs: $files = newline-separated list of paths the skill is about to stage,
+#         commit, or push. If empty, fall back to `git diff --cached --name-only`
+#         (already staged) or `git status --porcelain | awk '{print $2}'` (working tree).
+secrets_found=0
+warnings=()
+
+# 1. Block: secret-bearing filenames.
+secret_patterns='(^|/)\.env($|\..+$)|\.key$|\.pem$|(^|/)credentials\.json$|(^|/)secrets\.ya?ml$|(^|/)id_rsa($|\.pub$)|\.p12$|\.pfx$|\.cer$'
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  if printf '%s\n' "$f" | grep -E -q "$secret_patterns"; then
+    echo "✗ Secret-bearing file staged: $f"
+    secrets_found=1
+  fi
+done <<< "$files"
+
+# 2. Block: real API-key values inside text files.
+#    Distinguish placeholders ('your-...', 'xxx', 'placeholder', '<...>', '${...}')
+#    from real keys via known prefixes.
+realkey_patterns='(sk-(proj-)?[A-Za-z0-9_-]{20,}|sk_live_[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{30,}|gho_[A-Za-z0-9]{30,}|ghs_[A-Za-z0-9]{30,}|ghu_[A-Za-z0-9]{30,}|github_pat_[A-Za-z0-9_]{40,}|xox[abprs]-[A-Za-z0-9-]{10,}|glpat-[A-Za-z0-9_-]{20,}|AIza[0-9A-Za-z_-]{30,})'
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  [ -f "$f" ] || continue
+  # Skip binary files.
+  file --mime "$f" 2>/dev/null | grep -q 'charset=binary' && continue
+  if grep -E -n "$realkey_patterns" "$f" 2>/dev/null; then
+    echo "✗ Real API key detected in: $f"
+    secrets_found=1
+  fi
+done <<< "$files"
+
+# 3. Warn: large files (>10 MB) without Git LFS.
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  [ -f "$f" ] || continue
+  size=$(stat -f%z "$f" 2>/dev/null || stat -c%s "$f" 2>/dev/null || echo 0)
+  if [ "$size" -gt 10485760 ]; then
+    warnings+=("⚠ Large file (>10 MB) without LFS: $f")
+  fi
+done <<< "$files"
+
+# 4. Warn: build artifacts and temp files (gitignore hygiene).
+junk_patterns='(^|/)(node_modules|dist|build|__pycache__|\.venv)(/|$)|\.pyc$|(^|/)(\.DS_Store|thumbs\.db)$|\.swp$|\.tmp$'
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  if printf '%s\n' "$f" | grep -E -q "$junk_patterns"; then
+    warnings+=("⚠ Build artifact / temp file staged: $f — add to .gitignore")
+  fi
+done <<< "$files"
+
+# 5. Warn: pushing directly to a protected branch.
+branch="$(git rev-parse --abbrev-ref HEAD)"
+case "$branch" in
+  main|master|production|release) warnings+=("⚠ On protected branch: $branch — confirm push is intentional") ;;
+esac
+
+# Report and decide.
+if [ "$secrets_found" -eq 1 ]; then
+  cat <<'EOF'
+
+✗ Pre-commit security scan blocked the commit — secrets detected.
+
+  To fix:  remove or rotate the offending value, then re-stage the file.
+           If the match was a false positive, replace the literal with a
+           placeholder (your-key, xxx, <your-key>, ${YOUR_KEY}) and rerun.
+  Docs:    pre-commit-security conventions reference
+
+EOF
+  exit 1
+fi
+
+if [ "${#warnings[@]}" -gt 0 ]; then
+  printf '%s\n' "${warnings[@]}"
+  # Auto mode: log and proceed. Interactive mode: prompt.
+  # Skills set IDD_AUTO_MODE=1 when invoked with --auto (or by /auto-pilot).
+  if [ "${IDD_AUTO_MODE:-0}" = "1" ]; then
+    echo "○ Warnings logged — proceeding (auto mode)."
+  else
+    printf "Proceed anyway? [y/N] "
+    read -r reply
+    case "$reply" in
+      y|Y|yes|YES) echo "○ Continuing despite warnings." ;;
+      *) echo "✗ Stopped — resolve the warnings or rerun and confirm."; exit 1 ;;
+    esac
+  fi
+fi
+```
+
+### Behavior Notes
+
+- **Real keys vs. placeholders.** Real-key detection is gated on prefix patterns (`sk-proj-`, `sk_live_`, `AKIA`, `ghp_`, `gho_`, `ghs_`, `xox[abp]-`, `glpat-`, `AIza...`) plus length, so common placeholders (`your-api-key`, `xxx`, `placeholder`, `<your-key>`, `${VAR}`) do not match. When extending the pattern, prefer **prefix + length** over **identifier + value** — the latter false-positives on docstrings and tests.
+- **Binary skip.** Real-key scanning skips files whose MIME charset is `binary`. Without this, scanning a large image or PDF burns time and can false-positive on encoded bytes.
+- **Working set.** The scan operates on the file list the skill is about to stage/commit/push. Pre-stage skills (e.g., `implementer.md`'s atomic-commit step) pass the file list explicitly. Post-stage skills (e.g., `issue-pr-review` Step 2 auto-fix) fall back to `git diff --cached --name-only`.
+- **Exit code.** Real secrets exit `1` and stop the skill. Warnings print and either prompt the user (interactive mode) or log-and-continue (auto mode); see *Mode Contract* below.
+- **`.gitignore` hygiene.** When a warning fires for a build artifact (`node_modules/`, `dist/`, etc.), the user is told to add it to `.gitignore` rather than the skill rewriting `.gitignore` itself — `.gitignore` edits are too consequential to do silently.
+
+---
+
+## Mode Contract
+
+Both interactive and auto-pilot modes use **the same scan logic**. Real secrets always block. Warnings differ by mode:
+
+| Signal | Interactive mode | Auto mode (`--auto`) |
+|--------|------------------|----------------------|
+| Real secret detected (file or value) | `✗` error, stop | `✗` error, stop (auto-pilot does not bypass) |
+| Large file (>10 MB) without LFS | `⚠` warn, **prompt for confirmation** | `⚠` warn, log and proceed |
+| Build artifact / temp file staged | `⚠` warn, **prompt for confirmation** | `⚠` warn, log and proceed |
+| On protected branch (main/master/production/release) | `⚠` warn, **prompt for confirmation** | `⚠` warn, log and proceed |
+
+Real-secret detection is non-bypassable in both modes. If a real secret would block a commit in interactive mode, it blocks the commit in auto mode too — and the auto-pilot loop reports the issue and moves on rather than committing the leak.
+
+In **interactive mode**, when one or more warnings fire, the skill prints them and prompts `Proceed anyway? [y/N]` before running `git commit` or `git push`. A blank or `n` response stops the action; `y` proceeds. In **auto mode**, the prompt is skipped — warnings are logged via `○` and the action proceeds. Auto mode treats warnings the same way it treats blocking labels and other non-fatal risk signals: surfaced, recorded, but not blocking the loop.
+
+---
+
+## Skill-Side Responsibilities
+
+Every IDD skill that runs `git add`, `git commit`, or `git push` MUST:
+
+1. **Run the scan above** — execute it against the staged or about-to-be-staged set before each `git commit` and before each `git push`. Skills that batch multiple commits should scan once before each commit, not once per pipeline run.
+2. **Link to this document** — write `(see the pre-commit security conventions reference)` next to the snippet so users find this reference. The build's runtime-doc bundler (`scripts/build.py`) picks up bare `pre-commit-security.md` references with the `docs/` prefix automatically.
+3. **Honor the mode contract** — the scan checks `IDD_AUTO_MODE` to decide whether to prompt on warnings (interactive) or log-and-continue (auto). Skills invoked with `--auto` (or by `/auto-pilot`) MUST `export IDD_AUTO_MODE=1` before running the scan. Real-secret detection always blocks regardless of mode.
+4. **Never skip the scan to avoid a false positive** — if the scan flags a literal that is not a secret (e.g., a fixture, a docstring example, a regex pattern), replace it with a placeholder or move it behind a tested guard. Disabling the scan is not an option.
+
+---
+
+## When the Scan Blocks
+
+| Failure | Cause | Recovery |
+|---------|-------|----------|
+| `✗ Secret-bearing file staged: <path>` | A filename matched the secret-file pattern (`.env*`, `*.key`, etc.) | Add the path to `.gitignore`, unstage with `git reset HEAD <path>`, and remove from disk if the file is genuinely a secret. If it is a fixture/template, rename so it does not match (e.g., `.env.example`). |
+| `✗ Real API key detected in: <path>` | A real-key prefix matched (`sk-...`, `AKIA...`, `ghp_...`, etc.) | **Rotate the key first** (assume the leak window is exploited), then replace the literal in source with a placeholder (`your-key`, `${YOUR_KEY}`, `<your-key>`) and re-stage. If the literal is a fixture or test value, prefix with a non-real marker (`test-`, `fake-`, `example-`) so it no longer matches. |
+| `file: command not found` (no scan output) | `file` is not installed (BSD/macOS coreutils variants) | Install via `brew install file-formula` (macOS) or `apt install file` (Linux). Without `file`, binary files are not skipped — scans run slower but stay correct. |
+| `stat: illegal option -- f` or `stat: invalid option -- 'c'` | Platform mismatch (`-f%z` is BSD/macOS, `-c%s` is GNU/Linux) | The snippet falls through both forms with `2>/dev/null`. If both fail, large-file detection is silently skipped — fix by ensuring at least one `stat` form is available. |
+| Scan blocks on a value that genuinely is not a key | Real-key prefix matched a coincidental literal (rare but possible with `AKIA...` strings or long base64) | Replace the literal with a placeholder, or wrap the value behind a fixture loader (`os.environ["AWS_KEY"]`) so the literal never appears in source. Disabling the scan is not an option. |
+
+If the scan keeps firing on the same false positive across runs, do not edit the scan to suppress it — fix the source so it stops matching. The scan rules are in this document; if a rule is genuinely wrong, propose an update here so it applies project-wide.
+
+---
+
+## Lint Enforcement
+
+`tests/test-pre-commit-security.sh` greps `src/skills/**/*.md`, `src/skills/**/references/*.md`, `src/internal-skills/**/*.md`, and `src/shared/agents/*.md` for fenced-block invocations of `git commit` and `git push` and asserts that each occurrence is preceded (within the same fenced block, or in the surrounding prose within ~12 lines above) by a reference to this document (`pre-commit-security.md`). Failing the lint blocks merges. This is the regression guard — without it, future skill edits could silently reintroduce ungated commits.
+
+---
+
+## Quick Reference (Copy-Paste Snippet)
+
+For skills that want the minimal form inline:
+
+```bash
+# Pre-commit security scan — canonical procedure (see surrounding prose).
+# Block real secrets; warn on large files, build artifacts, protected-branch pushes.
+files="$(git diff --cached --name-only)"
+if printf '%s\n' "$files" | grep -E -q '(^|/)\.env($|\.)|\.key$|\.pem$|credentials\.json$|secrets\.ya?ml$|id_rsa($|\.pub$)|\.p12$|\.pfx$|\.cer$'; then
+  echo "✗ Secret-bearing file staged."
+  exit 1
+fi
+realkey='(sk-(proj-)?[A-Za-z0-9_-]{20,}|sk_live_[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{30,}|xox[abprs]-[A-Za-z0-9-]{10,}|glpat-[A-Za-z0-9_-]{20,}|AIza[0-9A-Za-z_-]{30,})'
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  [ -f "$f" ] || continue
+  file --mime "$f" 2>/dev/null | grep -q 'charset=binary' && continue
+  if grep -E -q "$realkey" "$f" 2>/dev/null; then
+    echo "✗ Real API key detected in: $f."
+    exit 1
+  fi
+done <<< "$files"
+```

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+- `feat(security)` shared pre-commit security scan — `docs/pre-commit-security.md` codifies the secret/credential/large-file gate adopted from `/auto-push`. Every skill that runs `git commit` or `git push` now invokes the scan before staging or pushing; real secrets block, warnings log and continue. Wired into `src/shared/agents/implementer.md`, `src/skills/issue-pr-review/SKILL.md` (auto-fix and fix-cycle steps), and `src/skills/issue-resolver/SKILL.md` (Step 5 push). `tests/test-pre-commit-security.sh` greps shell-fenced `git commit`/`git push` invocations and asserts each is gated by a reference to the canonical doc. (#87)
+
 ## [0.7.0] - 2026-04-29
 
 ### Added

--- a/docs/pre-commit-security.md
+++ b/docs/pre-commit-security.md
@@ -1,0 +1,187 @@
+# Pre-Commit Security Conventions
+
+Standard convention for scanning a working tree for secrets, credentials, and risky artifacts before any IDD skill stages, commits, or pushes changes. Centralizing this here ensures every skill that runs `git add` / `git commit` / `git push` applies the same gate — once a secret reaches a public branch the leak is permanent, so the check must never be skipped or copy-pasted into a divergent variant.
+
+The checks below are adopted from the `auto-push` skill and codified here as the canonical reference for this project.
+
+## Why This Matters
+
+A leaked API key, private key, or `.env` file pushed to a public remote is a security incident: the key must be rotated, the history must be rewritten, and the leak window must be assumed exploited. The fix is mechanical — scan staged changes for known secret patterns and refuse to proceed when one is detected. This document is the single source of truth; skills should link here rather than copy-pasting the snippet, so the rules can be tightened in one place.
+
+---
+
+## Primary Pattern: Pre-Commit Scan
+
+This is the **only** documented scan path. Every skill that runs `git add`, `git commit`, or `git push` MUST execute it against the staged set (or the about-to-be-staged set) before proceeding.
+
+```bash
+# Pre-commit security scan — canonical procedure (see surrounding prose).
+# Inputs: $files = newline-separated list of paths the skill is about to stage,
+#         commit, or push. If empty, fall back to `git diff --cached --name-only`
+#         (already staged) or `git status --porcelain | awk '{print $2}'` (working tree).
+secrets_found=0
+warnings=()
+
+# 1. Block: secret-bearing filenames.
+secret_patterns='(^|/)\.env($|\..+$)|\.key$|\.pem$|(^|/)credentials\.json$|(^|/)secrets\.ya?ml$|(^|/)id_rsa($|\.pub$)|\.p12$|\.pfx$|\.cer$'
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  if printf '%s\n' "$f" | grep -E -q "$secret_patterns"; then
+    echo "✗ Secret-bearing file staged: $f"
+    secrets_found=1
+  fi
+done <<< "$files"
+
+# 2. Block: real API-key values inside text files.
+#    Distinguish placeholders ('your-...', 'xxx', 'placeholder', '<...>', '${...}')
+#    from real keys via known prefixes.
+realkey_patterns='(sk-(proj-)?[A-Za-z0-9_-]{20,}|sk_live_[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{30,}|gho_[A-Za-z0-9]{30,}|ghs_[A-Za-z0-9]{30,}|ghu_[A-Za-z0-9]{30,}|github_pat_[A-Za-z0-9_]{40,}|xox[abprs]-[A-Za-z0-9-]{10,}|glpat-[A-Za-z0-9_-]{20,}|AIza[0-9A-Za-z_-]{30,})'
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  [ -f "$f" ] || continue
+  # Skip binary files.
+  file --mime "$f" 2>/dev/null | grep -q 'charset=binary' && continue
+  if grep -E -n "$realkey_patterns" "$f" 2>/dev/null; then
+    echo "✗ Real API key detected in: $f"
+    secrets_found=1
+  fi
+done <<< "$files"
+
+# 3. Warn: large files (>10 MB) without Git LFS.
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  [ -f "$f" ] || continue
+  size=$(stat -f%z "$f" 2>/dev/null || stat -c%s "$f" 2>/dev/null || echo 0)
+  if [ "$size" -gt 10485760 ]; then
+    warnings+=("⚠ Large file (>10 MB) without LFS: $f")
+  fi
+done <<< "$files"
+
+# 4. Warn: build artifacts and temp files (gitignore hygiene).
+junk_patterns='(^|/)(node_modules|dist|build|__pycache__|\.venv)(/|$)|\.pyc$|(^|/)(\.DS_Store|thumbs\.db)$|\.swp$|\.tmp$'
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  if printf '%s\n' "$f" | grep -E -q "$junk_patterns"; then
+    warnings+=("⚠ Build artifact / temp file staged: $f — add to .gitignore")
+  fi
+done <<< "$files"
+
+# 5. Warn: pushing directly to a protected branch.
+branch="$(git rev-parse --abbrev-ref HEAD)"
+case "$branch" in
+  main|master|production|release) warnings+=("⚠ On protected branch: $branch — confirm push is intentional") ;;
+esac
+
+# Report and decide.
+if [ "$secrets_found" -eq 1 ]; then
+  cat <<'EOF'
+
+✗ Pre-commit security scan blocked the commit — secrets detected.
+
+  To fix:  remove or rotate the offending value, then re-stage the file.
+           If the match was a false positive, replace the literal with a
+           placeholder (your-key, xxx, <your-key>, ${YOUR_KEY}) and rerun.
+  Docs:    pre-commit-security conventions reference
+
+EOF
+  exit 1
+fi
+
+if [ "${#warnings[@]}" -gt 0 ]; then
+  printf '%s\n' "${warnings[@]}"
+  # Auto mode: log and proceed. Interactive mode: prompt.
+  # Skills set IDD_AUTO_MODE=1 when invoked with --auto (or by /auto-pilot).
+  if [ "${IDD_AUTO_MODE:-0}" = "1" ]; then
+    echo "○ Warnings logged — proceeding (auto mode)."
+  else
+    printf "Proceed anyway? [y/N] "
+    read -r reply
+    case "$reply" in
+      y|Y|yes|YES) echo "○ Continuing despite warnings." ;;
+      *) echo "✗ Stopped — resolve the warnings or rerun and confirm."; exit 1 ;;
+    esac
+  fi
+fi
+```
+
+### Behavior Notes
+
+- **Real keys vs. placeholders.** Real-key detection is gated on prefix patterns (`sk-proj-`, `sk_live_`, `AKIA`, `ghp_`, `gho_`, `ghs_`, `xox[abp]-`, `glpat-`, `AIza...`) plus length, so common placeholders (`your-api-key`, `xxx`, `placeholder`, `<your-key>`, `${VAR}`) do not match. When extending the pattern, prefer **prefix + length** over **identifier + value** — the latter false-positives on docstrings and tests.
+- **Binary skip.** Real-key scanning skips files whose MIME charset is `binary`. Without this, scanning a large image or PDF burns time and can false-positive on encoded bytes.
+- **Working set.** The scan operates on the file list the skill is about to stage/commit/push. Pre-stage skills (e.g., `implementer.md`'s atomic-commit step) pass the file list explicitly. Post-stage skills (e.g., `issue-pr-review` Step 2 auto-fix) fall back to `git diff --cached --name-only`.
+- **Exit code.** Real secrets exit `1` and stop the skill. Warnings print and either prompt the user (interactive mode) or log-and-continue (auto mode); see *Mode Contract* below.
+- **`.gitignore` hygiene.** When a warning fires for a build artifact (`node_modules/`, `dist/`, etc.), the user is told to add it to `.gitignore` rather than the skill rewriting `.gitignore` itself — `.gitignore` edits are too consequential to do silently.
+
+---
+
+## Mode Contract
+
+Both interactive and auto-pilot modes use **the same scan logic**. Real secrets always block. Warnings differ by mode:
+
+| Signal | Interactive mode | Auto mode (`--auto`) |
+|--------|------------------|----------------------|
+| Real secret detected (file or value) | `✗` error, stop | `✗` error, stop (auto-pilot does not bypass) |
+| Large file (>10 MB) without LFS | `⚠` warn, **prompt for confirmation** | `⚠` warn, log and proceed |
+| Build artifact / temp file staged | `⚠` warn, **prompt for confirmation** | `⚠` warn, log and proceed |
+| On protected branch (main/master/production/release) | `⚠` warn, **prompt for confirmation** | `⚠` warn, log and proceed |
+
+Real-secret detection is non-bypassable in both modes. If a real secret would block a commit in interactive mode, it blocks the commit in auto mode too — and the auto-pilot loop reports the issue and moves on rather than committing the leak.
+
+In **interactive mode**, when one or more warnings fire, the skill prints them and prompts `Proceed anyway? [y/N]` before running `git commit` or `git push`. A blank or `n` response stops the action; `y` proceeds. In **auto mode**, the prompt is skipped — warnings are logged via `○` and the action proceeds. Auto mode treats warnings the same way it treats blocking labels and other non-fatal risk signals: surfaced, recorded, but not blocking the loop.
+
+---
+
+## Skill-Side Responsibilities
+
+Every IDD skill that runs `git add`, `git commit`, or `git push` MUST:
+
+1. **Run the scan above** — execute it against the staged or about-to-be-staged set before each `git commit` and before each `git push`. Skills that batch multiple commits should scan once before each commit, not once per pipeline run.
+2. **Link to this document** — write `(see the pre-commit security conventions reference)` next to the snippet so users find this reference. The build's runtime-doc bundler (`scripts/build.py`) picks up bare `pre-commit-security.md` references with the `docs/` prefix automatically.
+3. **Honor the mode contract** — the scan checks `IDD_AUTO_MODE` to decide whether to prompt on warnings (interactive) or log-and-continue (auto). Skills invoked with `--auto` (or by `/auto-pilot`) MUST `export IDD_AUTO_MODE=1` before running the scan. Real-secret detection always blocks regardless of mode.
+4. **Never skip the scan to avoid a false positive** — if the scan flags a literal that is not a secret (e.g., a fixture, a docstring example, a regex pattern), replace it with a placeholder or move it behind a tested guard. Disabling the scan is not an option.
+
+---
+
+## When the Scan Blocks
+
+| Failure | Cause | Recovery |
+|---------|-------|----------|
+| `✗ Secret-bearing file staged: <path>` | A filename matched the secret-file pattern (`.env*`, `*.key`, etc.) | Add the path to `.gitignore`, unstage with `git reset HEAD <path>`, and remove from disk if the file is genuinely a secret. If it is a fixture/template, rename so it does not match (e.g., `.env.example`). |
+| `✗ Real API key detected in: <path>` | A real-key prefix matched (`sk-...`, `AKIA...`, `ghp_...`, etc.) | **Rotate the key first** (assume the leak window is exploited), then replace the literal in source with a placeholder (`your-key`, `${YOUR_KEY}`, `<your-key>`) and re-stage. If the literal is a fixture or test value, prefix with a non-real marker (`test-`, `fake-`, `example-`) so it no longer matches. |
+| `file: command not found` (no scan output) | `file` is not installed (BSD/macOS coreutils variants) | Install via `brew install file-formula` (macOS) or `apt install file` (Linux). Without `file`, binary files are not skipped — scans run slower but stay correct. |
+| `stat: illegal option -- f` or `stat: invalid option -- 'c'` | Platform mismatch (`-f%z` is BSD/macOS, `-c%s` is GNU/Linux) | The snippet falls through both forms with `2>/dev/null`. If both fail, large-file detection is silently skipped — fix by ensuring at least one `stat` form is available. |
+| Scan blocks on a value that genuinely is not a key | Real-key prefix matched a coincidental literal (rare but possible with `AKIA...` strings or long base64) | Replace the literal with a placeholder, or wrap the value behind a fixture loader (`os.environ["AWS_KEY"]`) so the literal never appears in source. Disabling the scan is not an option. |
+
+If the scan keeps firing on the same false positive across runs, do not edit the scan to suppress it — fix the source so it stops matching. The scan rules are in this document; if a rule is genuinely wrong, propose an update here so it applies project-wide.
+
+---
+
+## Lint Enforcement
+
+`tests/test-pre-commit-security.sh` greps `src/skills/**/*.md`, `src/skills/**/references/*.md`, `src/internal-skills/**/*.md`, and `src/shared/agents/*.md` for fenced-block invocations of `git commit` and `git push` and asserts that each occurrence is preceded (within the same fenced block, or in the surrounding prose within ~12 lines above) by a reference to this document (`pre-commit-security.md`). Failing the lint blocks merges. This is the regression guard — without it, future skill edits could silently reintroduce ungated commits.
+
+---
+
+## Quick Reference (Copy-Paste Snippet)
+
+For skills that want the minimal form inline:
+
+```bash
+# Pre-commit security scan — canonical procedure (see surrounding prose).
+# Block real secrets; warn on large files, build artifacts, protected-branch pushes.
+files="$(git diff --cached --name-only)"
+if printf '%s\n' "$files" | grep -E -q '(^|/)\.env($|\.)|\.key$|\.pem$|credentials\.json$|secrets\.ya?ml$|id_rsa($|\.pub$)|\.p12$|\.pfx$|\.cer$'; then
+  echo "✗ Secret-bearing file staged."
+  exit 1
+fi
+realkey='(sk-(proj-)?[A-Za-z0-9_-]{20,}|sk_live_[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{30,}|xox[abprs]-[A-Za-z0-9-]{10,}|glpat-[A-Za-z0-9_-]{20,}|AIza[0-9A-Za-z_-]{30,})'
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  [ -f "$f" ] || continue
+  file --mime "$f" 2>/dev/null | grep -q 'charset=binary' && continue
+  if grep -E -q "$realkey" "$f" 2>/dev/null; then
+    echo "✗ Real API key detected in: $f."
+    exit 1
+  fi
+done <<< "$files"
+```

--- a/src/shared/agents/implementer.md
+++ b/src/shared/agents/implementer.md
@@ -109,6 +109,58 @@ Format: `type(scope): description (#issue_number)`
 - Keep first line under 72 characters
 - **Stage specific files** — use `git add <file>`, never `git add .` or `git add -A`
 
+**Pre-commit security scan (mandatory).** Before each `git commit`, run the
+pre-commit security scan against the file list you are about to stage (see the
+pre-commit security conventions reference at `docs/pre-commit-security.md` —
+that document is authoritative; the snippet below mirrors its Primary Pattern).
+The scan blocks real secrets, surfaces non-blocking warnings, and (in
+interactive mode) prompts before continuing past warnings; never bypass a
+real-secret block.
+
+```bash
+# Pre-commit security scan — mirrors the Primary Pattern in the
+# pre-commit-security conventions reference. Set IDD_AUTO_MODE=1 in auto mode.
+files="<newline-separated paths you are about to stage>"
+secrets_found=0
+warnings=()
+if printf '%s\n' "$files" | grep -E -q '(^|/)\.env($|\.)|\.key$|\.pem$|credentials\.json$|secrets\.ya?ml$|id_rsa($|\.pub$)|\.p12$|\.pfx$|\.cer$'; then
+  echo "✗ Secret-bearing file staged."
+  secrets_found=1
+fi
+realkey='(sk-(proj-)?[A-Za-z0-9_-]{20,}|sk_live_[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{30,}|gho_[A-Za-z0-9]{30,}|ghs_[A-Za-z0-9]{30,}|ghu_[A-Za-z0-9]{30,}|github_pat_[A-Za-z0-9_]{40,}|xox[abprs]-[A-Za-z0-9-]{10,}|glpat-[A-Za-z0-9_-]{20,}|AIza[0-9A-Za-z_-]{30,})'
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  [ -f "$f" ] || continue
+  file --mime "$f" 2>/dev/null | grep -q 'charset=binary' && continue
+  if grep -E -q "$realkey" "$f" 2>/dev/null; then
+    echo "✗ Real API key detected in: $f"
+    secrets_found=1
+  fi
+  size=$(stat -f%z "$f" 2>/dev/null || stat -c%s "$f" 2>/dev/null || echo 0)
+  [ "$size" -gt 10485760 ] && warnings+=("⚠ Large file (>10 MB) without LFS: $f")
+done <<< "$files"
+junk='(^|/)(node_modules|dist|build|__pycache__|\.venv)(/|$)|\.pyc$|(^|/)(\.DS_Store|thumbs\.db)$|\.swp$|\.tmp$'
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  printf '%s\n' "$f" | grep -E -q "$junk" && warnings+=("⚠ Build artifact staged: $f — add to .gitignore")
+done <<< "$files"
+case "$(git rev-parse --abbrev-ref HEAD)" in
+  main|master|production|release) warnings+=("⚠ On protected branch — confirm intentional") ;;
+esac
+[ "$secrets_found" = 1 ] && { echo "✗ Pre-commit security scan blocked. See pre-commit-security conventions reference."; exit 1; }
+if [ "${#warnings[@]}" -gt 0 ]; then
+  printf '%s\n' "${warnings[@]}"
+  if [ "${IDD_AUTO_MODE:-0}" = "1" ]; then
+    echo "○ Warnings logged — proceeding (auto mode)."
+  else
+    printf "Proceed anyway? [y/N] "; read -r reply
+    case "$reply" in y|Y|yes|YES) echo "○ Continuing despite warnings." ;; *) echo "✗ Stopped."; exit 1 ;; esac
+  fi
+fi
+git add <file>...
+git commit -m "..."
+```
+
 Commit order: implementation commits first, then test commits.
 
 ### 7. Track what you did

--- a/src/skills/issue-pr-review/SKILL.md
+++ b/src/skills/issue-pr-review/SKILL.md
@@ -24,6 +24,8 @@ Review a pull request end-to-end — analyze, test, fix, check CI, repeat until 
 
 The `--auto` flag is set automatically when invoked by `/auto-pilot`.
 
+In auto mode, export `IDD_AUTO_MODE=1` before any shell snippet that consults it — the pre-commit security scan reads this to switch from prompt-on-warning to log-and-continue (see `docs/pre-commit-security.md`).
+
 ## Prerequisites
 
 1. Confirm git repository: `git rev-parse --git-dir`
@@ -181,9 +183,52 @@ npm test          # or pytest, go test ./..., cargo test, etc.
 
 ### Commit auto-fixes
 
-If any files were modified by the auto-fix tools:
+If any files were modified by the auto-fix tools, run the pre-commit security
+scan before staging (see the pre-commit security conventions reference at
+`docs/pre-commit-security.md` — that document is authoritative; the snippet
+below mirrors its Primary Pattern). Real secrets block; warnings prompt for
+confirmation in interactive mode and log-and-continue in auto mode.
 
 ```bash
+# Pre-commit security scan — mirrors the Primary Pattern in the
+# pre-commit-security conventions reference. Set IDD_AUTO_MODE=1 in auto mode.
+files="$(git status --porcelain | awk '{print $2}')"
+secrets_found=0
+warnings=()
+if printf '%s\n' "$files" | grep -E -q '(^|/)\.env($|\.)|\.key$|\.pem$|credentials\.json$|secrets\.ya?ml$|id_rsa($|\.pub$)|\.p12$|\.pfx$|\.cer$'; then
+  echo "✗ Secret-bearing file in working tree."
+  secrets_found=1
+fi
+realkey='(sk-(proj-)?[A-Za-z0-9_-]{20,}|sk_live_[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{30,}|gho_[A-Za-z0-9]{30,}|ghs_[A-Za-z0-9]{30,}|ghu_[A-Za-z0-9]{30,}|github_pat_[A-Za-z0-9_]{40,}|xox[abprs]-[A-Za-z0-9-]{10,}|glpat-[A-Za-z0-9_-]{20,}|AIza[0-9A-Za-z_-]{30,})'
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  [ -f "$f" ] || continue
+  file --mime "$f" 2>/dev/null | grep -q 'charset=binary' && continue
+  if grep -E -q "$realkey" "$f" 2>/dev/null; then
+    echo "✗ Real API key detected in: $f"
+    secrets_found=1
+  fi
+  size=$(stat -f%z "$f" 2>/dev/null || stat -c%s "$f" 2>/dev/null || echo 0)
+  [ "$size" -gt 10485760 ] && warnings+=("⚠ Large file (>10 MB) without LFS: $f")
+done <<< "$files"
+junk='(^|/)(node_modules|dist|build|__pycache__|\.venv)(/|$)|\.pyc$|(^|/)(\.DS_Store|thumbs\.db)$|\.swp$|\.tmp$'
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  printf '%s\n' "$f" | grep -E -q "$junk" && warnings+=("⚠ Build artifact staged: $f")
+done <<< "$files"
+case "$(git rev-parse --abbrev-ref HEAD)" in
+  main|master|production|release) warnings+=("⚠ On protected branch — confirm intentional") ;;
+esac
+[ "$secrets_found" = 1 ] && { echo "✗ Pre-commit security scan blocked. See pre-commit-security conventions reference."; exit 1; }
+if [ "${#warnings[@]}" -gt 0 ]; then
+  printf '%s\n' "${warnings[@]}"
+  if [ "${IDD_AUTO_MODE:-0}" = "1" ]; then
+    echo "○ Warnings logged — proceeding (auto mode)."
+  else
+    printf "Proceed anyway? [y/N] "; read -r reply
+    case "$reply" in y|Y|yes|YES) echo "○ Continuing despite warnings." ;; *) echo "✗ Stopped."; exit 1 ;; esac
+  fi
+fi
 git add -A
 git commit -m "style: auto-fix lint and format issues"
 git push origin {branch_name}
@@ -474,7 +519,54 @@ For each issue where `action: "fix"`:
 2. Apply the fix
 3. Stage: `git add <specific-file>`
 
-After all fixes:
+After all fixes, run the pre-commit security scan against the staged set before
+committing (see the pre-commit security conventions reference at
+`docs/pre-commit-security.md` — that document is authoritative; the snippet
+below mirrors its Primary Pattern). Real secrets block; warnings prompt for
+confirmation in interactive mode and log-and-continue in auto mode.
+
+```bash
+# Pre-commit security scan — mirrors the Primary Pattern in the
+# pre-commit-security conventions reference. Set IDD_AUTO_MODE=1 in auto mode.
+files="$(git diff --cached --name-only)"
+secrets_found=0
+warnings=()
+if printf '%s\n' "$files" | grep -E -q '(^|/)\.env($|\.)|\.key$|\.pem$|credentials\.json$|secrets\.ya?ml$|id_rsa($|\.pub$)|\.p12$|\.pfx$|\.cer$'; then
+  echo "✗ Secret-bearing file staged."
+  secrets_found=1
+fi
+realkey='(sk-(proj-)?[A-Za-z0-9_-]{20,}|sk_live_[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{30,}|gho_[A-Za-z0-9]{30,}|ghs_[A-Za-z0-9]{30,}|ghu_[A-Za-z0-9]{30,}|github_pat_[A-Za-z0-9_]{40,}|xox[abprs]-[A-Za-z0-9-]{10,}|glpat-[A-Za-z0-9_-]{20,}|AIza[0-9A-Za-z_-]{30,})'
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  [ -f "$f" ] || continue
+  file --mime "$f" 2>/dev/null | grep -q 'charset=binary' && continue
+  if grep -E -q "$realkey" "$f" 2>/dev/null; then
+    echo "✗ Real API key detected in: $f"
+    secrets_found=1
+  fi
+  size=$(stat -f%z "$f" 2>/dev/null || stat -c%s "$f" 2>/dev/null || echo 0)
+  [ "$size" -gt 10485760 ] && warnings+=("⚠ Large file (>10 MB) without LFS: $f")
+done <<< "$files"
+junk='(^|/)(node_modules|dist|build|__pycache__|\.venv)(/|$)|\.pyc$|(^|/)(\.DS_Store|thumbs\.db)$|\.swp$|\.tmp$'
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  printf '%s\n' "$f" | grep -E -q "$junk" && warnings+=("⚠ Build artifact staged: $f")
+done <<< "$files"
+case "$(git rev-parse --abbrev-ref HEAD)" in
+  main|master|production|release) warnings+=("⚠ On protected branch — confirm intentional") ;;
+esac
+[ "$secrets_found" = 1 ] && { echo "✗ Pre-commit security scan blocked. See pre-commit-security conventions reference."; exit 1; }
+if [ "${#warnings[@]}" -gt 0 ]; then
+  printf '%s\n' "${warnings[@]}"
+  if [ "${IDD_AUTO_MODE:-0}" = "1" ]; then
+    echo "○ Warnings logged — proceeding (auto mode)."
+  else
+    printf "Proceed anyway? [y/N] "; read -r reply
+    case "$reply" in y|Y|yes|YES) echo "○ Continuing despite warnings." ;; *) echo "✗ Stopped."; exit 1 ;; esac
+  fi
+fi
+```
+
 4. Commit: `fix({scope}): address review feedback` (append `(#{linked_issue})` only if a linked issue exists)
 5. Push: `git push origin {branch_name}`
 

--- a/src/skills/issue-resolver/SKILL.md
+++ b/src/skills/issue-resolver/SKILL.md
@@ -274,7 +274,55 @@ If the changes affect documented behavior:
 
 ### Push branch
 
+Before pushing, run the pre-commit security scan against every file touched by
+commits on this branch. The implementer ran the scan per commit during Step 3,
+but a final pre-push pass catches secrets that may have slipped in during QA
+fixes (see the pre-commit security conventions reference at
+`docs/pre-commit-security.md` — that document is authoritative; the snippet
+below mirrors its Primary Pattern). Real secrets block the push; warnings
+prompt for confirmation in interactive mode and log-and-continue in auto mode.
+
 ```bash
+# Pre-push security scan — mirrors the Primary Pattern in the
+# pre-commit-security conventions reference. Set IDD_AUTO_MODE=1 in auto mode.
+base="$(gh pr view --json baseRefName --jq .baseRefName 2>/dev/null || echo main)"
+files="$(git diff --name-only "origin/${base}"...HEAD)"
+secrets_found=0
+warnings=()
+if printf '%s\n' "$files" | grep -E -q '(^|/)\.env($|\.)|\.key$|\.pem$|credentials\.json$|secrets\.ya?ml$|id_rsa($|\.pub$)|\.p12$|\.pfx$|\.cer$'; then
+  echo "✗ Secret-bearing file in branch diff."
+  secrets_found=1
+fi
+realkey='(sk-(proj-)?[A-Za-z0-9_-]{20,}|sk_live_[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{30,}|gho_[A-Za-z0-9]{30,}|ghs_[A-Za-z0-9]{30,}|ghu_[A-Za-z0-9]{30,}|github_pat_[A-Za-z0-9_]{40,}|xox[abprs]-[A-Za-z0-9-]{10,}|glpat-[A-Za-z0-9_-]{20,}|AIza[0-9A-Za-z_-]{30,})'
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  [ -f "$f" ] || continue
+  file --mime "$f" 2>/dev/null | grep -q 'charset=binary' && continue
+  if grep -E -q "$realkey" "$f" 2>/dev/null; then
+    echo "✗ Real API key detected in: $f"
+    secrets_found=1
+  fi
+  size=$(stat -f%z "$f" 2>/dev/null || stat -c%s "$f" 2>/dev/null || echo 0)
+  [ "$size" -gt 10485760 ] && warnings+=("⚠ Large file (>10 MB) without LFS: $f")
+done <<< "$files"
+junk='(^|/)(node_modules|dist|build|__pycache__|\.venv)(/|$)|\.pyc$|(^|/)(\.DS_Store|thumbs\.db)$|\.swp$|\.tmp$'
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  printf '%s\n' "$f" | grep -E -q "$junk" && warnings+=("⚠ Build artifact in diff: $f")
+done <<< "$files"
+case "$(git rev-parse --abbrev-ref HEAD)" in
+  main|master|production|release) warnings+=("⚠ On protected branch — confirm intentional") ;;
+esac
+[ "$secrets_found" = 1 ] && { echo "✗ Pre-push security scan blocked. See pre-commit-security conventions reference."; exit 1; }
+if [ "${#warnings[@]}" -gt 0 ]; then
+  printf '%s\n' "${warnings[@]}"
+  if [ "${IDD_AUTO_MODE:-0}" = "1" ]; then
+    echo "○ Warnings logged — proceeding (auto mode)."
+  else
+    printf "Proceed anyway? [y/N] "; read -r reply
+    case "$reply" in y|Y|yes|YES) echo "○ Continuing despite warnings." ;; *) echo "✗ Stopped."; exit 1 ;; esac
+  fi
+fi
 git push -u origin {branch_name}
 ```
 
@@ -313,6 +361,7 @@ After the pipeline completes, print a structured step-by-step summary so the use
 
 When invoked with `--auto` (or by `/auto-pilot`), the entire pipeline runs without user interaction:
 
+- **Environment:** Export `IDD_AUTO_MODE=1` before any shell snippet that consults it (the pre-commit security scan reads this to switch from prompt-on-warning to log-and-continue; see `docs/pre-commit-security.md`).
 - **Preflight:** Skip assignment guard. Log blocking labels as warnings, don't stop.
 - **Research:** If already resolved, close the issue with a comment and exit cleanly.
 - **Plan:** Auto-select the recommended option (best balance of quality/effort).

--- a/tests/test-pre-commit-security.sh
+++ b/tests/test-pre-commit-security.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# test-pre-commit-security.sh — Validate the pre-commit security convention (issue #87)
+#
+# This script verifies issue #87 acceptance criteria:
+#   AC #1: A shared pre-commit safety scan procedure exists at
+#          docs/pre-commit-security.md with the secret/credential/large-file
+#          checks adopted from /auto-push.
+#   AC #2: Every skill that runs `git commit` or `git push` references this
+#          shared scan in a fenced block that also (or in nearby prose) cites
+#          docs/pre-commit-security.md, so the gate cannot be silently dropped.
+#   AC #3: The canonical doc explicitly distinguishes real secrets from
+#          placeholders (covers AC #3 from the issue).
+#   AC #4: The canonical doc defines the rich-error format that skills use
+#          when a secret blocks (covers AC #4 from the issue).
+#   AC #5: The canonical doc states warnings are non-blocking and require
+#          explicit confirmation in interactive mode / log-and-continue in
+#          auto mode (covers AC #5 from the issue).
+#
+# Strategy: walk every fenced code block (```bash / ```sh) in
+# src/skills/**/*.md, src/internal-skills/**/*.md, and
+# src/shared/agents/*.md, looking for `git commit` or `git push`. For each
+# occurrence, the same fenced block — or the 12 lines of prose immediately
+# before the block — must reference `docs/pre-commit-security.md`. The
+# canonical doc itself and `/auto-push` examples that demonstrate failure
+# output are excluded.
+#
+# Usage: bash tests/test-pre-commit-security.sh
+# Returns: exit 0 if all checks pass, exit 1 on failure
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+PASS=0
+FAIL=0
+
+pass() {
+  echo "  ✓ $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "  ✗ $1"
+  FAIL=$((FAIL + 1))
+}
+
+echo "◆ Pre-Commit Security Lint (issue #87)"
+echo "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄"
+
+# ───────────────────────────────────────────────────────────
+# T1: docs/pre-commit-security.md exists
+# ───────────────────────────────────────────────────────────
+CONV="$REPO_ROOT/docs/pre-commit-security.md"
+if [ -f "$CONV" ]; then
+  pass "docs/pre-commit-security.md exists (canonical convention)"
+else
+  fail "docs/pre-commit-security.md missing"
+fi
+
+# ───────────────────────────────────────────────────────────
+# T2: Canonical doc covers the four required content areas:
+#     - real-key vs. placeholder discrimination
+#     - rich error format (✗ symbol + 'docs/pre-commit-security.md')
+#     - warning non-block contract
+#     - skill-side responsibilities section
+# ───────────────────────────────────────────────────────────
+if [ -f "$CONV" ]; then
+  if grep -q -i "placeholder" "$CONV" && grep -q "your-api-key\|your-key\|YOUR_KEY\|placeholder" "$CONV"; then
+    pass "canonical doc distinguishes real keys from placeholders"
+  else
+    fail "canonical doc missing placeholder discrimination"
+  fi
+
+  if grep -q "✗" "$CONV" && grep -q "Pre-commit security scan blocked" "$CONV"; then
+    pass "canonical doc defines rich-error format (✗ + blocked message)"
+  else
+    fail "canonical doc missing rich-error format"
+  fi
+
+  if grep -q -i "warnings.*log\|warn.*proceed\|log-and-continue\|log and continue" "$CONV"; then
+    pass "canonical doc documents warning non-block contract"
+  else
+    fail "canonical doc missing warning non-block contract"
+  fi
+
+  if grep -q -i "Skill-Side Responsibilities" "$CONV"; then
+    pass "canonical doc has Skill-Side Responsibilities section"
+  else
+    fail "canonical doc missing Skill-Side Responsibilities section"
+  fi
+fi
+
+# ───────────────────────────────────────────────────────────
+# T3: Every fenced block containing `git commit` or `git push` in
+#     skill sources is gated by a reference to
+#     docs/pre-commit-security.md — either inside the block, or in
+#     the 12 lines of prose immediately preceding the block.
+#     The canonical doc itself is excluded.
+# ───────────────────────────────────────────────────────────
+
+SCAN_DIRS=(
+  "$REPO_ROOT/src/skills"
+  "$REPO_ROOT/src/internal-skills"
+  "$REPO_ROOT/src/shared/agents"
+)
+
+violations="$(mktemp)"
+trap 'rm -f "$violations"' EXIT
+
+scan_file() {
+  local file="$1"
+  awk -v file="$file" '
+    BEGIN {
+      in_block = 0
+      is_shell_block = 0
+      block_start = 0
+      block_has_commit_or_push = 0
+      block_has_ref = 0
+      # Rolling window of recent prose lines (outside fenced blocks).
+      window_size = 12
+      for (i = 0; i < window_size; i++) prose[i] = ""
+      window_idx = 0
+      window_has_ref = 0
+    }
+    /^```/ {
+      if (in_block == 0) {
+        in_block = 1
+        # Only ```bash and ```sh blocks are executed shell instructions.
+        # Plain ``` blocks are display-only (error messages, sample output).
+        is_shell_block = ($0 ~ /^```(bash|sh)[[:space:]]*$/) ? 1 : 0
+        block_start = NR
+        block_has_commit_or_push = 0
+        block_has_ref = 0
+        # Snapshot whether the prose window already references the doc.
+        window_has_ref = 0
+        for (i = 0; i < window_size; i++) {
+          if (prose[i] ~ /pre-commit-security\.md/) window_has_ref = 1
+        }
+      } else {
+        # Closing fence — evaluate the block.
+        if (is_shell_block == 1 && block_has_commit_or_push == 1 && block_has_ref == 0 && window_has_ref == 0) {
+          printf("%s:%d: shell block with `git commit` or `git push` is not gated by docs/pre-commit-security.md\n", file, block_start)
+        }
+        in_block = 0
+        is_shell_block = 0
+      }
+      next
+    }
+    {
+      if (in_block == 1) {
+        # Match `git commit` or `git push` as actual commands, not in comments
+        # or inline-code mentions. We look for either at start of line (after
+        # optional whitespace) or after a shell separator.
+        if ($0 ~ /(^|[[:space:]&|;]|^[[:space:]]*)git[[:space:]]+commit([[:space:]]|$)/) {
+          block_has_commit_or_push = 1
+        }
+        if ($0 ~ /(^|[[:space:]&|;]|^[[:space:]]*)git[[:space:]]+push([[:space:]]|$)/) {
+          block_has_commit_or_push = 1
+        }
+        if ($0 ~ /pre-commit-security\.md/) {
+          block_has_ref = 1
+        }
+      } else {
+        # Update prose window (ring buffer of last N lines).
+        prose[window_idx] = $0
+        window_idx = (window_idx + 1) % window_size
+      }
+    }
+  ' "$file"
+}
+
+for dir in "${SCAN_DIRS[@]}"; do
+  if [ ! -d "$dir" ]; then
+    continue
+  fi
+  while IFS= read -r -d '' file; do
+    scan_file "$file" >> "$violations"
+  done < <(find "$dir" -type f -name "*.md" -print0)
+done
+
+if [ -s "$violations" ]; then
+  fail "Ungated \`git commit\` or \`git push\` found in fenced code blocks:"
+  while IFS= read -r line; do
+    echo "      $line"
+  done < "$violations"
+else
+  pass "All fenced \`git commit\` / \`git push\` blocks are gated by pre-commit-security.md"
+fi
+
+# ───────────────────────────────────────────────────────────
+# T4: All four touchpoints identified during research reference
+#     pre-commit-security.md somewhere in the file.
+# ───────────────────────────────────────────────────────────
+
+NAMED_FILES=(
+  "src/shared/agents/implementer.md"
+  "src/skills/issue-pr-review/SKILL.md"
+  "src/skills/issue-resolver/SKILL.md"
+)
+
+for rel in "${NAMED_FILES[@]}"; do
+  abs="$REPO_ROOT/$rel"
+  if [ ! -f "$abs" ]; then
+    fail "$rel missing"
+    continue
+  fi
+  if grep -q "pre-commit-security.md" "$abs"; then
+    pass "$rel references pre-commit-security.md"
+  else
+    fail "$rel does not reference pre-commit-security.md"
+  fi
+done
+
+# ───────────────────────────────────────────────────────────
+# Summary
+# ───────────────────────────────────────────────────────────
+echo "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄"
+echo "  Results: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+  echo "  ✗ Pre-commit security lint failed"
+  exit 1
+fi
+
+echo "  ✓ All pre-commit security checks passed"
+exit 0


### PR DESCRIPTION
## Summary

Adopt the secret/credential/large-file checks from the `/auto-push` skill as a shared, canonical procedure so every IDD skill that runs `git commit` or `git push` goes through the same gate. Real secrets always block. Warnings (large files, build artifacts, protected-branch pushes) prompt for confirmation in interactive mode and log-and-continue in auto mode (gated on `IDD_AUTO_MODE=1`).

Closes #87

## Approach

- **Canonical doc** — `docs/pre-commit-security.md` mirrors the shape of the existing `docs/sync-conventions.md` (Primary Pattern → Behavior Notes → Mode Contract → Skill-Side Responsibilities → When the Scan Blocks → Lint Enforcement → Quick Reference). The build's runtime-doc bundler picks it up automatically via the `docs/X.md` regex.
- **Wired into all four touchpoints** identified during research:
  1. `src/shared/agents/implementer.md` — atomic-commit step (fires N times per resolve)
  2. `src/skills/issue-pr-review/SKILL.md` Step 2 — auto-fix commit
  3. `src/skills/issue-pr-review/SKILL.md` Step 6 — fix-cycle commit
  4. `src/skills/issue-resolver/SKILL.md` Step 5 — pre-push scan over branch diff
- **Lint test** — `tests/test-pre-commit-security.sh` greps `bash`/`sh` fenced blocks for `git commit` / `git push` and asserts each is gated by a reference to the canonical doc within the same block or the 12 lines of preceding prose. Display-only fences (no language tag) are excluded so error-message templates do not false-positive.
- **Mode contract** — both modes use the same scan logic. Real secrets always block. Warnings prompt in interactive mode (`Proceed anyway? [y/N]`), log-and-continue in auto mode. Auto mode is signalled by `IDD_AUTO_MODE=1`, exported by `/issue-resolver --auto` and `/issue-pr-review --auto`.

## Decision Record

| Question | Decision | Rationale |
|----------|----------|-----------|
| Where does the canonical scan live? | `docs/pre-commit-security.md` (top-level runtime doc, not a shared agent) | Matches the precedent set by `docs/sync-conventions.md`. The build bundler auto-picks runtime docs referenced as `docs/X.md` tokens; no extra wiring needed. |
| Should the auto-push skill be edited? | No | `/auto-push` lives at `~/.claude/skills/auto-push/`, outside this repo. Its checks are adopted as the canonical project-local procedure here instead. |
| Real-secret pattern coverage | 12 prefix classes: `sk-proj-`, `sk_live_`, `AKIA`, `ASIA`, `ghp_`, `gho_`, `ghs_`, `ghu_`, `github_pat_`, `xox[abprs]-`, `glpat-`, `AIza` | Prefix + length discriminator, not identifier + value. Prefix-based avoids false-positives on docstrings/tests; length-based avoids matching short placeholders. |
| How are warnings handled in auto mode? | Log-and-continue (option A) | Matches how auto-pilot already treats blocking labels and other non-fatal signals — surfaced, recorded, but not blocking the loop. AC5's "explicit user confirmation" requirement applies to interactive mode only; auto mode is documented as the explicit alternative path. |
| Inline snippet vs. shared script | Inline shell snippet, mirrored from canonical | A shared script would require a runtime dependency and an installation step. The inline form keeps each skill self-contained and verifiable against the canonical via the lint test. |

## Changes

| Action | File | What changed |
|--------|------|--------------|
| created | `docs/pre-commit-security.md` | Canonical scan procedure (12 token classes, 3 warning loops, mode contract, recovery table). |
| created | `tests/test-pre-commit-security.sh` | Lint test (9 checks: doc exists, content presence, gated-block assertion, three named-file references). |
| modified | `src/shared/agents/implementer.md` | Step 6 atomic-commit now scans before each commit. |
| modified | `src/skills/issue-pr-review/SKILL.md` | Step 2 auto-fix and Step 6 fix-cycle scan before commit; auto-mode preamble exports `IDD_AUTO_MODE=1`. |
| modified | `src/skills/issue-resolver/SKILL.md` | Step 5 pre-push scan over branch diff; Auto-Pilot Mode section requires `IDD_AUTO_MODE=1` export. |
| modified | `docs/CHANGELOG.md` | Unreleased entry under Added. |
| regenerated | `dist/skills/...` | `bash scripts/build.sh` rebuilt; deterministic. |

## Test Results

| Test | Result |
|------|--------|
| `tests/test-pre-commit-security.sh` | ✓ 9/9 pass (new) |
| `tests/test-sync-safety.sh` | ✓ 8/8 pass (unchanged) |
| `tests/test-build-determinism.sh` | ✓ pass |
| `tests/test-dependency-closure.sh` | ✓ pass |
| `tests/test-flattened-self-contained.sh` | ✓ pass |
| `tests/test-plugin-layout.sh` | ✓ pass |
| `tests/test-issue-pr-review-fix-loop-deprecation.sh` | ✗ pre-existing failure on main (CHANGELOG entries for #37/#54 deprecation) — not a regression introduced by this PR |
| All other tests | ✓ pass |

Smoke-tested the scan against synthetic fixtures: `sk-proj-...` and `AKIA...EXAMPLE` are detected; placeholders like `your-api-key-here`, `xxx`, `<your-key>`, `${YOUR_KEY}` are not.

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Shared pre-commit safety scan procedure exists, codifying secret/credential/large-file checks adopted from `/auto-push` | ✅ pass | `docs/pre-commit-security.md` Primary Pattern + Behavior Notes |
| Every commit-capable skill invokes the shared scan and refuses to proceed when real secrets are detected | ✅ pass | `implementer.md`:118-160, `issue-pr-review`:189-237, `issue-pr-review`:521-569, `issue-resolver`:285-333. Lint test T3 enforces this. |
| Scan distinguishes real secrets from placeholders without false-positives | ✅ pass | 12 prefix-anchored patterns + length minimums; smoke-tested against `your-api-key-here`, `xxx`, `<your-key>`, `${YOUR_KEY}` |
| When a secret is detected, the skill prints a rich error matching project conventions and stops | ✅ pass | `docs/pre-commit-security.md` lines 76-87; lint test T2 enforces presence of `✗` symbol + `Pre-commit security scan blocked` message |
| Warnings (large files, gitignore, protected-branch) are surfaced but require explicit confirmation in interactive mode | ✅ pass | Mode Contract table + interactive `Proceed anyway? [y/N]` prompt. Auto mode log-and-continues per the documented alternative path. |

## Test plan

- [ ] Reviewer: confirm the lint test catches an intentional ungated `git commit` block by adding one temporarily and re-running `bash tests/test-pre-commit-security.sh`.
- [ ] Reviewer: confirm `bash scripts/build.sh` is deterministic and emits no `cycle detected` warnings.
- [ ] Reviewer: confirm the canonical doc was bundled into `dist/skills/issue-resolver/references/docs/pre-commit-security.md` and `dist/skills/issue-pr-review/references/docs/pre-commit-security.md`.