### PR TITLE
test(issue-pr-review): fix stale version-pin and CHANGELOG-scope assertions (#100)

### DIFF
--- a/tests/test-config-schema-38.sh
+++ b/tests/test-config-schema-38.sh
@@ -258,22 +258,19 @@ else
 fi
 
 # ───────────────────────────────────────────────────────────
-# T5: Version bumps — both consuming skills bumped, version bumps
-#     stay in the test-friendly version range.
+# T5: Version bumps — both consuming skills bumped past the
+#     pre-#38 baseline. Use a semver floor (sort -V) rather than
+#     pinning an exact minor, so the assertion survives later
+#     legitimate bumps (e.g. 0.5.0, 0.10.0) — see issue #100.
 # ───────────────────────────────────────────────────────────
-# /issue-pr-review must remain on 0.4.x so test-issue-pr-review-traceability.sh
-# T9 still passes.
-if grep -qE '^[[:space:]]*version:[[:space:]]+0\.4\.[0-9]+' "$PR_REVIEW_SKILL"; then
-  pass "T5.1: /issue-pr-review SKILL.md still on 0.4.x"
+# /issue-pr-review must be at or past 0.4.1 — i.e. #38's bump
+# landed and the version has only moved forward since.
+pr_review_ver="$(grep -E '^[[:space:]]*version:' "$PR_REVIEW_SKILL" | head -1 | sed -E 's/.*version:[[:space:]]*//')"
+if [ -n "$pr_review_ver" ] \
+   && [ "$(printf '%s\n%s\n' "0.4.1" "$pr_review_ver" | sort -V | head -n1)" = "0.4.1" ]; then
+  pass "T5.1: /issue-pr-review SKILL.md at or past 0.4.1 (#38 bump landed) — $pr_review_ver"
 else
-  fail "T5.1: /issue-pr-review SKILL.md not on 0.4.x"
-fi
-
-# Version actually moved past 0.4.0 — i.e., this PR bumped it.
-if grep -qE '^[[:space:]]*version:[[:space:]]+0\.4\.[1-9][0-9]*' "$PR_REVIEW_SKILL"; then
-  pass "T5.2: /issue-pr-review SKILL.md bumped past 0.4.0"
-else
-  fail "T5.2: /issue-pr-review SKILL.md still at 0.4.0 — expected a bump for #38"
+  fail "T5.1: /issue-pr-review SKILL.md below 0.4.1 — expected a bump for #38 (got '${pr_review_ver:-none}')"
 fi
 
 # /init-gitissue bumped past 0.3.1

--- a/tests/test-issue-pr-review-fix-loop-deprecation.sh
+++ b/tests/test-issue-pr-review-fix-loop-deprecation.sh
@@ -206,66 +206,64 @@ else
 fi
 
 # ───────────────────────────────────────────────────────────
-# T9: CHANGELOG has Deprecated entry (AC #2 + AC #3)
+# T9: CHANGELOG documents the deprecation (#37) and removal (#54)
+#     of /issue-pr-review-fix-loop (AC #2 + AC #3 + AC #54).
+#
+#     These are durable historical facts. Keep a Changelog files
+#     finalize [Unreleased] entries into a dated release section when
+#     a version is cut — here they live under [0.7.0]. Scanning only
+#     [Unreleased] therefore reports the completed work as missing
+#     (issue #100). Instead, extract the `### Deprecated` and
+#     `### Removed` subsection bodies from anywhere in the file and
+#     assert the /issue-pr-review-fix-loop content within them. This
+#     stays content-anchored: a bare `### Removed` header from some
+#     other release won't satisfy the checks.
 # ───────────────────────────────────────────────────────────
-if awk '
-  /^## \[Unreleased\]/ {in_unrel=1; next}
-  /^## \[/ && in_unrel {exit}
-  in_unrel
-' "$CHANGELOG" | grep -qE '^### Deprecated[[:space:]]*$'; then
-  pass "T9.1: AC #3 — CHANGELOG [Unreleased] has Deprecated subsection"
+
+# Body of every `### Deprecated` subsection in the changelog (lines
+# until the next `###` or `##` header), concatenated.
+deprecated_body="$(awk '
+  /^### Deprecated[[:space:]]*$/ {grab=1; next}
+  /^#{2,3} / {grab=0}
+  grab
+' "$CHANGELOG")"
+
+# Body of every `### Removed` subsection.
+removed_body="$(awk '
+  /^### Removed[[:space:]]*$/ {grab=1; next}
+  /^#{2,3} / {grab=0}
+  grab
+' "$CHANGELOG")"
+
+if printf '%s\n' "$deprecated_body" | grep -qE '/issue-pr-review-fix-loop'; then
+  pass "T9.1: AC #3 — CHANGELOG ### Deprecated documents /issue-pr-review-fix-loop"
 else
-  fail "T9.1: AC #3 — CHANGELOG [Unreleased] missing Deprecated subsection"
+  fail "T9.1: AC #3 — CHANGELOG ### Deprecated missing /issue-pr-review-fix-loop"
 fi
 
-if awk '
-  /^## \[Unreleased\]/ {in_unrel=1; next}
-  /^## \[/ && in_unrel {exit}
-  in_unrel
-' "$CHANGELOG" | grep -qE '/issue-pr-review-fix-loop'; then
-  pass "T9.2: AC #2 — CHANGELOG [Unreleased] mentions /issue-pr-review-fix-loop"
+if printf '%s\n' "$deprecated_body" | grep -qE '#37'; then
+  pass "T9.2: AC #3 — CHANGELOG deprecation entry links tracking issue #37"
 else
-  fail "T9.2: AC #2 — CHANGELOG [Unreleased] missing /issue-pr-review-fix-loop entry"
+  fail "T9.2: AC #3 — CHANGELOG deprecation entry missing #37 tracking reference"
 fi
 
-if awk '
-  /^## \[Unreleased\]/ {in_unrel=1; next}
-  /^## \[/ && in_unrel {exit}
-  in_unrel
-' "$CHANGELOG" | grep -qE 'src/deprecated-skills/issue-pr-review-fix-loop'; then
+if printf '%s\n%s\n' "$deprecated_body" "$removed_body" \
+   | grep -qE 'src/deprecated-skills/issue-pr-review-fix-loop'; then
   pass "T9.3: AC #3/#54 — CHANGELOG documents retained deprecated source path"
 else
   fail "T9.3: AC #3/#54 — CHANGELOG missing retained deprecated source path"
 fi
 
-if awk '
-  /^## \[Unreleased\]/ {in_unrel=1; next}
-  /^## \[/ && in_unrel {exit}
-  in_unrel
-' "$CHANGELOG" | grep -qE '#37'; then
-  pass "T9.4: AC #3 — CHANGELOG entry links tracking issue #37"
+if printf '%s\n' "$removed_body" | grep -qE '/issue-pr-review-fix-loop'; then
+  pass "T9.4: AC #54 — CHANGELOG ### Removed documents /issue-pr-review-fix-loop"
 else
-  fail "T9.4: AC #3 — CHANGELOG entry missing #37 tracking reference"
+  fail "T9.4: AC #54 — CHANGELOG ### Removed missing /issue-pr-review-fix-loop"
 fi
 
-if awk '
-  /^## \[Unreleased\]/ {in_unrel=1; next}
-  /^## \[/ && in_unrel {exit}
-  in_unrel
-' "$CHANGELOG" | grep -qE '^### Removed[[:space:]]*$'; then
-  pass "T9.5: AC #54 — CHANGELOG [Unreleased] has Removed subsection"
+if printf '%s\n' "$removed_body" | grep -qE '#54'; then
+  pass "T9.5: AC #54 — CHANGELOG removal entry documents distribution decision (#54)"
 else
-  fail "T9.5: AC #54 — CHANGELOG [Unreleased] missing Removed subsection"
-fi
-
-if awk '
-  /^## \[Unreleased\]/ {in_unrel=1; next}
-  /^## \[/ && in_unrel {exit}
-  in_unrel
-' "$CHANGELOG" | grep -qE '#54'; then
-  pass "T9.6: AC #54 — CHANGELOG documents the public distribution removal decision"
-else
-  fail "T9.6: AC #54 — CHANGELOG missing issue #54 removal decision"
+  fail "T9.5: AC #54 — CHANGELOG removal entry missing issue #54 reference"
 fi
 
 # ───────────────────────────────────────────────────────────

--- a/tests/test-issue-pr-review-traceability.sh
+++ b/tests/test-issue-pr-review-traceability.sh
@@ -304,12 +304,16 @@ else
 fi
 
 # ───────────────────────────────────────────────────────────
-# T9: Version bump
+# T9: Version bump — at or past the 0.4.0 baseline this spec shipped
+# under. Use a semver floor (sort -V), not an exact-minor pin, so the
+# check survives later legitimate bumps (0.5.0, 0.10.0, …) — issue #100.
 # ───────────────────────────────────────────────────────────
-if grep -qE '^[[:space:]]*version:[[:space:]]+0\.4\.[0-9]+' "$SKILL"; then
-  pass "T9: SKILL.md version bumped to 0.4.x"
+skill_ver="$(grep -E '^[[:space:]]*version:' "$SKILL" | head -1 | sed -E 's/.*version:[[:space:]]*//')"
+if [ -n "$skill_ver" ] \
+   && [ "$(printf '%s\n%s\n' "0.4.0" "$skill_ver" | sort -V | head -n1)" = "0.4.0" ]; then
+  pass "T9: SKILL.md version at or past 0.4.0 — $skill_ver"
 else
-  fail "T9: SKILL.md version not bumped to 0.4.x"
+  fail "T9: SKILL.md version below 0.4.0 (got '${skill_ver:-none}')"
 fi
 
 # ───────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #100

## Summary

Three test suites failed on `main` against correct, already-shipped code — the assertions lagged the code. This repairs all three by removing the brittle coupling, with no change to shipped skill behavior or CHANGELOG content.

## Approach

**Cluster 1 — version pin drift** (`test-config-schema-38.sh` T5.1/T5.2, `test-issue-pr-review-traceability.sh` T9): replaced exact-minor regex pins (`0\.4\.[0-9]+`) with a `sort -V` semver floor. The previously-cited "floor" pattern in T5.3 (`0\.[4-9]\.`) is itself brittle — it does not match two-digit minors, and this repo is already at `[0.10.0]`. A `sort -V` comparison is correct at `0.4.1`, `0.5.0`, `0.10.0`, and `1.0.0`. T5.1/T5.2 collapsed into one floor check since both reduced to `≥ 0.4.1`.

**Cluster 2 — CHANGELOG section drift** (`test-issue-pr-review-fix-loop-deprecation.sh` T9.x): the awk idiom scanned only `[Unreleased]`, but the #37/#54 entries were finalized into the released `[0.7.0]` section when that version was cut (there is no `[Unreleased]` section anymore). Now extracts the `### Deprecated` / `### Removed` subsection bodies wherever they appear and asserts the `/issue-pr-review-fix-loop` content within them — content-anchored, so a bare header from another release won't satisfy the checks. Verified via a negative test (removing the entries fails all five T9 checks).

## Decision Record

- **Root cause:** Test assertions hardcoded transient facts (an exact version minor; the `[Unreleased]` CHANGELOG section) that legitimately moved when later work shipped (#91 bumped the skill to 0.5.0; a release cut moved the deprecation entries into `[0.7.0]`). The tests were never updated, so they reported completed, correct work as broken.
- **Options considered:** (1) Re-pin the expectations to the current values (`0.5.x`, scan `[0.7.0]`). (2) Decouple the assertions from transient state — semver floor + scan released sections.
- **Options rejected:** Option 1 — re-pinning re-breaks at the next bump or release cut, directly violating issue #100's "must not re-break" criterion. Copying T5.3's digit-class regex was also rejected: it fails at `0.10.0`, which this repo has already reached.
- **Selected option:** Option 2 — semver floor via `sort -V`; scan `### Deprecated`/`### Removed` bodies file-wide, anchored to the skill name.
- **Residual risk:** Low. The floors assert "≥ baseline", so an accidental *downgrade* below the baseline would no longer be flagged as wrong — an acceptable trade for durability, since downgrades are not a realistic failure mode here. CHANGELOG checks remain content-anchored, confirmed by the negative test.

## Changes

| File | Change |
|------|--------|
| `tests/test-config-schema-38.sh` | T5.1/T5.2 → single `sort -V` floor (`≥ 0.4.1`) |
| `tests/test-issue-pr-review-traceability.sh` | T9 → `sort -V` floor (`≥ 0.4.0`) |
| `tests/test-issue-pr-review-fix-loop-deprecation.sh` | T9.x → scan `### Deprecated`/`### Removed` bodies file-wide, content-anchored |

## Test Results

- All 23 suites green (was 20/23).
- AC verification: new floor checks pass at `0.4.1`, `0.5.0`, `0.10.0`, `1.0.0` and correctly reject below-baseline — proven the old digit-class regex would have failed at `0.10.0`.
- Negative test: stripping the `/issue-pr-review-fix-loop` entries fails all five T9 checks, confirming they still guard the content.

## Acceptance Criteria Verification

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | `test-config-schema-38.sh` passes without hardcoding `0.4.x`/`0.5.x` | pass | `sort -V` floor `≥ 0.4.1`; suite 35/35 |
| 2 | `test-issue-pr-review-traceability.sh` T9 passes, no exact-version pin | pass | `sort -V` floor `≥ 0.4.0`; suite 50/50 |
| 3 | Deprecation test recognizes entries wherever they live in CHANGELOG | pass | scans `### Deprecated`/`### Removed` bodies file-wide; suite 29/29 |
| 4 | All three suites green; no change to shipped behavior or CHANGELOG | pass | 23/23 suites; diff touches only the 3 test files |
| 5 | Repaired assertions don't re-break on next bump or release cut | pass | floors verified at `0.10.0`/`1.0.0`; CHANGELOG scan is release-section-agnostic |