### PR TITLE
refactor(tests): harden CHANGELOG awk scan to avoid interval expression

### DIFF
--- a/tests/test-issue-pr-review-fix-loop-deprecation.sh
+++ b/tests/test-issue-pr-review-fix-loop-deprecation.sh
@@ -221,17 +221,22 @@ fi
 # ───────────────────────────────────────────────────────────
 
 # Body of every `### Deprecated` subsection in the changelog (lines
-# until the next `###` or `##` header), concatenated.
+# until the next markdown header), concatenated. The reset matches any
+# line starting with `#` rather than an interval like `^#{2,3} ` —
+# CHANGELOG body lines are bullets (`-`) or blank, never `#`, so any
+# `#` line is a header that ends the subsection. This avoids awk
+# interval expressions, which older one-true-awk builds treat as
+# literal characters (silently leaking the scan to EOF — issue #100).
 deprecated_body="$(awk '
   /^### Deprecated[[:space:]]*$/ {grab=1; next}
-  /^#{2,3} / {grab=0}
+  /^#/ {grab=0}
   grab
 ' "$CHANGELOG")"
 
 # Body of every `### Removed` subsection.
 removed_body="$(awk '
   /^### Removed[[:space:]]*$/ {grab=1; next}
-  /^#{2,3} / {grab=0}
+  /^#/ {grab=0}
   grab
 ' "$CHANGELOG")"
 


### PR DESCRIPTION
Type: refactor

## Summary

Follow-up hardening to the test repair merged in #101. The CHANGELOG subsection-boundary scan in `test-issue-pr-review-fix-loop-deprecation.sh` used an awk interval expression (`/^#{2,3} /`) to detect the next markdown header. Older one-true-awk builds (pre-~2019) treat `{2,3}` as **literal characters**, which would silently leak the `### Deprecated` / `### Removed` extraction to EOF. Because the content anchors would still be found in the leaked body, the test would then **falsely pass** — the exact false-pass class issue #100 set out to eliminate.

This replaces both interval resets with `/^#/`, which is equivalent here (CHANGELOG body lines are bullets or blank, never `#`-prefixed, so any `#` line is a header) and portable to every awk build. It was the only awk interval expression in the test suite.

## Changes

| File | Change |
|------|--------|
| `tests/test-issue-pr-review-fix-loop-deprecation.sh` | `/^#{2,3} /` → `/^#/` for both subsection-boundary resets; comment updated to explain the portability rationale |

## Test Results

- All 23 suites green.
- Target suite 29/29.
- Boundary verified unchanged: Deprecated body = 2 lines, Removed body = 5 lines (genuine `[0.7.0]` content, no leak).
- Negative test (strip `/issue-pr-review-fix-loop` entries) still fails all content checks — anchoring intact.

No shipped skill behavior or CHANGELOG content changed; diff touches only the one test file.