### PR TITLE
feat(issue-pr-review): exempt refactor/chore PRs from Closes #N traceability check (#91)

### DIFF
--- a/dist/skills/auto-pilot/references/docs/config-schema.md
+++ b/dist/skills/auto-pilot/references/docs/config-schema.md
@@ -198,6 +198,28 @@ review:
   # contract from issue #36.
   require_traceability_check: true
 
+  # PR labels that exempt a PR from the `Closes #N` hard-fail (check 1 only).
+  # Type: list of strings (label names — exact, case-sensitive match)
+  # Default: ["refactor", "chore"]
+  # When the PR carries any label in this list, /issue-pr-review skips the
+  # `Closes #N` check and reports `traceability: pass — exempt`. The other
+  # three traceability checks (commit reference, Decision Record, Acceptance
+  # Criteria Verification block) still run and report `partial` if absent.
+  # Set to [] to disable label-based exemption (see also traceability_exempt_pattern).
+  traceability_exempt_labels:
+    - refactor
+    - chore
+
+  # PR-body pattern that exempts a PR from the `Closes #N` hard-fail (check 1 only).
+  # Type: string (regex, multiline-anchored, case-insensitive)
+  # Default: "^\\s*Type:\\s*(refactor|chore)\\s*$"
+  # When the PR body contains a line matching this pattern, /issue-pr-review
+  # skips the `Closes #N` check and reports `traceability: pass — exempt`. The
+  # other three traceability checks still run.
+  # Set to "" to disable pattern-based exemption. Setting both this and
+  # traceability_exempt_labels to empty restores strict issue #36 behavior.
+  traceability_exempt_pattern: "^\\s*Type:\\s*(refactor|chore)\\s*$"
+
 # Auto-pilot settings (used by /auto-pilot)
 autopilot:
   # Merge mode — controls when /auto-pilot is allowed to merge PRs.
@@ -388,6 +410,8 @@ graph TD
     RV --> RV9["soft_pass"]
     RV --> RV10["require_acceptance_criteria_check"]
     RV --> RV11["require_traceability_check"]
+    RV --> RV12["traceability_exempt_labels"]
+    RV --> RV13["traceability_exempt_pattern"]
 
     AP --> AP0["mode"]
     AP --> AP00["merge_partial"]
@@ -470,6 +494,8 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `review.soft_pass` | `true` | Treat soft-pass as pass |
 | `review.require_acceptance_criteria_check` | `true` | Run per-criterion acceptance-criteria verification; `fail` blocks soft-pass |
 | `review.require_traceability_check` | `true` | Run the four traceability checks; missing `Closes #N` blocks soft-pass |
+| `review.traceability_exempt_labels` | `["refactor", "chore"]` | PR labels that exempt a PR from the `Closes #N` hard-fail (check 1 only; other three checks still run) |
+| `review.traceability_exempt_pattern` | `"^\\s*Type:\\s*(refactor\|chore)\\s*$"` | Regex (multiline, case-insensitive) matched against PR body for exemption from check 1 |
 | `autopilot.mode` | `conservative` | Merge mode: `conservative` (never merge), `balanced` (merge clean PRs), `aggressive` (merge clean + partial w/ `merge_partial: true`) |
 | `autopilot.merge_partial` | `false` | Allow merging PRs with unresolved review issues. Only honored when `mode: aggressive` |
 | `autopilot.max_iterations` | `10` | Max issues to process |

--- a/dist/skills/init-gitissue/references/docs/config-schema.md
+++ b/dist/skills/init-gitissue/references/docs/config-schema.md
@@ -198,6 +198,28 @@ review:
   # contract from issue #36.
   require_traceability_check: true
 
+  # PR labels that exempt a PR from the `Closes #N` hard-fail (check 1 only).
+  # Type: list of strings (label names — exact, case-sensitive match)
+  # Default: ["refactor", "chore"]
+  # When the PR carries any label in this list, /issue-pr-review skips the
+  # `Closes #N` check and reports `traceability: pass — exempt`. The other
+  # three traceability checks (commit reference, Decision Record, Acceptance
+  # Criteria Verification block) still run and report `partial` if absent.
+  # Set to [] to disable label-based exemption (see also traceability_exempt_pattern).
+  traceability_exempt_labels:
+    - refactor
+    - chore
+
+  # PR-body pattern that exempts a PR from the `Closes #N` hard-fail (check 1 only).
+  # Type: string (regex, multiline-anchored, case-insensitive)
+  # Default: "^\\s*Type:\\s*(refactor|chore)\\s*$"
+  # When the PR body contains a line matching this pattern, /issue-pr-review
+  # skips the `Closes #N` check and reports `traceability: pass — exempt`. The
+  # other three traceability checks still run.
+  # Set to "" to disable pattern-based exemption. Setting both this and
+  # traceability_exempt_labels to empty restores strict issue #36 behavior.
+  traceability_exempt_pattern: "^\\s*Type:\\s*(refactor|chore)\\s*$"
+
 # Auto-pilot settings (used by /auto-pilot)
 autopilot:
   # Merge mode — controls when /auto-pilot is allowed to merge PRs.
@@ -388,6 +410,8 @@ graph TD
     RV --> RV9["soft_pass"]
     RV --> RV10["require_acceptance_criteria_check"]
     RV --> RV11["require_traceability_check"]
+    RV --> RV12["traceability_exempt_labels"]
+    RV --> RV13["traceability_exempt_pattern"]
 
     AP --> AP0["mode"]
     AP --> AP00["merge_partial"]
@@ -470,6 +494,8 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `review.soft_pass` | `true` | Treat soft-pass as pass |
 | `review.require_acceptance_criteria_check` | `true` | Run per-criterion acceptance-criteria verification; `fail` blocks soft-pass |
 | `review.require_traceability_check` | `true` | Run the four traceability checks; missing `Closes #N` blocks soft-pass |
+| `review.traceability_exempt_labels` | `["refactor", "chore"]` | PR labels that exempt a PR from the `Closes #N` hard-fail (check 1 only; other three checks still run) |
+| `review.traceability_exempt_pattern` | `"^\\s*Type:\\s*(refactor\|chore)\\s*$"` | Regex (multiline, case-insensitive) matched against PR body for exemption from check 1 |
 | `autopilot.mode` | `conservative` | Merge mode: `conservative` (never merge), `balanced` (merge clean PRs), `aggressive` (merge clean + partial w/ `merge_partial: true`) |
 | `autopilot.merge_partial` | `false` | Allow merging PRs with unresolved review issues. Only honored when `mode: aggressive` |
 | `autopilot.max_iterations` | `10` | Max issues to process |

--- a/dist/skills/init-gitissue/templates/gitissue-template.yml
+++ b/dist/skills/init-gitissue/templates/gitissue-template.yml
@@ -74,6 +74,22 @@ review:
   # Set to false to skip the check (traceability reported as `pass`).
   require_traceability_check: true
 
+  # PR labels that exempt a PR from the `Closes #N` hard-fail (check 1 only;
+  # the other three traceability checks still run).
+  # Default: ["refactor", "chore"] — refactor/chore PRs are exempt by default.
+  # Set to [] to disable label-based exemption.
+  traceability_exempt_labels:
+    - refactor
+    - chore
+
+  # Regex matched against the PR body (multiline-anchored, case-insensitive).
+  # When the body contains a matching line, the PR is exempt from the
+  # `Closes #N` hard-fail (check 1 only).
+  # Default: "^\\s*Type:\\s*(refactor|chore)\\s*$" — recognizes a `Type: refactor`
+  # or `Type: chore` line anywhere in the PR body.
+  # Set to "" to disable pattern-based exemption.
+  traceability_exempt_pattern: "^\\s*Type:\\s*(refactor|chore)\\s*$"
+
 # Auto-pilot settings (used by /auto-pilot)
 autopilot:
   # Merge mode — controls when /auto-pilot is allowed to merge PRs.

--- a/dist/skills/issue-analysis/references/docs/config-schema.md
+++ b/dist/skills/issue-analysis/references/docs/config-schema.md
@@ -198,6 +198,28 @@ review:
   # contract from issue #36.
   require_traceability_check: true
 
+  # PR labels that exempt a PR from the `Closes #N` hard-fail (check 1 only).
+  # Type: list of strings (label names — exact, case-sensitive match)
+  # Default: ["refactor", "chore"]
+  # When the PR carries any label in this list, /issue-pr-review skips the
+  # `Closes #N` check and reports `traceability: pass — exempt`. The other
+  # three traceability checks (commit reference, Decision Record, Acceptance
+  # Criteria Verification block) still run and report `partial` if absent.
+  # Set to [] to disable label-based exemption (see also traceability_exempt_pattern).
+  traceability_exempt_labels:
+    - refactor
+    - chore
+
+  # PR-body pattern that exempts a PR from the `Closes #N` hard-fail (check 1 only).
+  # Type: string (regex, multiline-anchored, case-insensitive)
+  # Default: "^\\s*Type:\\s*(refactor|chore)\\s*$"
+  # When the PR body contains a line matching this pattern, /issue-pr-review
+  # skips the `Closes #N` check and reports `traceability: pass — exempt`. The
+  # other three traceability checks still run.
+  # Set to "" to disable pattern-based exemption. Setting both this and
+  # traceability_exempt_labels to empty restores strict issue #36 behavior.
+  traceability_exempt_pattern: "^\\s*Type:\\s*(refactor|chore)\\s*$"
+
 # Auto-pilot settings (used by /auto-pilot)
 autopilot:
   # Merge mode — controls when /auto-pilot is allowed to merge PRs.
@@ -388,6 +410,8 @@ graph TD
     RV --> RV9["soft_pass"]
     RV --> RV10["require_acceptance_criteria_check"]
     RV --> RV11["require_traceability_check"]
+    RV --> RV12["traceability_exempt_labels"]
+    RV --> RV13["traceability_exempt_pattern"]
 
     AP --> AP0["mode"]
     AP --> AP00["merge_partial"]
@@ -470,6 +494,8 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `review.soft_pass` | `true` | Treat soft-pass as pass |
 | `review.require_acceptance_criteria_check` | `true` | Run per-criterion acceptance-criteria verification; `fail` blocks soft-pass |
 | `review.require_traceability_check` | `true` | Run the four traceability checks; missing `Closes #N` blocks soft-pass |
+| `review.traceability_exempt_labels` | `["refactor", "chore"]` | PR labels that exempt a PR from the `Closes #N` hard-fail (check 1 only; other three checks still run) |
+| `review.traceability_exempt_pattern` | `"^\\s*Type:\\s*(refactor\|chore)\\s*$"` | Regex (multiline, case-insensitive) matched against PR body for exemption from check 1 |
 | `autopilot.mode` | `conservative` | Merge mode: `conservative` (never merge), `balanced` (merge clean PRs), `aggressive` (merge clean + partial w/ `merge_partial: true`) |
 | `autopilot.merge_partial` | `false` | Allow merging PRs with unresolved review issues. Only honored when `mode: aggressive` |
 | `autopilot.max_iterations` | `10` | Max issues to process |

--- a/dist/skills/issue-pr-review/README.md
+++ b/dist/skills/issue-pr-review/README.md
@@ -16,6 +16,7 @@
 - Five-dimension review output — correctness, acceptance_criteria, traceability, maintainability, safety — so a PR can pass tests and still be flagged for missing issue links or unmet acceptance criteria
 - Per-criterion acceptance-criteria verification (`pass` / `fail` / `unverified` with evidence) against the linked issue
 - Soft-pass when zero "fix" issues remain, with **hard blocks** on `traceability: fail` (missing `Closes #N`) and any `acceptance_criteria: fail` — green tests do not override these
+- Refactor/chore PRs (matching `review.traceability_exempt_labels` or `review.traceability_exempt_pattern`) are exempt from the `Closes #N` hard-fail; the other three traceability checks still run
 
 ## When to Use
 

--- a/dist/skills/issue-pr-review/SKILL.md
+++ b/dist/skills/issue-pr-review/SKILL.md
@@ -68,6 +68,8 @@ Load `.gitissue.yml` once. Defaults:
 - `review.soft_pass: true` — pass when zero "fix" issues remain, even if "note" issues exist (≤ 2 medium allowed)
 - `review.require_acceptance_criteria_check: true` — when `false`, skip per-criterion AC verification; report acceptance_criteria as `pass` with a "verification disabled" note (never blocks soft-pass). Default `true` preserves the issue #36 contract.
 - `review.require_traceability_check: true` — when `false`, skip the four traceability checks; report traceability as `pass` with a "verification disabled" note (never blocks soft-pass). Default `true` preserves the issue #36 contract.
+- `review.traceability_exempt_labels: ["refactor", "chore"]` — PR labels that exempt a PR from the `Closes #N` hard-fail (check 1 only; the other three traceability checks still run). Set to `[]` to disable label-based exemption.
+- `review.traceability_exempt_pattern: "^\\s*Type:\\s*(refactor|chore)\\s*$"` — case-insensitive multiline regex; if the PR body contains a matching line, the PR is exempt from the `Closes #N` hard-fail (check 1 only). Set to empty string `""` to disable pattern-based exemption.
 
 ---
 
@@ -330,6 +332,8 @@ Two `.gitissue.yml` flags decide whether the acceptance-criteria and traceabilit
 
 Both default to `true`, which preserves the issue #36 contract verbatim. Setting either flag to `false` is an explicit opt-out — the corresponding hard-block conditions in *Loop controls* below no longer apply for that dimension.
 
+A separate, narrower opt-out exists for refactor/chore PRs (see *Refactor/chore exemption* below). It relaxes only check 1 (`Closes #N`) for the matching PR; the other three traceability checks still run.
+
 ### Acceptance-criteria verification (per criterion)
 
 > Run only when `review.require_acceptance_criteria_check` is `true`. When `false`, skip this entire subsection and emit `○ acceptance_criteria: pass — verification disabled (review.require_acceptance_criteria_check: false)`.
@@ -373,7 +377,7 @@ Each `fail` criterion becomes a fixable issue in Step 6 with `category: acceptan
 
 Per the dual-write rule (see *Analysis Artifacts and Durable Memory* in `references/docs/idd-methodology.md`), the durable analysis signal must survive the squash-merge into git history. Run the following four checks against the PR body and the commits in the PR:
 
-1. **Issue link** — PR body contains `Closes #{N}`, `Fixes #{N}`, or `Resolves #{N}` for the linked issue. Detected with the same regex used by GitHub itself: `(?i)(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#\d+`.
+1. **Issue link** — PR body contains `Closes #{N}`, `Fixes #{N}`, or `Resolves #{N}` for the linked issue. Detected with the same regex used by GitHub itself: `(?i)(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#\d+`. See *Refactor/chore exemption* below — the `Closes #N` requirement is relaxed for refactor/chore PRs (the other three checks still run).
 2. **Commit references issue** — at least one commit between base and head references the issue number:
    ```bash
    git log "{base_branch}..{head_branch}" --grep="#{N}" --oneline
@@ -387,6 +391,7 @@ Per the dual-write rule (see *Analysis Artifacts and Durable Memory* in `referen
 | Outcome | Conditions | Status |
 |---------|-----------|--------|
 | All four checks pass | Closes #N + commit ref + Decision Record + AC Verification block all present | ✓ traceability: pass |
+| `Closes #{N}` absent on a refactor/chore-exempt PR | check 1 skipped via the *Refactor/chore exemption* below; checks 2-4 still run | ○ traceability: pass — exempt (refactor/chore PR; no Closes #N required), with any check 2-4 partial findings appended |
 | `Closes #{N}` absent | check 1 fails (regardless of other checks) | ✗ traceability: fail (blocking — see below) |
 | Decision Record absent on a human-authored PR | check 3 partially fails: PR was not produced by `/issue-resolver` and has no Decision Record | ⚠ traceability: partial — "PR not produced by `/issue-resolver`; Decision Record absent" |
 | Commit reference absent | check 2 fails but check 1 passes (PR body has Closes #N but no commit references the issue) | ⚠ traceability: partial — "no commit references #{N}" |
@@ -395,6 +400,32 @@ Per the dual-write rule (see *Analysis Artifacts and Durable Memory* in `referen
 The `Closes #{N}` failure is the only traceability outcome that **blocks** the soft-pass. All other partial outcomes are reported but do not block. This matches issue #36's contract: a PR missing `Closes #N` reports a traceability failure even if tests pass; a human-authored PR without a Decision Record reports `partial`, not `fail`.
 
 When traceability fails on `Closes #{N}`, emit a fixable issue in Step 6 with `category: traceability`, `action: fix`, suggested fix: "Add `Closes #{N}` to the PR body."
+
+### Refactor/chore exemption
+
+Some PRs aren't tied to a single tracked issue — skill quality passes, dependency bumps, doc-only updates. Forcing each one to open a tracking issue purely to satisfy the `Closes #N` gate is workflow ceremony with no information gain. To accommodate this, check 1 (`Closes #N`) is **skipped** when either of the following holds:
+
+1. The PR has any label whose name appears in `review.traceability_exempt_labels` (default: `["refactor", "chore"]`). Match is exact and case-sensitive against GitHub label names.
+2. The PR body contains a line matching `review.traceability_exempt_pattern` (default: `"^\\s*Type:\\s*(refactor|chore)\\s*$"`, case-insensitive, evaluated multiline-anchored against the body). The line may appear anywhere in the body. The default is shown in YAML double-quoted form, so `\\s` is the correct value to copy into `.gitissue.yml`.
+
+The exemption applies **only to check 1**. Checks 2-4 (commit reference, Decision Record, Acceptance Criteria Verification block) still run; their absence is reported as `partial`, never `fail`. Note that check 2 (`git log --grep="#{N}"`) is well-defined only when there is a tracked issue number; an exempt refactor/chore PR with no linked issue has no `#{N}` to grep for, so check 2 is reported as `n/a — no linked issue`, not `partial`. When an exempt PR _does_ have a linked issue (e.g., a refactor scoped under a tracking ticket) but no commit references it, the report is `○ pass — exempt; no commit references #{N} (note)`, not `fail`.
+
+Report wording:
+
+```
+traceability:        ○ pass — exempt (refactor/chore PR; no Closes #N required)
+```
+
+If checks 2-4 produce partial findings on an exempt PR, append them as in the human-authored case:
+
+```
+traceability:        ○ pass — exempt (refactor/chore PR; no Closes #N required);
+                       no commit references #{N}
+```
+
+To **disable** the exemption entirely (restore the strict issue #36 behavior), set `traceability_exempt_labels: []` and `traceability_exempt_pattern: ""` in `.gitissue.yml`.
+
+The exemption check runs before the four traceability checks; if a PR matches, log which mechanism matched (label name or pattern) so reviewers can audit the decision in the report.
 
 ### Reviewer call-out for the other three dimensions
 
@@ -593,7 +624,7 @@ After Step 6, go back to Step 3 — but reuse the same reviewer agent via `SendM
 - **Max cycles:** `review.max_cycles` (default: 3)
 - **Agent reuse:** Cycles 2+ reuse the existing reviewer and fixer agents. Fresh spawn only for the confirmation pass after fixer reports zero issues.
 - **Soft pass (default):** Stop when ALL of the following hold: zero `action: "fix"` issues remain (across all five dimensions, including `acceptance_criteria` and `traceability` failures) AND tests pass AND CI passes AND traceability is not `fail`. Medium "note" issues (≤ 2) and `partial` dimensions are allowed — they don't block the pass.
-- **Hard-block conditions:** `traceability: fail` (e.g., `Closes #{N}` missing) and any `acceptance_criteria: fail` always block, even if every other dimension is clean. Tests passing does not override these — that is the explicit contract from issue #36. The block is gated on `review.require_traceability_check` and `review.require_acceptance_criteria_check`: when either flag is `false`, the corresponding dimension is reported as `pass — verification disabled` and never blocks soft-pass. Both flags default to `true`.
+- **Hard-block conditions:** `traceability: fail` (e.g., `Closes #{N}` missing) and any `acceptance_criteria: fail` always block, even if every other dimension is clean. Tests passing does not override these — that is the explicit contract from issue #36. The block is gated on `review.require_traceability_check` and `review.require_acceptance_criteria_check`: when either flag is `false`, the corresponding dimension is reported as `pass — verification disabled` and never blocks soft-pass. Both flags default to `true`. A narrower opt-out applies to refactor/chore PRs (see *Refactor/chore exemption* in Step 3): a matching PR reports `traceability: pass — exempt` and is not blocked, even though the four checks (minus check 1) still run.
 - **Confirmation pass:** When the fixer reports all fixed, spawn one fresh reviewer for unbiased verification. If clean → PASS. If new issues → back to existing fixer (counts as a cycle).
 - **Exit on stagnation:** If the same issues appear in 2 consecutive cycles, stop and report
 - **Review-only mode:** Run one cycle of Steps 3-5 only, never fix or loop

--- a/dist/skills/issue-pr-review/references/report-templates.md
+++ b/dist/skills/issue-pr-review/references/report-templates.md
@@ -72,7 +72,33 @@ When a human-authored PR (one not produced by `/issue-resolver`) is reviewed, th
     safety:              ✓ pass
 ```
 
-Acceptance-criteria checks still apply at full strength — they do not relax for human PRs. `Closes #{N}` checks also still apply at full strength — a human PR missing the issue link still fails traceability.
+Acceptance-criteria checks still apply at full strength — they do not relax for human PRs. `Closes #{N}` checks also still apply at full strength — a human PR missing the issue link still fails traceability, **unless** the PR matches the refactor/chore exemption described below.
+
+## Summary — Refactor/Chore Exempt PR
+
+Refactor or chore PRs (skill quality passes, dependency bumps, doc-only updates) are exempt from the `Closes #N` hard-fail when they match `review.traceability_exempt_labels` or `review.traceability_exempt_pattern`. Check 1 is skipped; checks 2-4 still run and report `partial` if absent.
+
+```
+  Review dimensions:
+    correctness:         ✓ pass
+    acceptance_criteria: ○ pass — none defined; manual review recommended
+    traceability:        ○ pass — exempt (refactor/chore PR; no Closes #N required)
+    maintainability:     ✓ pass
+    safety:              ✓ pass
+```
+
+The `acceptance_criteria` line above shows the common case for refactor/chore PRs (no linked issue, so no AC defined). When a refactor PR does have a linked issue with acceptance criteria, those criteria still verify normally — the refactor exemption relaxes only check 1 of traceability, never AC. The "verification disabled" wording appears only when `review.require_acceptance_criteria_check: false` is explicitly set.
+
+When checks 2-4 produce partial findings on an exempt PR, append them inline:
+
+```
+    traceability:        ○ pass — exempt (refactor/chore PR; no Closes #N required);
+                           no commit references #{N}
+```
+
+Note: check 2 (`git log --grep="#{N}"`) is well-defined only when the exempt PR has a linked issue number to grep for. If the PR is opened without any tracked issue, check 2 is reported as `n/a — no linked issue` rather than `partial`.
+
+The match mechanism (label name or pattern) is logged so reviewers can audit which exemption rule fired. To restore strict issue #36 behavior (no exemption), set `review.traceability_exempt_labels: []` and `review.traceability_exempt_pattern: ""`.
 
 ## Auto-Merge (auto mode only)
 

--- a/dist/skills/issue-resolver/references/docs/config-schema.md
+++ b/dist/skills/issue-resolver/references/docs/config-schema.md
@@ -198,6 +198,28 @@ review:
   # contract from issue #36.
   require_traceability_check: true
 
+  # PR labels that exempt a PR from the `Closes #N` hard-fail (check 1 only).
+  # Type: list of strings (label names — exact, case-sensitive match)
+  # Default: ["refactor", "chore"]
+  # When the PR carries any label in this list, /issue-pr-review skips the
+  # `Closes #N` check and reports `traceability: pass — exempt`. The other
+  # three traceability checks (commit reference, Decision Record, Acceptance
+  # Criteria Verification block) still run and report `partial` if absent.
+  # Set to [] to disable label-based exemption (see also traceability_exempt_pattern).
+  traceability_exempt_labels:
+    - refactor
+    - chore
+
+  # PR-body pattern that exempts a PR from the `Closes #N` hard-fail (check 1 only).
+  # Type: string (regex, multiline-anchored, case-insensitive)
+  # Default: "^\\s*Type:\\s*(refactor|chore)\\s*$"
+  # When the PR body contains a line matching this pattern, /issue-pr-review
+  # skips the `Closes #N` check and reports `traceability: pass — exempt`. The
+  # other three traceability checks still run.
+  # Set to "" to disable pattern-based exemption. Setting both this and
+  # traceability_exempt_labels to empty restores strict issue #36 behavior.
+  traceability_exempt_pattern: "^\\s*Type:\\s*(refactor|chore)\\s*$"
+
 # Auto-pilot settings (used by /auto-pilot)
 autopilot:
   # Merge mode — controls when /auto-pilot is allowed to merge PRs.
@@ -388,6 +410,8 @@ graph TD
     RV --> RV9["soft_pass"]
     RV --> RV10["require_acceptance_criteria_check"]
     RV --> RV11["require_traceability_check"]
+    RV --> RV12["traceability_exempt_labels"]
+    RV --> RV13["traceability_exempt_pattern"]
 
     AP --> AP0["mode"]
     AP --> AP00["merge_partial"]
@@ -470,6 +494,8 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `review.soft_pass` | `true` | Treat soft-pass as pass |
 | `review.require_acceptance_criteria_check` | `true` | Run per-criterion acceptance-criteria verification; `fail` blocks soft-pass |
 | `review.require_traceability_check` | `true` | Run the four traceability checks; missing `Closes #N` blocks soft-pass |
+| `review.traceability_exempt_labels` | `["refactor", "chore"]` | PR labels that exempt a PR from the `Closes #N` hard-fail (check 1 only; other three checks still run) |
+| `review.traceability_exempt_pattern` | `"^\\s*Type:\\s*(refactor\|chore)\\s*$"` | Regex (multiline, case-insensitive) matched against PR body for exemption from check 1 |
 | `autopilot.mode` | `conservative` | Merge mode: `conservative` (never merge), `balanced` (merge clean PRs), `aggressive` (merge clean + partial w/ `merge_partial: true`) |
 | `autopilot.merge_partial` | `false` | Allow merging PRs with unresolved review issues. Only honored when `mode: aggressive` |
 | `autopilot.max_iterations` | `10` | Max issues to process |

--- a/dist/skills/issue-triage/references/docs/config-schema.md
+++ b/dist/skills/issue-triage/references/docs/config-schema.md
@@ -198,6 +198,28 @@ review:
   # contract from issue #36.
   require_traceability_check: true
 
+  # PR labels that exempt a PR from the `Closes #N` hard-fail (check 1 only).
+  # Type: list of strings (label names — exact, case-sensitive match)
+  # Default: ["refactor", "chore"]
+  # When the PR carries any label in this list, /issue-pr-review skips the
+  # `Closes #N` check and reports `traceability: pass — exempt`. The other
+  # three traceability checks (commit reference, Decision Record, Acceptance
+  # Criteria Verification block) still run and report `partial` if absent.
+  # Set to [] to disable label-based exemption (see also traceability_exempt_pattern).
+  traceability_exempt_labels:
+    - refactor
+    - chore
+
+  # PR-body pattern that exempts a PR from the `Closes #N` hard-fail (check 1 only).
+  # Type: string (regex, multiline-anchored, case-insensitive)
+  # Default: "^\\s*Type:\\s*(refactor|chore)\\s*$"
+  # When the PR body contains a line matching this pattern, /issue-pr-review
+  # skips the `Closes #N` check and reports `traceability: pass — exempt`. The
+  # other three traceability checks still run.
+  # Set to "" to disable pattern-based exemption. Setting both this and
+  # traceability_exempt_labels to empty restores strict issue #36 behavior.
+  traceability_exempt_pattern: "^\\s*Type:\\s*(refactor|chore)\\s*$"
+
 # Auto-pilot settings (used by /auto-pilot)
 autopilot:
   # Merge mode — controls when /auto-pilot is allowed to merge PRs.
@@ -388,6 +410,8 @@ graph TD
     RV --> RV9["soft_pass"]
     RV --> RV10["require_acceptance_criteria_check"]
     RV --> RV11["require_traceability_check"]
+    RV --> RV12["traceability_exempt_labels"]
+    RV --> RV13["traceability_exempt_pattern"]
 
     AP --> AP0["mode"]
     AP --> AP00["merge_partial"]
@@ -470,6 +494,8 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `review.soft_pass` | `true` | Treat soft-pass as pass |
 | `review.require_acceptance_criteria_check` | `true` | Run per-criterion acceptance-criteria verification; `fail` blocks soft-pass |
 | `review.require_traceability_check` | `true` | Run the four traceability checks; missing `Closes #N` blocks soft-pass |
+| `review.traceability_exempt_labels` | `["refactor", "chore"]` | PR labels that exempt a PR from the `Closes #N` hard-fail (check 1 only; other three checks still run) |
+| `review.traceability_exempt_pattern` | `"^\\s*Type:\\s*(refactor\|chore)\\s*$"` | Regex (multiline, case-insensitive) matched against PR body for exemption from check 1 |
 | `autopilot.mode` | `conservative` | Merge mode: `conservative` (never merge), `balanced` (merge clean PRs), `aggressive` (merge clean + partial w/ `merge_partial: true`) |
 | `autopilot.merge_partial` | `false` | Allow merging PRs with unresolved review issues. Only honored when `mode: aggressive` |
 | `autopilot.max_iterations` | `10` | Max issues to process |

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -409,6 +409,8 @@ graph TD
     RV --> RV9["soft_pass"]
     RV --> RV10["require_acceptance_criteria_check"]
     RV --> RV11["require_traceability_check"]
+    RV --> RV12["traceability_exempt_labels"]
+    RV --> RV13["traceability_exempt_pattern"]
 
     AP --> AP0["mode"]
     AP --> AP00["merge_partial"]
@@ -491,6 +493,8 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `review.soft_pass` | `true` | Treat soft-pass as pass |
 | `review.require_acceptance_criteria_check` | `true` | Run per-criterion acceptance-criteria verification; `fail` blocks soft-pass |
 | `review.require_traceability_check` | `true` | Run the four traceability checks; missing `Closes #N` blocks soft-pass |
+| `review.traceability_exempt_labels` | `["refactor", "chore"]` | PR labels that exempt a PR from the `Closes #N` hard-fail (check 1 only; other three checks still run) |
+| `review.traceability_exempt_pattern` | `"^\\s*Type:\\s*(refactor\|chore)\\s*$"` | Regex (multiline, case-insensitive) matched against PR body for exemption from check 1 |
 | `autopilot.mode` | `conservative` | Merge mode: `conservative` (never merge), `balanced` (merge clean PRs), `aggressive` (merge clean + partial w/ `merge_partial: true`) |
 | `autopilot.merge_partial` | `false` | Allow merging PRs with unresolved review issues. Only honored when `mode: aggressive` |
 | `autopilot.max_iterations` | `10` | Max issues to process |

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -197,6 +197,28 @@ review:
   # contract from issue #36.
   require_traceability_check: true
 
+  # PR labels that exempt a PR from the `Closes #N` hard-fail (check 1 only).
+  # Type: list of strings (label names — exact, case-sensitive match)
+  # Default: ["refactor", "chore"]
+  # When the PR carries any label in this list, /issue-pr-review skips the
+  # `Closes #N` check and reports `traceability: pass — exempt`. The other
+  # three traceability checks (commit reference, Decision Record, Acceptance
+  # Criteria Verification block) still run and report `partial` if absent.
+  # Set to [] to disable label-based exemption (see also traceability_exempt_pattern).
+  traceability_exempt_labels:
+    - refactor
+    - chore
+
+  # PR-body pattern that exempts a PR from the `Closes #N` hard-fail (check 1 only).
+  # Type: string (regex, multiline-anchored, case-insensitive)
+  # Default: "^\\s*Type:\\s*(refactor|chore)\\s*$"
+  # When the PR body contains a line matching this pattern, /issue-pr-review
+  # skips the `Closes #N` check and reports `traceability: pass — exempt`. The
+  # other three traceability checks still run.
+  # Set to "" to disable pattern-based exemption. Setting both this and
+  # traceability_exempt_labels to empty restores strict issue #36 behavior.
+  traceability_exempt_pattern: "^\\s*Type:\\s*(refactor|chore)\\s*$"
+
 # Auto-pilot settings (used by /auto-pilot)
 autopilot:
   # Merge mode — controls when /auto-pilot is allowed to merge PRs.

--- a/src/skills/init-gitissue/templates/gitissue-template.yml
+++ b/src/skills/init-gitissue/templates/gitissue-template.yml
@@ -74,6 +74,22 @@ review:
   # Set to false to skip the check (traceability reported as `pass`).
   require_traceability_check: true
 
+  # PR labels that exempt a PR from the `Closes #N` hard-fail (check 1 only;
+  # the other three traceability checks still run).
+  # Default: ["refactor", "chore"] — refactor/chore PRs are exempt by default.
+  # Set to [] to disable label-based exemption.
+  traceability_exempt_labels:
+    - refactor
+    - chore
+
+  # Regex matched against the PR body (multiline-anchored, case-insensitive).
+  # When the body contains a matching line, the PR is exempt from the
+  # `Closes #N` hard-fail (check 1 only).
+  # Default: "^\\s*Type:\\s*(refactor|chore)\\s*$" — recognizes a `Type: refactor`
+  # or `Type: chore` line anywhere in the PR body.
+  # Set to "" to disable pattern-based exemption.
+  traceability_exempt_pattern: "^\\s*Type:\\s*(refactor|chore)\\s*$"
+
 # Auto-pilot settings (used by /auto-pilot)
 autopilot:
   # Merge mode — controls when /auto-pilot is allowed to merge PRs.

--- a/src/skills/issue-pr-review/README.md
+++ b/src/skills/issue-pr-review/README.md
@@ -16,6 +16,7 @@
 - Five-dimension review output — correctness, acceptance_criteria, traceability, maintainability, safety — so a PR can pass tests and still be flagged for missing issue links or unmet acceptance criteria
 - Per-criterion acceptance-criteria verification (`pass` / `fail` / `unverified` with evidence) against the linked issue
 - Soft-pass when zero "fix" issues remain, with **hard blocks** on `traceability: fail` (missing `Closes #N`) and any `acceptance_criteria: fail` — green tests do not override these
+- Refactor/chore PRs (matching `review.traceability_exempt_labels` or `review.traceability_exempt_pattern`) are exempt from the `Closes #N` hard-fail; the other three traceability checks still run
 
 ## When to Use
 

--- a/src/skills/issue-pr-review/SKILL.md
+++ b/src/skills/issue-pr-review/SKILL.md
@@ -408,7 +408,7 @@ Some PRs aren't tied to a single tracked issue — skill quality passes, depende
 1. The PR has any label whose name appears in `review.traceability_exempt_labels` (default: `["refactor", "chore"]`). Match is exact and case-sensitive against GitHub label names.
 2. The PR body contains a line matching `review.traceability_exempt_pattern` (default: `"^\s*Type:\s*(refactor|chore)\s*$"`, case-insensitive, evaluated multiline-anchored against the body). The line may appear anywhere in the body.
 
-The exemption applies **only to check 1**. Checks 2-4 (commit reference, Decision Record, Acceptance Criteria Verification block) still run; their absence is reported as `partial`, never `fail`. This means an exempt PR with no Decision Record reports `○ pass — exempt; no commit references the PR (note)`, not `fail`.
+The exemption applies **only to check 1**. Checks 2-4 (commit reference, Decision Record, Acceptance Criteria Verification block) still run; their absence is reported as `partial`, never `fail`. This means an exempt PR whose commits do not reference the PR reports `○ pass — exempt; no commit references the PR (note)`, not `fail`.
 
 Report wording:
 

--- a/src/skills/issue-pr-review/SKILL.md
+++ b/src/skills/issue-pr-review/SKILL.md
@@ -406,9 +406,9 @@ When traceability fails on `Closes #{N}`, emit a fixable issue in Step 6 with `c
 Some PRs aren't tied to a single tracked issue — skill quality passes, dependency bumps, doc-only updates. Forcing each one to open a tracking issue purely to satisfy the `Closes #N` gate is workflow ceremony with no information gain. To accommodate this, check 1 (`Closes #N`) is **skipped** when either of the following holds:
 
 1. The PR has any label whose name appears in `review.traceability_exempt_labels` (default: `["refactor", "chore"]`). Match is exact and case-sensitive against GitHub label names.
-2. The PR body contains a line matching `review.traceability_exempt_pattern` (default: `"^\s*Type:\s*(refactor|chore)\s*$"`, case-insensitive, evaluated multiline-anchored against the body). The line may appear anywhere in the body.
+2. The PR body contains a line matching `review.traceability_exempt_pattern` (default: `"^\\s*Type:\\s*(refactor|chore)\\s*$"`, case-insensitive, evaluated multiline-anchored against the body). The line may appear anywhere in the body. The default is shown in YAML double-quoted form, so `\\s` is the correct value to copy into `.gitissue.yml`.
 
-The exemption applies **only to check 1**. Checks 2-4 (commit reference, Decision Record, Acceptance Criteria Verification block) still run; their absence is reported as `partial`, never `fail`. This means an exempt PR whose commits do not reference the PR reports `○ pass — exempt; no commit references the PR (note)`, not `fail`.
+The exemption applies **only to check 1**. Checks 2-4 (commit reference, Decision Record, Acceptance Criteria Verification block) still run; their absence is reported as `partial`, never `fail`. Note that check 2 (`git log --grep="#{N}"`) is well-defined only when there is a tracked issue number; an exempt refactor/chore PR with no linked issue has no `#{N}` to grep for, so check 2 is reported as `n/a — no linked issue`, not `partial`. When an exempt PR _does_ have a linked issue (e.g., a refactor scoped under a tracking ticket) but no commit references it, the report is `○ pass — exempt; no commit references #{N} (note)`, not `fail`.
 
 Report wording:
 
@@ -420,7 +420,7 @@ If checks 2-4 produce partial findings on an exempt PR, append them as in the hu
 
 ```
 traceability:        ○ pass — exempt (refactor/chore PR; no Closes #N required);
-                       no commit references the PR
+                       no commit references #{N}
 ```
 
 To **disable** the exemption entirely (restore the strict issue #36 behavior), set `traceability_exempt_labels: []` and `traceability_exempt_pattern: ""` in `.gitissue.yml`.

--- a/src/skills/issue-pr-review/SKILL.md
+++ b/src/skills/issue-pr-review/SKILL.md
@@ -68,6 +68,8 @@ Load `.gitissue.yml` once. Defaults:
 - `review.soft_pass: true` — pass when zero "fix" issues remain, even if "note" issues exist (≤ 2 medium allowed)
 - `review.require_acceptance_criteria_check: true` — when `false`, skip per-criterion AC verification; report acceptance_criteria as `pass` with a "verification disabled" note (never blocks soft-pass). Default `true` preserves the issue #36 contract.
 - `review.require_traceability_check: true` — when `false`, skip the four traceability checks; report traceability as `pass` with a "verification disabled" note (never blocks soft-pass). Default `true` preserves the issue #36 contract.
+- `review.traceability_exempt_labels: ["refactor", "chore"]` — PR labels that exempt a PR from the `Closes #N` hard-fail (check 1 only; the other three traceability checks still run). Set to `[]` to disable label-based exemption.
+- `review.traceability_exempt_pattern: "^\\s*Type:\\s*(refactor|chore)\\s*$"` — case-insensitive multiline regex; if the PR body contains a matching line, the PR is exempt from the `Closes #N` hard-fail (check 1 only). Set to empty string `""` to disable pattern-based exemption.
 
 ---
 
@@ -330,6 +332,8 @@ Two `.gitissue.yml` flags decide whether the acceptance-criteria and traceabilit
 
 Both default to `true`, which preserves the issue #36 contract verbatim. Setting either flag to `false` is an explicit opt-out — the corresponding hard-block conditions in *Loop controls* below no longer apply for that dimension.
 
+A separate, narrower opt-out exists for refactor/chore PRs (see *Refactor/chore exemption* below). It relaxes only check 1 (`Closes #N`) for the matching PR; the other three traceability checks still run.
+
 ### Acceptance-criteria verification (per criterion)
 
 > Run only when `review.require_acceptance_criteria_check` is `true`. When `false`, skip this entire subsection and emit `○ acceptance_criteria: pass — verification disabled (review.require_acceptance_criteria_check: false)`.
@@ -373,7 +377,7 @@ Each `fail` criterion becomes a fixable issue in Step 6 with `category: acceptan
 
 Per the dual-write rule (see *Analysis Artifacts and Durable Memory* in `docs/idd-methodology.md`), the durable analysis signal must survive the squash-merge into git history. Run the following four checks against the PR body and the commits in the PR:
 
-1. **Issue link** — PR body contains `Closes #{N}`, `Fixes #{N}`, or `Resolves #{N}` for the linked issue. Detected with the same regex used by GitHub itself: `(?i)(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#\d+`.
+1. **Issue link** — PR body contains `Closes #{N}`, `Fixes #{N}`, or `Resolves #{N}` for the linked issue. Detected with the same regex used by GitHub itself: `(?i)(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#\d+`. See *Refactor/chore exemption* below — the `Closes #N` requirement is relaxed for refactor/chore PRs (the other three checks still run).
 2. **Commit references issue** — at least one commit between base and head references the issue number:
    ```bash
    git log "{base_branch}..{head_branch}" --grep="#{N}" --oneline
@@ -387,6 +391,7 @@ Per the dual-write rule (see *Analysis Artifacts and Durable Memory* in `docs/id
 | Outcome | Conditions | Status |
 |---------|-----------|--------|
 | All four checks pass | Closes #N + commit ref + Decision Record + AC Verification block all present | ✓ traceability: pass |
+| `Closes #{N}` absent on a refactor/chore-exempt PR | check 1 skipped via the *Refactor/chore exemption* below; checks 2-4 still run | ○ traceability: pass — exempt (refactor/chore PR; no Closes #N required), with any check 2-4 partial findings appended |
 | `Closes #{N}` absent | check 1 fails (regardless of other checks) | ✗ traceability: fail (blocking — see below) |
 | Decision Record absent on a human-authored PR | check 3 partially fails: PR was not produced by `/issue-resolver` and has no Decision Record | ⚠ traceability: partial — "PR not produced by `/issue-resolver`; Decision Record absent" |
 | Commit reference absent | check 2 fails but check 1 passes (PR body has Closes #N but no commit references the issue) | ⚠ traceability: partial — "no commit references #{N}" |
@@ -395,6 +400,32 @@ Per the dual-write rule (see *Analysis Artifacts and Durable Memory* in `docs/id
 The `Closes #{N}` failure is the only traceability outcome that **blocks** the soft-pass. All other partial outcomes are reported but do not block. This matches issue #36's contract: a PR missing `Closes #N` reports a traceability failure even if tests pass; a human-authored PR without a Decision Record reports `partial`, not `fail`.
 
 When traceability fails on `Closes #{N}`, emit a fixable issue in Step 6 with `category: traceability`, `action: fix`, suggested fix: "Add `Closes #{N}` to the PR body."
+
+### Refactor/chore exemption
+
+Some PRs aren't tied to a single tracked issue — skill quality passes, dependency bumps, doc-only updates. Forcing each one to open a tracking issue purely to satisfy the `Closes #N` gate is workflow ceremony with no information gain. To accommodate this, check 1 (`Closes #N`) is **skipped** when either of the following holds:
+
+1. The PR has any label whose name appears in `review.traceability_exempt_labels` (default: `["refactor", "chore"]`). Match is exact and case-sensitive against GitHub label names.
+2. The PR body contains a line matching `review.traceability_exempt_pattern` (default: `"^\s*Type:\s*(refactor|chore)\s*$"`, case-insensitive, evaluated multiline-anchored against the body). The line may appear anywhere in the body.
+
+The exemption applies **only to check 1**. Checks 2-4 (commit reference, Decision Record, Acceptance Criteria Verification block) still run; their absence is reported as `partial`, never `fail`. This means an exempt PR with no Decision Record reports `○ pass — exempt; no commit references the PR (note)`, not `fail`.
+
+Report wording:
+
+```
+traceability:        ○ pass — exempt (refactor/chore PR; no Closes #N required)
+```
+
+If checks 2-4 produce partial findings on an exempt PR, append them as in the human-authored case:
+
+```
+traceability:        ○ pass — exempt (refactor/chore PR; no Closes #N required);
+                       no commit references the PR
+```
+
+To **disable** the exemption entirely (restore the strict issue #36 behavior), set `traceability_exempt_labels: []` and `traceability_exempt_pattern: ""` in `.gitissue.yml`.
+
+The exemption check runs before the four traceability checks; if a PR matches, log which mechanism matched (label name or pattern) so reviewers can audit the decision in the report.
 
 ### Reviewer call-out for the other three dimensions
 
@@ -593,7 +624,7 @@ After Step 6, go back to Step 3 — but reuse the same reviewer agent via `SendM
 - **Max cycles:** `review.max_cycles` (default: 3)
 - **Agent reuse:** Cycles 2+ reuse the existing reviewer and fixer agents. Fresh spawn only for the confirmation pass after fixer reports zero issues.
 - **Soft pass (default):** Stop when ALL of the following hold: zero `action: "fix"` issues remain (across all five dimensions, including `acceptance_criteria` and `traceability` failures) AND tests pass AND CI passes AND traceability is not `fail`. Medium "note" issues (≤ 2) and `partial` dimensions are allowed — they don't block the pass.
-- **Hard-block conditions:** `traceability: fail` (e.g., `Closes #{N}` missing) and any `acceptance_criteria: fail` always block, even if every other dimension is clean. Tests passing does not override these — that is the explicit contract from issue #36. The block is gated on `review.require_traceability_check` and `review.require_acceptance_criteria_check`: when either flag is `false`, the corresponding dimension is reported as `pass — verification disabled` and never blocks soft-pass. Both flags default to `true`.
+- **Hard-block conditions:** `traceability: fail` (e.g., `Closes #{N}` missing) and any `acceptance_criteria: fail` always block, even if every other dimension is clean. Tests passing does not override these — that is the explicit contract from issue #36. The block is gated on `review.require_traceability_check` and `review.require_acceptance_criteria_check`: when either flag is `false`, the corresponding dimension is reported as `pass — verification disabled` and never blocks soft-pass. Both flags default to `true`. A narrower opt-out applies to refactor/chore PRs (see *Refactor/chore exemption* in Step 3): a matching PR reports `traceability: pass — exempt` and is not blocked, even though the four checks (minus check 1) still run.
 - **Confirmation pass:** When the fixer reports all fixed, spawn one fresh reviewer for unbiased verification. If clean → PASS. If new issues → back to existing fixer (counts as a cycle).
 - **Exit on stagnation:** If the same issues appear in 2 consecutive cycles, stop and report
 - **Review-only mode:** Run one cycle of Steps 3-5 only, never fix or loop

--- a/src/skills/issue-pr-review/references/report-templates.md
+++ b/src/skills/issue-pr-review/references/report-templates.md
@@ -81,11 +81,13 @@ Refactor or chore PRs (skill quality passes, dependency bumps, doc-only updates)
 ```
   Review dimensions:
     correctness:         ✓ pass
-    acceptance_criteria: ✓ pass — verification disabled
+    acceptance_criteria: ○ pass — none defined; manual review recommended
     traceability:        ○ pass — exempt (refactor/chore PR; no Closes #N required)
     maintainability:     ✓ pass
     safety:              ✓ pass
 ```
+
+The `acceptance_criteria` line above shows the common case for refactor/chore PRs (no linked issue, so no AC defined). When a refactor PR does have a linked issue with acceptance criteria, those criteria still verify normally — the refactor exemption relaxes only check 1 of traceability, never AC. The "verification disabled" wording appears only when `review.require_acceptance_criteria_check: false` is explicitly set.
 
 When checks 2-4 produce partial findings on an exempt PR, append them inline:
 

--- a/src/skills/issue-pr-review/references/report-templates.md
+++ b/src/skills/issue-pr-review/references/report-templates.md
@@ -93,8 +93,10 @@ When checks 2-4 produce partial findings on an exempt PR, append them inline:
 
 ```
     traceability:        ○ pass — exempt (refactor/chore PR; no Closes #N required);
-                           no commit references the PR
+                           no commit references #{N}
 ```
+
+Note: check 2 (`git log --grep="#{N}"`) is well-defined only when the exempt PR has a linked issue number to grep for. If the PR is opened without any tracked issue, check 2 is reported as `n/a — no linked issue` rather than `partial`.
 
 The match mechanism (label name or pattern) is logged so reviewers can audit which exemption rule fired. To restore strict issue #36 behavior (no exemption), set `review.traceability_exempt_labels: []` and `review.traceability_exempt_pattern: ""`.
 

--- a/src/skills/issue-pr-review/references/report-templates.md
+++ b/src/skills/issue-pr-review/references/report-templates.md
@@ -72,7 +72,29 @@ When a human-authored PR (one not produced by `/issue-resolver`) is reviewed, th
     safety:              ✓ pass
 ```
 
-Acceptance-criteria checks still apply at full strength — they do not relax for human PRs. `Closes #{N}` checks also still apply at full strength — a human PR missing the issue link still fails traceability.
+Acceptance-criteria checks still apply at full strength — they do not relax for human PRs. `Closes #{N}` checks also still apply at full strength — a human PR missing the issue link still fails traceability, **unless** the PR matches the refactor/chore exemption described below.
+
+## Summary — Refactor/Chore Exempt PR
+
+Refactor or chore PRs (skill quality passes, dependency bumps, doc-only updates) are exempt from the `Closes #N` hard-fail when they match `review.traceability_exempt_labels` or `review.traceability_exempt_pattern`. Check 1 is skipped; checks 2-4 still run and report `partial` if absent.
+
+```
+  Review dimensions:
+    correctness:         ✓ pass
+    acceptance_criteria: ✓ pass — verification disabled
+    traceability:        ○ pass — exempt (refactor/chore PR; no Closes #N required)
+    maintainability:     ✓ pass
+    safety:              ✓ pass
+```
+
+When checks 2-4 produce partial findings on an exempt PR, append them inline:
+
+```
+    traceability:        ○ pass — exempt (refactor/chore PR; no Closes #N required);
+                           no commit references the PR
+```
+
+The match mechanism (label name or pattern) is logged so reviewers can audit which exemption rule fired. To restore strict issue #36 behavior (no exemption), set `review.traceability_exempt_labels: []` and `review.traceability_exempt_pattern: ""`.
 
 ## Auto-Merge (auto mode only)
 


### PR DESCRIPTION
Closes #91

## Summary

Refactor/chore PRs (skill quality passes, dependency bumps, doc-only updates) aren't tied to a single tracked issue. The existing issue-#36 contract requires `Closes #N` in every PR body and hard-blocks soft-pass when missing. Forcing each refactor PR to open a tracking issue purely to satisfy the gate is workflow ceremony with no information gain — the upstream decision (luongnv89/skills#21) chose to relax the rule rather than mandate a tracking issue per PR.

A PR is now exempt from the `Closes #N` hard-fail when **either**:

1. It carries a label in `review.traceability_exempt_labels` (default `["refactor", "chore"]`), or
2. Its body contains a line matching `review.traceability_exempt_pattern` (default `"^\\s*Type:\\s*(refactor|chore)\\s*$"`, case-insensitive, multiline-anchored).

The exemption applies **only to check 1** (`Closes #N`). The other three traceability checks (commit reference, Decision Record, Acceptance Criteria Verification block) still run; their absence is reported as `partial`, never `fail`. Strict issue-#36 behavior is preserved when both exemption keys are set to their empty values (`[]` and `""`).

## Approach

The implementation is **pure doc/spec** — gitissue is a skills-only project, so the change consists of edits to skill instructions, config schemas, and config templates that the agent reads at runtime.

| Change | File |
|---|---|
| Configuration bullets for the two new keys | `src/skills/issue-pr-review/SKILL.md` (Configuration section) |
| Verification gates note pointing to the exemption | `src/skills/issue-pr-review/SKILL.md` (gates table) |
| Forward-link from check 1 description to the exemption | `src/skills/issue-pr-review/SKILL.md` (Traceability checks) |
| New "Refactor/chore exemption" subsection with detection rules, scope, report wording | `src/skills/issue-pr-review/SKILL.md` |
| Loop-controls note that the narrower exemption coexists with the global flag | `src/skills/issue-pr-review/SKILL.md` (Loop controls) |
| New "Refactor/Chore Exempt PR" report template + clarifying note | `src/skills/issue-pr-review/references/report-templates.md` |
| Feature bullet | `src/skills/issue-pr-review/README.md` |
| Two new keys with explanatory comments | `src/skills/init-gitissue/templates/gitissue-template.yml` |
| Schema entries + Defaults Table rows + Section Map mermaid nodes | `docs/config-schema.md` |

## Decision Record

- **Root cause** — The issue-#36 traceability contract treats every PR identically: missing `Closes #N` is a hard-fail. There is no recognition of PRs that are legitimately decoupled from a single tracked issue (refactor passes, dependency bumps, doc-only updates).
- **Options considered** — (A) exempt refactor/chore PRs from check 1; (B) mandate a tracking issue for every PR via `CONTRIBUTING.md`; (C) variants of A differing on detection scope and breadth.
- **Options rejected** — (B) was rejected upstream (luongnv89/skills#21) because it creates a class of "tracking only" issues that exist solely to satisfy the gate, which is the opposite of what issue tracking is for. (C-tight: label-only) was rejected as less ergonomic. (C-comprehensive: skip all four checks on exempt PRs) was rejected because it loses signal — refactor PRs still benefit from Decision Records and commit references when applicable.
- **Selected option** — (C-balanced) — label OR body pattern detection; relax check 1 only; checks 2-4 still report `partial` if absent; both exemption keys are user-configurable and disabling both restores strict issue-#36 behavior.
- **Residual risk** — A maintainer could mislabel a non-refactor PR as `refactor`/`chore` to bypass the gate; this is detectable in PR review and the audit log records which mechanism matched. Risk is low because the exemption is narrowly scoped to one of four checks.

## Changes

| File | Lines added | Notes |
|---|---|---|
| `src/skills/issue-pr-review/SKILL.md` | ~30 | New exemption subsection; updated gates table, check 1 description, hard-block sentence |
| `src/skills/issue-pr-review/references/report-templates.md` | ~20 | New "Refactor/Chore Exempt PR" example + note about check 2 on untracked exempt PRs |
| `src/skills/issue-pr-review/README.md` | 1 | Feature bullet |
| `src/skills/init-gitissue/templates/gitissue-template.yml` | ~17 | Two new keys with comments |
| `docs/config-schema.md` | ~28 | Schema entries + Defaults Table rows + mermaid Section Map nodes |

## Test Results

This is a doc/spec-only change — no executable code, no test suite to run. Verified via:

- Two-cycle code review (5 findings total, all addressed): see commits `3319194` and `b522656`.
- Cross-file consistency audit: regex default value identical across SKILL.md, config-schema.md, gitissue-template.yml, and the Defaults Table.
- No regression to issue-#36 contract for non-exempt PRs (the blocking row in the Step 3 outcome table and the Loop-controls hard-block sentence remain intact).

## Acceptance Criteria Verification

| # | Criterion | Status | Evidence |
|---|---|---|---|
| 1 | `SKILL.md` documents exemption rule, two detection mechanisms, report wording | pass | SKILL.md lines 405-428 (new "Refactor/chore exemption" subsection) |
| 2 | `SKILL.md` clarifies exemption only relaxes check 1; other three still run | pass | SKILL.md line 411 ("applies **only to check 1**") and outcome-table row at line 391 |
| 3 | `references/report-templates.md` shows `○ pass — exempt` output sample | pass | report-templates.md lines 80-100 (new "Refactor/Chore Exempt PR" subsection) |
| 4 | `docs/config-schema.md` documents both keys with defaults | pass | config-schema.md lines 200-220 (full schema) + lines 412-413 (mermaid) + lines 496-497 (Defaults Table) |
| 5 | `init-gitissue/templates/gitissue-template.yml` surfaces both flags with comments | pass | gitissue-template.yml lines 77-93 |
| 6 | `README.md` mentions exemption in feature bullets | pass | README.md line 19 |
| 7 | After merge, post comment on luongnv89/skills#21 with merged PR link | unverified | Will be done as a post-merge step (cross-repo cannot be done in this PR) |