### PR TITLE
fix(auto-pilot): never pass skill name as subagent_type (#98)

### DIFF
--- a/dist/skills/auto-pilot/references/phases.md
+++ b/dist/skills/auto-pilot/references/phases.md
@@ -136,7 +136,7 @@ This is safe because the auto-pilot always pushes work to remote PRs before clea
 
 ### Step 2.2 — Spawn Resolver Subagent
 
-Launch a subagent using the Agent tool to perform the entire resolve pipeline. This keeps all codebase reading, code writing, and test execution out of the main agent's context.
+Launch a subagent using the Agent tool to perform the entire resolve pipeline. This keeps all codebase reading, code writing, and test execution out of the main agent's context. Pass only `description` and `prompt` — do NOT set `subagent_type`. The resolver is a **skill** invoked from inside the prompt (via `../issue-resolver/SKILL.md`), not an agent type; passing `subagent_type: "issue-resolver"` fails with `Agent type 'issue-resolver' not found`.
 
 ```
 ● [Iteration {i}/{max}] Resolving #{issue_number}...

--- a/dist/skills/auto-pilot/references/subagent-prompts.md
+++ b/dist/skills/auto-pilot/references/subagent-prompts.md
@@ -2,7 +2,7 @@
 
 This file contains the exact prompts to pass to each subagent via the Agent tool. The main agent reads this file once at skill start and uses these templates for every iteration.
 
-**CRITICAL — never set `subagent_type`:** Every subagent below is spawned with the **default general-purpose agent**. Do NOT pass a `subagent_type` parameter to the Agent tool. The skills referenced in these prompts (`issue-resolver`, `issue-pr-review`, `issue-analysis`) are **skills**, not agent types — passing `subagent_type: "issue-resolver"` fails with `Agent type 'issue-resolver' not found`. The skill is invoked from *inside* the subagent's prompt via the `{{skill:...}}` token, never as the agent type. Pass only `description` and `prompt`.
+**CRITICAL — never set `subagent_type`:** Every subagent below is spawned with the **default general-purpose agent**. Do NOT pass a `subagent_type` parameter to the Agent tool. The skills referenced in these prompts (`issue-resolver`, `issue-pr-review`, `issue-analysis`) are **skills**, not agent types — passing `subagent_type: "issue-resolver"` fails with `Agent type 'issue-resolver' not found`. The skill is invoked from *inside* the subagent's prompt (via the skill prompts below), never as the agent type. Pass only `description` and `prompt`.
 
 **Autonomy principle:** All subagents operate in fully autonomous mode. They make all decisions independently, always choosing the best available option. They never prompt the user for confirmation. If something fails, they report the failure back to the main agent — they don't stop and ask.
 

--- a/dist/skills/auto-pilot/references/subagent-prompts.md
+++ b/dist/skills/auto-pilot/references/subagent-prompts.md
@@ -2,6 +2,8 @@
 
 This file contains the exact prompts to pass to each subagent via the Agent tool. The main agent reads this file once at skill start and uses these templates for every iteration.
 
+**CRITICAL — never set `subagent_type`:** Every subagent below is spawned with the **default general-purpose agent**. Do NOT pass a `subagent_type` parameter to the Agent tool. The skills referenced in these prompts (`issue-resolver`, `issue-pr-review`, `issue-analysis`) are **skills**, not agent types — passing `subagent_type: "issue-resolver"` fails with `Agent type 'issue-resolver' not found`. The skill is invoked from *inside* the subagent's prompt via the `{{skill:...}}` token, never as the agent type. Pass only `description` and `prompt`.
+
 **Autonomy principle:** All subagents operate in fully autonomous mode. They make all decisions independently, always choosing the best available option. They never prompt the user for confirmation. If something fails, they report the failure back to the main agent — they don't stop and ask.
 
 ## Resolver Subagent
@@ -9,6 +11,7 @@ This file contains the exact prompts to pass to each subagent via the Agent tool
 **Agent tool parameters:**
 - `description`: "Resolve issue #{N}"
 - `prompt`: (below)
+- `subagent_type`: omit (use the default general-purpose agent — `issue-resolver` is a skill, not an agent type)
 
 ```
 Resolve GitHub issue #{issue_number} in this repository using the ../issue-resolver/SKILL.md skill in auto mode.
@@ -45,6 +48,7 @@ When done, report back ONLY these fields:
 **Agent tool parameters:**
 - `description`: "Review PR #{N}"
 - `prompt`: (below)
+- `subagent_type`: omit (use the default general-purpose agent — `issue-pr-review` is a skill, not an agent type)
 
 ```
 Review pull request #{pr_number} in this repository using the ../issue-pr-review/SKILL.md skill.
@@ -87,6 +91,7 @@ Used in explicit list mode (`--issues`) to analyze all issues before resolution 
 **Agent tool parameters:**
 - `description`: "Analyze issues for optimal resolution"
 - `prompt`: (below)
+- `subagent_type`: omit (use the default general-purpose agent — `issue-analysis` is a skill, not an agent type)
 
 ```
 Analyze the following GitHub issues to determine the optimal resolution order
@@ -142,6 +147,7 @@ Used when the analyzer identifies issues that can be resolved together in a sing
 **Agent tool parameters:**
 - `description`: "Batch-resolve issues #{N1}, #{N2}"
 - `prompt`: (below)
+- `subagent_type`: omit (use the default general-purpose agent — `issue-resolver` is a skill, not an agent type)
 
 ```
 Resolve the following GitHub issues TOGETHER in a single branch and PR.

--- a/src/skills/auto-pilot/references/phases.md
+++ b/src/skills/auto-pilot/references/phases.md
@@ -136,7 +136,7 @@ This is safe because the auto-pilot always pushes work to remote PRs before clea
 
 ### Step 2.2 — Spawn Resolver Subagent
 
-Launch a subagent using the Agent tool to perform the entire resolve pipeline. This keeps all codebase reading, code writing, and test execution out of the main agent's context.
+Launch a subagent using the Agent tool to perform the entire resolve pipeline. This keeps all codebase reading, code writing, and test execution out of the main agent's context. Pass only `description` and `prompt` — do NOT set `subagent_type`. The resolver is a **skill** invoked from inside the prompt (via `{{skill:issue-resolver}}`), not an agent type; passing `subagent_type: "issue-resolver"` fails with `Agent type 'issue-resolver' not found`.
 
 ```
 ● [Iteration {i}/{max}] Resolving #{issue_number}...

--- a/src/skills/auto-pilot/references/subagent-prompts.md
+++ b/src/skills/auto-pilot/references/subagent-prompts.md
@@ -2,7 +2,7 @@
 
 This file contains the exact prompts to pass to each subagent via the Agent tool. The main agent reads this file once at skill start and uses these templates for every iteration.
 
-**CRITICAL — never set `subagent_type`:** Every subagent below is spawned with the **default general-purpose agent**. Do NOT pass a `subagent_type` parameter to the Agent tool. The skills referenced in these prompts (`issue-resolver`, `issue-pr-review`, `issue-analysis`) are **skills**, not agent types — passing `subagent_type: "issue-resolver"` fails with `Agent type 'issue-resolver' not found`. The skill is invoked from *inside* the subagent's prompt via the `{{skill:...}}` token, never as the agent type. Pass only `description` and `prompt`.
+**CRITICAL — never set `subagent_type`:** Every subagent below is spawned with the **default general-purpose agent**. Do NOT pass a `subagent_type` parameter to the Agent tool. The skills referenced in these prompts (`issue-resolver`, `issue-pr-review`, `issue-analysis`) are **skills**, not agent types — passing `subagent_type: "issue-resolver"` fails with `Agent type 'issue-resolver' not found`. The skill is invoked from *inside* the subagent's prompt (via the skill prompts below), never as the agent type. Pass only `description` and `prompt`.
 
 **Autonomy principle:** All subagents operate in fully autonomous mode. They make all decisions independently, always choosing the best available option. They never prompt the user for confirmation. If something fails, they report the failure back to the main agent — they don't stop and ask.
 

--- a/src/skills/auto-pilot/references/subagent-prompts.md
+++ b/src/skills/auto-pilot/references/subagent-prompts.md
@@ -2,6 +2,8 @@
 
 This file contains the exact prompts to pass to each subagent via the Agent tool. The main agent reads this file once at skill start and uses these templates for every iteration.
 
+**CRITICAL — never set `subagent_type`:** Every subagent below is spawned with the **default general-purpose agent**. Do NOT pass a `subagent_type` parameter to the Agent tool. The skills referenced in these prompts (`issue-resolver`, `issue-pr-review`, `issue-analysis`) are **skills**, not agent types — passing `subagent_type: "issue-resolver"` fails with `Agent type 'issue-resolver' not found`. The skill is invoked from *inside* the subagent's prompt via the `{{skill:...}}` token, never as the agent type. Pass only `description` and `prompt`.
+
 **Autonomy principle:** All subagents operate in fully autonomous mode. They make all decisions independently, always choosing the best available option. They never prompt the user for confirmation. If something fails, they report the failure back to the main agent — they don't stop and ask.
 
 ## Resolver Subagent
@@ -9,6 +11,7 @@ This file contains the exact prompts to pass to each subagent via the Agent tool
 **Agent tool parameters:**
 - `description`: "Resolve issue #{N}"
 - `prompt`: (below)
+- `subagent_type`: omit (use the default general-purpose agent — `issue-resolver` is a skill, not an agent type)
 
 ```
 Resolve GitHub issue #{issue_number} in this repository using the {{skill:issue-resolver}} skill in auto mode.
@@ -45,6 +48,7 @@ When done, report back ONLY these fields:
 **Agent tool parameters:**
 - `description`: "Review PR #{N}"
 - `prompt`: (below)
+- `subagent_type`: omit (use the default general-purpose agent — `issue-pr-review` is a skill, not an agent type)
 
 ```
 Review pull request #{pr_number} in this repository using the {{skill:issue-pr-review}} skill.
@@ -87,6 +91,7 @@ Used in explicit list mode (`--issues`) to analyze all issues before resolution 
 **Agent tool parameters:**
 - `description`: "Analyze issues for optimal resolution"
 - `prompt`: (below)
+- `subagent_type`: omit (use the default general-purpose agent — `issue-analysis` is a skill, not an agent type)
 
 ```
 Analyze the following GitHub issues to determine the optimal resolution order
@@ -142,6 +147,7 @@ Used when the analyzer identifies issues that can be resolved together in a sing
 **Agent tool parameters:**
 - `description`: "Batch-resolve issues #{N1}, #{N2}"
 - `prompt`: (below)
+- `subagent_type`: omit (use the default general-purpose agent — `issue-resolver` is a skill, not an agent type)
 
 ```
 Resolve the following GitHub issues TOGETHER in a single branch and PR.


### PR DESCRIPTION
Closes #98

## Problem

In the `/auto-pilot` workflow, the resolve phase failed immediately when spawning the resolver subagent:

```
issue-resolver(Resolve issue #18 sandbox hardening)
  ⎿  Initializing…
  ⎿  Error: Agent type 'issue-resolver' not found. Available agents: claude, claude-code-guide, code-reviewer, ...
```

The orchestrator called the **Agent tool** with `subagent_type: "issue-resolver"`. But `issue-resolver` is a Claude Code **skill**, not a registered agent type — so the call was rejected. The skill should be invoked from *inside* the subagent's prompt via the `{{skill:issue-resolver}}` token, with **no** `subagent_type` (defaulting to the general-purpose agent, as `CLAUDE.md` already requires).

The skill instructions never said "omit `subagent_type`," so the model inferred the skill name as the agent type.

## Fix

`src/skills/auto-pilot/references/subagent-prompts.md`:
- Added a prominent **CRITICAL — never set `subagent_type`** note at the top.
- Added an explicit `subagent_type: omit` line to all four spawn blocks (Resolver, PR Reviewer, Analyzer, Batch Resolver).

`src/skills/auto-pilot/references/phases.md`:
- Reinforced at the Step 2.2 spawn point: pass only `description` and `prompt`, don't set `subagent_type`.

Rebuilt `dist/` so the change is reflected in the built skill tree (the other two changed files).

## Verification

- `./scripts/build.sh` — clean build (7 skills + 6 agents + plugin).
- Confirmed the fix is present in both `dist/` and the installed `~/.claude/skills/auto-pilot/`.

The same `subagent_type` mistake could affect resolver, PR reviewer, analyzer, and batch resolver — all four are covered.
