### PR TITLE
feat(install): support multiple tools with interactive picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,11 +205,18 @@ If you can't or don't want to install `asm`, clone the repo and run the bundled 
 ```bash
 git clone https://github.com/luongnv89/idd.git
 cd idd
-./scripts/install.sh                          # all standalone skills
+./scripts/install.sh                          # interactive tool picker — choose one or more tools
+# the picker lists every supported tool; pick by number (e.g. "1 3 4"), "a" for all,
+# or press Enter for Claude Code. Bypass the picker by naming tools explicitly:
 # or: ./scripts/install.sh --skill issue-resolver
+# or target another tool: ./scripts/install.sh --tool codex
+# or several at once:      ./scripts/install.sh --tools claude,codex,pi
+# or every supported tool: ./scripts/install.sh --tools all
 ```
 
-The script copies each `dist/skills/<name>/` to `~/.claude/skills/<name>/` and each generated shared agent from `dist/agents/*.md` to `~/.claude/agents/`. It replaces IDD-managed agents cleanly, removes stale managed agents on update, and skips unmanaged same-name agents unless you pass `--force-agents` (which backs them up before replacement). Use `./scripts/install.sh --target <dir>` to target a different Claude root. Pure POSIX bash — no extra runtime needed.
+> When run on a terminal with no `--tool`/`--tools` flag, the script shows an interactive picker so you can select one or more tools. In a non-interactive context (CI, `curl | bash` without a TTY, piped input) it falls back to Claude Code so automation keeps working.
+
+The script copies each `dist/skills/<name>/` to the selected tool's skills directory (default `~/.claude/skills/<name>/`). It supports `claude`, `agents`, `codex`, `opencode`, `pi`, `openclaw`, `hermes`, `antigravity`, and `windsurf` — each `dist/skills/<name>/` is a self-contained SKILL.md tree (the shared agents are bundled inside it at `references/agents/`), so a skill runs on any SKILL.md-compatible tool. Shared agents are *also* installed standalone from `dist/agents/*.md` into `~/.claude/agents/` (and `~/.agents/agents/`) — a Claude Code optimization for native subagent spawning; other tools use the bundled copies. The installer replaces IDD-managed agents cleanly, removes stale managed agents on update, and skips unmanaged same-name agents unless you pass `--force-agents` (which backs them up before replacement). Use `./scripts/install.sh --target <dir>` to target a different Claude root (Claude tool only; other tools use their fixed conventions). Pure POSIX bash — no extra runtime needed.
 
 You can also do the copy by hand if you prefer to see every file move:
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -17,7 +17,13 @@
 2. Install skills locally. Standalone is the recommended default — pick one of these:
    ```bash
    # Standalone (recommended) — bundled install script, all skills, idempotent:
-   ./scripts/install.sh
+   ./scripts/install.sh                       # interactive tool picker (TTY); Claude if non-interactive
+
+   # Standalone — target another SKILL.md-compatible tool, or several at once (skips the picker):
+   ./scripts/install.sh --tool codex          # Codex CLI
+   ./scripts/install.sh --tools claude,pi     # multiple tools
+   ./scripts/install.sh --tools all           # every supported tool
+   # Supported: claude, agents, codex, opencode, pi, openclaw, hermes, antigravity, windsurf
 
    # Standalone — single skill from this checkout (manual variant):
    mkdir -p ~/.claude/skills ~/.claude/agents
@@ -30,7 +36,7 @@
    # Plugin (Claude Code only) — build then install the plugin tree:
    ./scripts/build.sh && ./scripts/install.sh --plugin
    ```
-   The Plugin path lands under `~/.claude/plugins/idd/`; the Standalone paths drop individual skills into `~/.claude/skills/` and shared Claude Code agents into `~/.claude/agents/`. See [README → Install](../README.md#install) for the full hierarchy.
+   The Plugin path lands under `~/.claude/plugins/idd/`; the Standalone paths drop individual skills into each tool's skills directory (e.g. `~/.claude/skills/`, `~/.codex/skills/`, `~/.windsurf/rules/`). Each `dist/skills/<name>/` is a self-contained SKILL.md tree with the shared agents bundled inside it (`references/agents/`), so it runs on any tool. Shared agents are also installed standalone into `~/.claude/agents/` (and `~/.agents/agents/`) — a Claude Code optimization for native subagent spawning; other tools fall back to the bundled copies. See [README → Install](../README.md#install) for the full hierarchy.
 
 3. Verify setup:
    ```bash

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,24 +5,44 @@
 # not have `asm` (the recommended primary install tool — see README → Install).
 # This is a thin wrapper around the supported install layouts:
 #
-#   - Standalone path: copy each `dist/skills/<name>/` to ~/.claude/skills/<name>/
-#                      copy `dist/agents/*.md` to ~/.claude/agents/
-#   - Plugin path:     copy `dist/plugin/` to ~/.claude/plugins/idd/
+#   - Standalone path: copy each `dist/skills/<name>/` to <tool>/skills/<name>/
+#                      copy `dist/agents/*.md` to <tool>/agents/ (Claude + agents only)
+#   - Plugin path:     copy `dist/plugin/` to ~/.claude/plugins/idd/ (Claude only)
 #                      (requires a fresh build — `dist/plugin/` is gitignored)
+#
+# Each `dist/skills/<name>/` is a self-contained SKILL.md tree (the shared
+# agents are bundled inside it at references/agents/), so it works on any
+# SKILL.md-compatible tool. The standalone path therefore supports multiple
+# tools. The shared-agents and plugin layouts are Claude Code concepts and
+# only apply to the Claude target (and the universal `agents` target).
+#
+# Supported tools (--tool / --tools):
+#   claude       ~/.claude/skills            + agents ~/.claude/agents       (default)
+#   agents       ~/.agents/skills            + agents ~/.agents/agents
+#   codex        ~/.codex/skills
+#   opencode     ~/.config/opencode/skills
+#   pi           ~/.pi/skills
+#   openclaw     ~/.openclaw/skills
+#   hermes       ~/.hermes/skills
+#   antigravity  ~/.antigravity/skills
+#   windsurf     ~/.windsurf/rules
 #
 # Idempotent: re-running cleans the destination directory first, so no
 # duplicate files or stale references are left behind.
 #
 # Usage:
-#   ./scripts/install.sh                # install standalone skills (default)
-#   ./scripts/install.sh --plugin       # install plugin tree
-#   ./scripts/install.sh --all          # install both standalone + plugin
-#   ./scripts/install.sh --agents-only  # install Claude Code agents only
-#   ./scripts/install.sh --skill <n>    # install one named skill (standalone)
-#   ./scripts/install.sh --target <dir> # override Claude install root (default: ~/.claude)
-#   ./scripts/install.sh --uninstall    # remove installed standalone skills + managed agents
-#   ./scripts/install.sh --dry-run      # show what would be installed
-#   ./scripts/install.sh --help         # this help text
+#   ./scripts/install.sh                  # interactive tool picker on a TTY;
+#                                         # defaults to Claude when non-interactive
+#   ./scripts/install.sh --tool codex     # install standalone skills for one tool (skips picker)
+#   ./scripts/install.sh --tools all      # install standalone skills for every supported tool
+#   ./scripts/install.sh --plugin         # install plugin tree (Claude only)
+#   ./scripts/install.sh --all            # install both standalone + plugin (Claude)
+#   ./scripts/install.sh --agents-only    # install shared agents only (Claude/agents)
+#   ./scripts/install.sh --skill <n>      # install one named skill (standalone)
+#   ./scripts/install.sh --target <dir>   # override Claude install root (default: ~/.claude)
+#   ./scripts/install.sh --uninstall      # remove installed standalone skills + managed agents
+#   ./scripts/install.sh --dry-run        # show what would be installed
+#   ./scripts/install.sh --help           # this help text
 #
 # Exit codes:
 #   0  success
@@ -48,36 +68,95 @@ ONLY_SKILL=""
 DRY_RUN=0
 INSTALL_AGENTS=1
 FORCE_AGENTS=0
+TARGET_SET=0        # 1 once --target is given (only valid for the claude tool)
+TOOLS=""            # space-separated list of selected tools; empty = default (claude)
+
+# All supported tools, in display order. Paths mirror `asm config show`.
+ALL_TOOLS="claude agents codex opencode pi openclaw hermes antigravity windsurf"
+
+# Skills destination directory for a tool. For claude this honors --target;
+# every other tool uses its fixed convention under $HOME.
+tool_skills_dest() {
+  case "$1" in
+    claude)      printf '%s\n' "$TARGET/skills" ;;
+    agents)      printf '%s\n' "${HOME}/.agents/skills" ;;
+    codex)       printf '%s\n' "${HOME}/.codex/skills" ;;
+    opencode)    printf '%s\n' "${HOME}/.config/opencode/skills" ;;
+    pi)          printf '%s\n' "${HOME}/.pi/skills" ;;
+    openclaw)    printf '%s\n' "${HOME}/.openclaw/skills" ;;
+    hermes)      printf '%s\n' "${HOME}/.hermes/skills" ;;
+    antigravity) printf '%s\n' "${HOME}/.antigravity/skills" ;;
+    windsurf)    printf '%s\n' "${HOME}/.windsurf/rules" ;;
+    *)           return 1 ;;
+  esac
+}
+
+# Shared-agents destination for a tool, or empty if the tool has no agents
+# layout. Shared agents are a Claude Code concept; the universal `agents`
+# tool mirrors it. Other tools bundle the agents inside each skill instead.
+# NOTE: ~/.agents/agents is an IDD-owned convention (asm tracks only
+# ~/.agents/skills). cleanup_stale_agents treats every IDD-marked .md there
+# as managed, so only IDD should write to this directory.
+tool_agents_dest() {
+  case "$1" in
+    claude) printf '%s\n' "$TARGET/agents" ;;
+    agents) printf '%s\n' "${HOME}/.agents/agents" ;;
+    *)      printf '%s\n' "" ;;
+  esac
+}
+
+is_valid_tool() {
+  case " $ALL_TOOLS " in *" $1 "*) return 0 ;; *) return 1 ;; esac
+}
+
+# Append a tool to TOOLS if not already present.
+add_tool() {
+  is_valid_tool "$1" || { err "unknown tool: $1"; err "  Supported: $ALL_TOOLS"; exit 1; }
+  case " $TOOLS " in *" $1 "*) return 0 ;; esac
+  TOOLS="${TOOLS:+$TOOLS }$1"
+}
 
 usage() {
   cat <<EOF
 install.sh — install IDD skills/plugin from this working tree.
 
 USAGE
+  ./scripts/install.sh [--tool <name> | --tools <list|all>] [--skill <name>] [--target <dir>] [--dry-run]
   ./scripts/install.sh [--plugin | --all | --agents-only] [--skill <name>] [--target <dir>] [--dry-run]
-  ./scripts/install.sh --uninstall [--plugin | --all] [--skill <name>] [--target <dir>] [--dry-run]
+  ./scripts/install.sh --uninstall [...same flags...]
   ./scripts/install.sh --help
 
 OPTIONS
-  --plugin           Install plugin tree to <target>/plugins/idd/
+  --tool <name>      Install standalone skills for one tool (repeatable). Default: claude
+  --tools <list>     Comma-separated tools, or "all" for every supported tool
+                     (note: "--tools all" = every tool; "--all" = Claude skills+plugin)
+  --plugin           Install plugin tree to <target>/plugins/idd/ (Claude only)
                      (requires running ./scripts/build.sh first to populate dist/plugin/)
-  --all              Install both standalone skills and the plugin tree
-  --agents-only      Install shared Claude Code agents to <target>/agents/
+  --all              Install both standalone skills and the plugin tree (Claude)
+  --agents-only      Install shared agents to <target>/agents/ (Claude/agents only)
   --skill <name>     Standalone install of a single named skill (e.g. issue-resolver)
-  --target <dir>     Override Claude root (default: \$HOME/.claude)
+  --target <dir>     Override Claude root (default: \$HOME/.claude; claude tool only)
   --no-agents        Install standalone skills without updating shared agents
   --force-agents     Back up and replace unmanaged agent files with the same names
   --uninstall        Remove installed files instead of installing them
   --dry-run          Print actions without copying
   --help             Show this help
 
+SUPPORTED TOOLS
+  claude (default), agents, codex, opencode, pi, openclaw, hermes, antigravity, windsurf
+  Shared agents install only for claude and agents; every other tool gets
+  self-contained skills (the agents are bundled inside each skill).
+
 EXAMPLES
-  ./scripts/install.sh                          # all standalone skills
-  ./scripts/install.sh --skill issue-resolver   # one skill
-  ./scripts/install.sh --agents-only             # agents only
+  ./scripts/install.sh                          # interactive tool picker (TTY); Claude if non-interactive
+  ./scripts/install.sh --tool codex             # all skills for Codex (skips the picker)
+  ./scripts/install.sh --tools claude,codex,pi  # several tools at once
+  ./scripts/install.sh --tools all              # every supported tool
+  ./scripts/install.sh --skill issue-resolver --tool opencode   # one skill, one tool
+  ./scripts/install.sh --agents-only            # shared agents only (Claude)
   ./scripts/install.sh --plugin                 # plugin only (run build.sh first)
-  ./scripts/install.sh --all                    # everything
-  ./scripts/install.sh --uninstall              # remove standalone skills + managed agents
+  ./scripts/install.sh --all                    # everything (Claude)
+  ./scripts/install.sh --tools all --uninstall  # remove skills from every tool
 EOF
 }
 
@@ -95,6 +174,83 @@ run() {
   fi
 }
 
+# Human-readable label for a tool (matches `asm config show` labels).
+tool_label() {
+  case "$1" in
+    claude)      printf '%s\n' "Claude Code" ;;
+    agents)      printf '%s\n' "Agents (universal ~/.agents)" ;;
+    codex)       printf '%s\n' "Codex CLI" ;;
+    opencode)    printf '%s\n' "OpenCode" ;;
+    pi)          printf '%s\n' "Pi" ;;
+    openclaw)    printf '%s\n' "OpenClaw" ;;
+    hermes)      printf '%s\n' "Hermes" ;;
+    antigravity) printf '%s\n' "Google Antigravity" ;;
+    windsurf)    printf '%s\n' "Windsurf" ;;
+    *)           printf '%s\n' "$1" ;;
+  esac
+}
+
+# Interactively prompt for one or more tools, populating TOOLS. Falls back to
+# the default (claude) on empty input. Reads from /dev/tty so it works even
+# when the script is piped (e.g. curl | bash) as long as a terminal exists.
+prompt_for_tools() {
+  local -a tool_arr
+  read -r -a tool_arr <<< "$ALL_TOOLS"
+
+  {
+    log ""
+    log "◆ Select the tool(s) to install IDD skills for:"
+    log "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄"
+    local i=1
+    for t in "${tool_arr[@]}"; do
+      local suffix=""
+      [ "$t" = "claude" ] && suffix="  (default)"
+      printf '  %d) %-12s %s%s\n' "$i" "$t" "$(tool_label "$t")" "$suffix"
+      i=$((i + 1))
+    done
+    log "  a) all of the above"
+    log ""
+    log "  Enter numbers (e.g. 1 3 4 or 1,3,4), 'a' for all, or press Enter for Claude Code."
+  } >&2
+
+  # Read the reply from stdin when it is a terminal (also lets tests feed a
+  # here-string); otherwise read from /dev/tty so a piped `curl | bash` still
+  # gets an interactive prompt.
+  local reply
+  printf '  > ' >&2
+  if [ -t 0 ] || [ "${IDD_FORCE_PROMPT:-0}" = "1" ]; then
+    read -r reply || reply=""
+  else
+    read -r reply </dev/tty || reply=""
+  fi
+
+  # Empty -> default to claude.
+  if [ -z "$(printf '%s' "$reply" | tr -d '[:space:]')" ]; then
+    add_tool "claude"
+    return
+  fi
+
+  # 'a'/'all' -> every tool.
+  case "$(printf '%s' "$reply" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')" in
+    a|all) for t in "${tool_arr[@]}"; do add_tool "$t"; done; return ;;
+  esac
+
+  # Otherwise parse space/comma-separated numbers.
+  local cleaned
+  cleaned="$(printf '%s' "$reply" | tr ',' ' ')"
+  local token
+  for token in $cleaned; do
+    case "$token" in
+      ''|*[!0-9]*)
+        err "invalid selection: '$token' — enter list numbers, 'a', or Enter"; exit 1 ;;
+    esac
+    if [ "$token" -lt 1 ] || [ "$token" -gt "${#tool_arr[@]}" ]; then
+      err "selection out of range: '$token' (valid: 1-${#tool_arr[@]})"; exit 1
+    fi
+    add_tool "${tool_arr[$((token - 1))]}"
+  done
+}
+
 # ---------------------------------------------------------------------------
 # Arg parsing
 # ---------------------------------------------------------------------------
@@ -104,12 +260,27 @@ while [ $# -gt 0 ]; do
     --plugin)    MODE="plugin"; shift ;;
     --all)       MODE="all"; shift ;;
     --agents-only) MODE="agents"; shift ;;
+    --tool)
+      [ $# -ge 2 ] || { err "--tool requires a name"; exit 1; }
+      add_tool "$2"; shift 2 ;;
+    --tools)
+      [ $# -ge 2 ] || { err "--tools requires a comma-separated list or 'all'"; exit 1; }
+      if [ "$2" = "all" ]; then
+        for t in $ALL_TOOLS; do add_tool "$t"; done
+      else
+        IFS=',' read -r -a _tools <<< "$2"
+        for t in "${_tools[@]}"; do
+          t="$(printf '%s' "$t" | tr -d '[:space:]')"
+          [ -n "$t" ] && add_tool "$t"
+        done
+      fi
+      shift 2 ;;
     --skill)
       [ $# -ge 2 ] || { err "--skill requires a name"; exit 1; }
       ONLY_SKILL="$2"; shift 2 ;;
     --target)
       [ $# -ge 2 ] || { err "--target requires a directory"; exit 1; }
-      TARGET="$2"; shift 2 ;;
+      TARGET="$2"; TARGET_SET=1; shift 2 ;;
     --no-agents) INSTALL_AGENTS=0; shift ;;
     --force-agents) FORCE_AGENTS=1; shift ;;
     --uninstall) ACTION="uninstall"; shift ;;
@@ -119,9 +290,42 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-SKILLS_DEST="$TARGET/skills"
-AGENTS_DEST="$TARGET/agents"
-PLUGIN_DEST="$TARGET/plugins/idd"
+# Resolve the tool selection when none was given on the command line.
+# For a standalone install on an interactive terminal, prompt the user to
+# pick one or more tools. Otherwise (non-TTY, or plugin/agents-only modes
+# which are Claude-scoped) fall back to the Claude default silently.
+# IDD_FORCE_PROMPT=1 forces the prompt regardless of TTY (used by tests).
+if [ -z "$TOOLS" ]; then
+  if [ "$MODE" = "standalone" ] && \
+     { [ "${IDD_FORCE_PROMPT:-0}" = "1" ] || { [ -t 0 ] && [ -r /dev/tty ]; }; }; then
+    prompt_for_tools
+  fi
+  [ -n "$TOOLS" ] || TOOLS="claude"
+fi
+
+# --target only makes sense for the claude tool (other tools use fixed paths).
+if [ "$TARGET_SET" -eq 1 ]; then
+  case " $TOOLS " in
+    *" claude "*) : ;;
+    *) err "--target only applies to the claude tool; selected: $TOOLS"; exit 1 ;;
+  esac
+fi
+
+# Plugin and shared-agents layouts are Claude Code concepts. Reject them when a
+# tool without an agents/plugin layout is selected (everything except claude
+# and agents; the plugin tree is claude-only).
+case "$MODE" in
+  plugin|all)
+    case " $TOOLS " in
+      *" claude "*) : ;;
+      *) err "--plugin / --all install the Claude plugin tree and only apply to the claude tool"; exit 1 ;;
+    esac ;;
+  agents)
+    for t in $TOOLS; do
+      [ -n "$(tool_agents_dest "$t")" ] || {
+        err "--agents-only does not apply to '$t' (no shared-agents layout); use claude or agents"; exit 1; }
+    done ;;
+esac
 
 # ---------------------------------------------------------------------------
 # Source presence checks
@@ -170,9 +374,10 @@ ensure_plugin_src() {
 
 install_one_skill() {
   local name="$1"
+  local skills_dest="$2"
   local src="$DIST_SKILLS/$name"
-  local dst="$SKILLS_DEST/$name"
-  run mkdir -p "$SKILLS_DEST"
+  local dst="$skills_dest/$name"
+  run mkdir -p "$skills_dest"
   if [ -d "$dst" ]; then
     run rm -rf "$dst"
   fi
@@ -189,12 +394,13 @@ is_idd_managed_agent() {
 
 install_one_agent() {
   local src="$1"
+  local agents_dest="$2"
   local file
   file="$(basename "$src")"
   local name="${file%.md}"
-  local dst="$AGENTS_DEST/$file"
+  local dst="$agents_dest/$file"
 
-  run mkdir -p "$AGENTS_DEST"
+  run mkdir -p "$agents_dest"
   if [ -f "$dst" ]; then
     if cmp -s "$src" "$dst"; then
       ok "agent current: $name -> $dst"
@@ -219,10 +425,11 @@ install_one_agent() {
 }
 
 cleanup_stale_agents() {
-  if [ ! -d "$AGENTS_DEST" ]; then
+  local agents_dest="$1"
+  if [ ! -d "$agents_dest" ]; then
     return 0
   fi
-  for f in "$AGENTS_DEST"/*.md; do
+  for f in "$agents_dest"/*.md; do
     [ -f "$f" ] || continue
     is_idd_managed_agent "$f" || continue
     if [ ! -f "$DIST_AGENTS/$(basename "$f")" ]; then
@@ -233,43 +440,57 @@ cleanup_stale_agents() {
 }
 
 install_agents() {
+  local agents_dest="$1"
   ensure_agents_src
-  info "installing shared Claude Code agents to $AGENTS_DEST"
-  cleanup_stale_agents
+  info "installing shared agents to $agents_dest"
+  cleanup_stale_agents "$agents_dest"
   for f in "$DIST_AGENTS"/*.md; do
     [ -f "$f" ] || continue
-    install_one_agent "$f"
+    install_one_agent "$f" "$agents_dest"
   done
+}
+
+# Install standalone skills (and, where applicable, shared agents) for one tool.
+install_standalone_tool() {
+  local tool="$1"
+  local skills_dest agents_dest
+  skills_dest="$(tool_skills_dest "$tool")"
+  agents_dest="$(tool_agents_dest "$tool")"
+
+  info "[$tool] installing standalone skills to $skills_dest"
+  if [ -n "$ONLY_SKILL" ]; then
+    install_one_skill "$ONLY_SKILL" "$skills_dest"
+  else
+    for d in "$DIST_SKILLS"/*/; do
+      [ -d "$d" ] || continue
+      install_one_skill "$(basename "$d")" "$skills_dest"
+    done
+  fi
+
+  # Shared agents only for tools that have an agents layout (claude, agents).
+  if [ "$INSTALL_AGENTS" -eq 1 ] && [ -n "$agents_dest" ]; then
+    install_agents "$agents_dest"
+  fi
 }
 
 install_standalone() {
   ensure_skills_src
-  info "installing standalone skills to $SKILLS_DEST"
-  if [ -n "$ONLY_SKILL" ]; then
-    install_one_skill "$ONLY_SKILL"
-    if [ "$INSTALL_AGENTS" -eq 1 ]; then
-      install_agents
-    fi
-    return
-  fi
-  for d in "$DIST_SKILLS"/*/; do
-    [ -d "$d" ] || continue
-    install_one_skill "$(basename "$d")"
+  for tool in $TOOLS; do
+    install_standalone_tool "$tool"
   done
-  if [ "$INSTALL_AGENTS" -eq 1 ]; then
-    install_agents
-  fi
 }
 
 install_plugin() {
+  # Plugin tree is a Claude Code concept — always installs under $TARGET.
+  local plugin_dest="$TARGET/plugins/idd"
   ensure_plugin_src
-  info "installing plugin tree to $PLUGIN_DEST"
-  run mkdir -p "$(dirname "$PLUGIN_DEST")"
-  if [ -d "$PLUGIN_DEST" ]; then
-    run rm -rf "$PLUGIN_DEST"
+  info "installing plugin tree to $plugin_dest"
+  run mkdir -p "$(dirname "$plugin_dest")"
+  if [ -d "$plugin_dest" ]; then
+    run rm -rf "$plugin_dest"
   fi
-  run cp -R "$DIST_PLUGIN/" "$PLUGIN_DEST/"
-  ok "plugin installed: $PLUGIN_DEST"
+  run cp -R "$DIST_PLUGIN/" "$plugin_dest/"
+  ok "plugin installed: $plugin_dest"
 }
 
 remove_path() {
@@ -284,15 +505,16 @@ remove_path() {
 }
 
 uninstall_agents() {
+  local agents_dest="$1"
   ensure_agents_src
-  if [ ! -d "$AGENTS_DEST" ]; then
-    info "agents not installed: $AGENTS_DEST"
+  if [ ! -d "$agents_dest" ]; then
+    info "agents not installed: $agents_dest"
     return
   fi
-  info "removing IDD-managed agents from $AGENTS_DEST"
+  info "removing IDD-managed agents from $agents_dest"
   for src in "$DIST_AGENTS"/*.md; do
     [ -f "$src" ] || continue
-    local dst="$AGENTS_DEST/$(basename "$src")"
+    local dst="$agents_dest/$(basename "$src")"
     if [ ! -f "$dst" ]; then
       info "agent not installed: $(basename "$src" .md)"
     elif is_idd_managed_agent "$dst"; then
@@ -302,27 +524,39 @@ uninstall_agents() {
       warn "left unmanaged agent untouched: $dst"
     fi
   done
-  cleanup_stale_agents
+  cleanup_stale_agents "$agents_dest"
 }
 
-uninstall_standalone() {
-  ensure_skills_src
+# Remove standalone skills (and, where applicable, shared agents) for one tool.
+uninstall_standalone_tool() {
+  local tool="$1"
+  local skills_dest agents_dest
+  skills_dest="$(tool_skills_dest "$tool")"
+  agents_dest="$(tool_agents_dest "$tool")"
+
   if [ -n "$ONLY_SKILL" ]; then
-    remove_path "skill" "$SKILLS_DEST/$ONLY_SKILL"
-    info "agents left installed because --skill targets one skill only"
+    remove_path "[$tool] skill" "$skills_dest/$ONLY_SKILL"
+    [ -n "$agents_dest" ] && info "[$tool] agents left installed because --skill targets one skill only"
     return
   fi
   for d in "$DIST_SKILLS"/*/; do
     [ -d "$d" ] || continue
-    remove_path "skill" "$SKILLS_DEST/$(basename "$d")"
+    remove_path "[$tool] skill" "$skills_dest/$(basename "$d")"
   done
-  if [ "$INSTALL_AGENTS" -eq 1 ]; then
-    uninstall_agents
+  if [ "$INSTALL_AGENTS" -eq 1 ] && [ -n "$agents_dest" ]; then
+    uninstall_agents "$agents_dest"
   fi
 }
 
+uninstall_standalone() {
+  ensure_skills_src
+  for tool in $TOOLS; do
+    uninstall_standalone_tool "$tool"
+  done
+}
+
 uninstall_plugin() {
-  remove_path "plugin" "$PLUGIN_DEST"
+  remove_path "plugin" "$TARGET/plugins/idd"
 }
 
 # ---------------------------------------------------------------------------
@@ -331,14 +565,21 @@ uninstall_plugin() {
 
 case "$ACTION:$MODE" in
   install:standalone) install_standalone ;;
-  install:agents)     install_agents ;;
+  install:agents)
+    ensure_agents_src
+    for tool in $TOOLS; do
+      install_agents "$(tool_agents_dest "$tool")"
+    done ;;
   install:plugin)     install_plugin ;;
   install:all)
     install_standalone
     install_plugin
     ;;
   uninstall:standalone) uninstall_standalone ;;
-  uninstall:agents)     uninstall_agents ;;
+  uninstall:agents)
+    for tool in $TOOLS; do
+      uninstall_agents "$(tool_agents_dest "$tool")"
+    done ;;
   uninstall:plugin)     uninstall_plugin ;;
   uninstall:all)
     uninstall_standalone
@@ -349,7 +590,7 @@ esac
 
 log ""
 if [ "$ACTION" = "install" ]; then
-  ok "done — restart Claude Code to load the new skills/agents/plugin"
+  ok "done — restart your agent tool(s) to load the new skills/agents/plugin"
 else
-  ok "done — restart Claude Code to unload removed skills/agents/plugin"
+  ok "done — restart your agent tool(s) to unload removed skills/agents/plugin"
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -265,11 +265,13 @@ while [ $# -gt 0 ]; do
       add_tool "$2"; shift 2 ;;
     --tools)
       [ $# -ge 2 ] || { err "--tools requires a comma-separated list or 'all'"; exit 1; }
-      if [ "$2" = "all" ]; then
+      [ -n "$(printf '%s' "$2" | tr -d '[:space:]')" ] || \
+        { err "--tools requires a non-empty list or 'all'"; exit 1; }
+      if [ "$(printf '%s' "$2" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')" = "all" ]; then
         for t in $ALL_TOOLS; do add_tool "$t"; done
       else
         IFS=',' read -r -a _tools <<< "$2"
-        for t in "${_tools[@]}"; do
+        for t in "${_tools[@]+"${_tools[@]}"}"; do
           t="$(printf '%s' "$t" | tr -d '[:space:]')"
           [ -n "$t" ] && add_tool "$t"
         done

--- a/tests/test-install-script-tools.sh
+++ b/tests/test-install-script-tools.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# test-install-script-tools.sh — Verify multi-tool standalone install support.
+#
+# install.sh installs self-contained skills to any SKILL.md-compatible tool.
+# This suite asserts the per-tool destination paths, the skills-only behavior
+# for tools without a shared-agents layout, and the guard rails that reject
+# Claude-only options (--plugin / --agents-only / --target) for those tools.
+#
+# Each non-Claude tool uses a fixed $HOME-relative path, so the tests run the
+# installer under an isolated HOME (a temp dir) to avoid touching real config.
+#
+# Usage: bash tests/test-install-script-tools.sh
+# Returns: exit 0 on pass, exit 1 on failure.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BUILD_SH="$REPO_ROOT/scripts/build.sh"
+INSTALL_SH="$REPO_ROOT/scripts/install.sh"
+DIST_SKILLS="$REPO_ROOT/dist/skills"
+
+PASS=0
+FAIL=0
+
+pass() { echo "  ✓ $1"; PASS=$((PASS + 1)); }
+fail() { echo "  ✗ $1"; FAIL=$((FAIL + 1)); }
+
+echo "◆ Install Script Multi-Tool Tests"
+echo "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄"
+
+TMP_HOME="$(mktemp -d)"
+trap 'rm -rf "$TMP_HOME"' EXIT
+
+if "$BUILD_SH" >/dev/null 2>&1; then
+  pass "T0: build.sh generates current dist outputs"
+else
+  fail "T0: build.sh failed"
+  exit 1
+fi
+
+skill_count="$(find "$DIST_SKILLS" -maxdepth 1 -mindepth 1 -type d | wc -l | tr -d ' ')"
+
+# run install.sh under an isolated HOME
+inst() { HOME="$TMP_HOME" "$INSTALL_SH" "$@"; }
+
+# ───────────────────────────────────────────────────────────
+# T1: each non-Claude tool installs all skills to its fixed path
+# ───────────────────────────────────────────────────────────
+# tool|skills dir relative to HOME
+declare -a TOOL_PATHS=(
+  "codex|.codex/skills"
+  "opencode|.config/opencode/skills"
+  "pi|.pi/skills"
+  "openclaw|.openclaw/skills"
+  "hermes|.hermes/skills"
+  "antigravity|.antigravity/skills"
+  "windsurf|.windsurf/rules"
+)
+
+for entry in "${TOOL_PATHS[@]}"; do
+  tool="${entry%%|*}"
+  rel="${entry#*|}"
+  dest="$TMP_HOME/$rel"
+  if inst --tool "$tool" >/dev/null 2>&1; then
+    installed="$(find "$dest" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | wc -l | tr -d ' ')"
+    if [ "$installed" = "$skill_count" ]; then
+      pass "T1[$tool]: $skill_count skills installed to $rel"
+    else
+      fail "T1[$tool]: expected $skill_count skills at $rel, found $installed"
+    fi
+  else
+    fail "T1[$tool]: install failed"
+  fi
+done
+
+# ───────────────────────────────────────────────────────────
+# T2: non-Claude tools get NO shared-agents directory
+# ───────────────────────────────────────────────────────────
+if [ ! -d "$TMP_HOME/.codex/agents" ] && [ ! -d "$TMP_HOME/.hermes/agents" ]; then
+  pass "T2: non-Claude tools receive skills only (no agents dir)"
+else
+  fail "T2: unexpected agents dir created for a non-Claude tool"
+fi
+
+# ───────────────────────────────────────────────────────────
+# T3: skills are self-contained (bundled agents present)
+# ───────────────────────────────────────────────────────────
+if [ -f "$TMP_HOME/.codex/skills/issue-resolver/references/agents/codebase-researcher.md" ]; then
+  pass "T3: skills ship bundled shared agents (self-contained)"
+else
+  fail "T3: bundled agents missing from installed skill"
+fi
+
+# ───────────────────────────────────────────────────────────
+# T4: 'agents' tool installs skills AND shared agents
+# ───────────────────────────────────────────────────────────
+if inst --tool agents >/dev/null 2>&1; then
+  if [ -d "$TMP_HOME/.agents/skills" ] && \
+     [ -f "$TMP_HOME/.agents/agents/codebase-researcher.md" ]; then
+    pass "T4: 'agents' tool installs skills + shared agents (~/.agents/agents)"
+  else
+    fail "T4: 'agents' tool missing skills or shared agents"
+  fi
+else
+  fail "T4: 'agents' tool install failed"
+fi
+
+# ───────────────────────────────────────────────────────────
+# T5: --tools list and 'all' fan out
+# ───────────────────────────────────────────────────────────
+TMP_HOME2="$(mktemp -d)"
+if HOME="$TMP_HOME2" "$INSTALL_SH" --tools codex,pi >/dev/null 2>&1; then
+  if [ -d "$TMP_HOME2/.codex/skills" ] && [ -d "$TMP_HOME2/.pi/skills" ] && \
+     [ ! -d "$TMP_HOME2/.hermes/skills" ]; then
+    pass "T5: --tools codex,pi installs exactly those two"
+  else
+    fail "T5: --tools comma-list did not fan out correctly"
+  fi
+else
+  fail "T5: --tools comma-list install failed"
+fi
+rm -rf "$TMP_HOME2"
+
+# ───────────────────────────────────────────────────────────
+# T6: guard rails reject Claude-only options for other tools
+# ───────────────────────────────────────────────────────────
+if ! inst --plugin --tool codex --dry-run >/dev/null 2>&1; then
+  pass "T6.1: --plugin rejected for non-Claude tool"
+else
+  fail "T6.1: --plugin should be rejected for non-Claude tool"
+fi
+
+if ! inst --agents-only --tool codex --dry-run >/dev/null 2>&1; then
+  pass "T6.2: --agents-only rejected for tool without agents layout"
+else
+  fail "T6.2: --agents-only should be rejected for codex"
+fi
+
+if ! inst --tool codex --target /tmp/x --dry-run >/dev/null 2>&1; then
+  pass "T6.3: --target rejected for non-Claude tool"
+else
+  fail "T6.3: --target should be rejected for non-Claude tool"
+fi
+
+if ! inst --tool bogus --dry-run >/dev/null 2>&1; then
+  pass "T6.4: unknown tool name rejected"
+else
+  fail "T6.4: unknown tool name should be rejected"
+fi
+
+# ───────────────────────────────────────────────────────────
+# T7: uninstall removes a tool's skills
+# ───────────────────────────────────────────────────────────
+if inst --tool hermes --uninstall >/dev/null 2>&1; then
+  remaining="$(find "$TMP_HOME/.hermes/skills" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | wc -l | tr -d ' ')"
+  if [ "$remaining" = "0" ]; then
+    pass "T7: uninstall removes all skills for a tool"
+  else
+    fail "T7: uninstall left $remaining skills for hermes"
+  fi
+else
+  fail "T7: uninstall failed"
+fi
+
+# ───────────────────────────────────────────────────────────
+# T8: interactive tool selection (IDD_FORCE_PROMPT reads from stdin)
+# ───────────────────────────────────────────────────────────
+# prompt + reply, capture which tools the installer reported targeting
+prompt_inst() { IDD_FORCE_PROMPT=1 HOME="$TMP_HOME" "$INSTALL_SH" --dry-run "$@"; }
+
+# Enter (empty) -> Claude default
+out="$(prompt_inst <<< "" 2>&1 || true)"
+if grep -q '\[claude\] installing' <<< "$out" && ! grep -q '\[codex\] installing' <<< "$out"; then
+  pass "T8.1: empty reply defaults to Claude"
+else
+  fail "T8.1: empty reply did not default to Claude"
+fi
+
+# numeric multi-select "3 5" -> codex + pi
+out="$(prompt_inst <<< "3 5" 2>&1 || true)"
+if grep -q '\[codex\] installing' <<< "$out" && grep -q '\[pi\] installing' <<< "$out" && \
+   ! grep -q '\[claude\] installing' <<< "$out"; then
+  pass "T8.2: '3 5' selects codex + pi"
+else
+  fail "T8.2: '3 5' did not select codex + pi"
+fi
+
+# comma list "1,3" -> claude + codex
+out="$(prompt_inst <<< "1,3" 2>&1 || true)"
+if grep -q '\[claude\] installing' <<< "$out" && grep -q '\[codex\] installing' <<< "$out"; then
+  pass "T8.3: '1,3' selects claude + codex"
+else
+  fail "T8.3: '1,3' did not select claude + codex"
+fi
+
+# 'a' -> all 9 tools
+count="$(prompt_inst <<< "a" 2>&1 | grep -c 'installing standalone skills' || true)"
+if [ "$count" = "9" ]; then
+  pass "T8.4: 'a' selects all 9 tools"
+else
+  fail "T8.4: 'a' selected $count tools (expected 9)"
+fi
+
+# out-of-range / invalid input exits non-zero
+if prompt_inst <<< "99" >/dev/null 2>&1; then
+  fail "T8.5: out-of-range selection should fail"
+else
+  pass "T8.5: out-of-range selection rejected"
+fi
+if prompt_inst <<< "xyz" >/dev/null 2>&1; then
+  fail "T8.6: non-numeric selection should fail"
+else
+  pass "T8.6: non-numeric selection rejected"
+fi
+
+# explicit --tool bypasses the prompt entirely
+out="$(prompt_inst --tool windsurf <<< "3 5" 2>&1 || true)"
+if grep -q '\[windsurf\] installing' <<< "$out" && ! grep -q '\[codex\] installing' <<< "$out"; then
+  pass "T8.7: explicit --tool bypasses the interactive prompt"
+else
+  fail "T8.7: explicit --tool did not bypass the prompt"
+fi
+
+# non-interactive (no force, piped stdin) falls back to Claude without prompting
+out="$(printf '' | HOME="$TMP_HOME" "$INSTALL_SH" --dry-run 2>&1 || true)"
+if ! grep -q 'Select the tool' <<< "$out" && grep -q '\[claude\] installing' <<< "$out"; then
+  pass "T8.8: non-interactive run skips prompt, defaults to Claude"
+else
+  fail "T8.8: non-interactive run did not behave correctly"
+fi
+
+echo "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄"
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+if [ "$FAIL" -eq 0 ]; then
+  echo "  ✓ Install script multi-tool tests pass"
+  exit 0
+else
+  echo "  ✗ Install script multi-tool tests failed"
+  exit 1
+fi

--- a/tests/test-install-script-tools.sh
+++ b/tests/test-install-script-tools.sh
@@ -148,6 +148,21 @@ else
   fail "T6.4: unknown tool name should be rejected"
 fi
 
+# Empty --tools value is rejected cleanly (not an unbound-variable crash).
+if ! inst --tools "" --dry-run >/dev/null 2>&1; then
+  pass "T6.5: empty --tools value rejected"
+else
+  fail "T6.5: empty --tools value should be rejected"
+fi
+
+# 'all' keyword tolerates case and surrounding whitespace, like the picker.
+count="$(inst --tools 'All ' --dry-run 2>&1 | grep -c 'installing standalone skills' || true)"
+if [ "$count" = "9" ]; then
+  pass "T6.6: --tools 'All ' normalizes to all 9 tools"
+else
+  fail "T6.6: --tools 'All ' selected $count tools (expected 9)"
+fi
+
 # ───────────────────────────────────────────────────────────
 # T7: uninstall removes a tool's skills
 # ───────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #97

## Summary

Extends `scripts/install.sh` beyond Claude Code so IDD skills install into other SKILL.md-compatible agent tools. When run interactively, the script now presents a picker to select one or more target tools.

Supported tools (paths mirror `asm config show`):

| Tool | Skills dir | Agents dir |
|------|-----------|-----------|
| claude *(default)* | `~/.claude/skills` | `~/.claude/agents` |
| agents | `~/.agents/skills` | `~/.agents/agents` |
| codex | `~/.codex/skills` | — |
| opencode | `~/.config/opencode/skills` | — |
| pi | `~/.pi/skills` | — |
| openclaw | `~/.openclaw/skills` | — |
| hermes | `~/.hermes/skills` | — |
| antigravity | `~/.antigravity/skills` | — |
| windsurf | `~/.windsurf/rules` | — |

Each `dist/skills/<name>/` bundles its shared agents at `references/agents/` (with an inline fallback), so a skill is self-contained and runs on any tool. The standalone `~/.claude/agents/` (and `~/.agents/agents/`) install is a Claude-native subagent optimization; other tools use the bundled copies.

## Interactive picker

Running `./scripts/install.sh` with no `--tool`/`--tools` flag on a terminal shows a numbered list:

```
◆ Select the tool(s) to install IDD skills for:
  1) claude       Claude Code  (default)
  2) agents       Agents (universal ~/.agents)
  3) codex        Codex CLI
  ...
  9) windsurf     Windsurf
  a) all of the above
```

- Multiple tools via space/comma-separated numbers (`1 3 4` or `1,3,4`)
- `a` → all tools; Enter → Claude Code
- Invalid/out-of-range input is rejected

Reads from `/dev/tty`, so it works under `curl | bash`. In non-interactive contexts (CI, piped input, no TTY) it falls back to Claude Code — existing automation is unaffected.

## Flags

- New: `--tool <name>` (repeatable), `--tools <list|all>`
- Default (no flag, no TTY) stays **Claude-only** for backward compatibility
- Guard rails: `--plugin`/`--all`/`--agents-only`/`--target` reject tools lacking the relevant Claude-only layout; unknown tool names rejected

## Testing

- New `tests/test-install-script-tools.sh` — 25 assertions (per-tool paths, skills-only behavior, self-contained bundling, `agents` dual install, comma-list fan-out, guard rails, uninstall, and 8 interactive-picker cases). ✅
- Existing `tests/test-install-script-agents.sh` (10 assertions) still passes. ✅

## Docs

Updated README and `docs/DEVELOPMENT.md` install sections.