### PR TITLE
feat(config): update default merge strategy to balanced and always-create config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,7 @@ Examples:
 - `.gitissue.yml` loaded ONCE at skill start, not re-read at each step
 - Zero-config: all defaults applied when no config file exists
 - First-run hint: `○ First run — using default config. Run /init-gitissue to customize.`
+- init-gitissue always creates `.gitissue.yml` when missing (even from non-interactive skill invocation)
 
 ### Skills
 - Each skill follows the skill-creator standard (frontmatter with name/description, progressive disclosure)

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Dependency detection, priority suggestions, parallelizable work, stale issue war
   ◆ complete           4/5 resolved, 1 stopped
 ```
 
-Triage, resolve, review, merge — repeated for every open issue. Up to three review-fix cycles per PR with a script pre-pass (lint/format/test auto-fix) before any LLM cycle is spent. Conservative by default: clean PRs are merged, partial PRs are left open for review unless `autopilot.mode: aggressive` is explicitly set. Supports explicit issue lists for targeted runs.
+Triage, resolve, review, merge — repeated for every open issue. Up to three review-fix cycles per PR with a script pre-pass (lint/format/test auto-fix) before any LLM cycle is spent. Balanced by default: clean PRs are merged, partial PRs are left open for review unless `autopilot.mode: aggressive` is explicitly set. Supports explicit issue lists for targeted runs.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ graph TD
 | `/issue-resolver N` | 6-step pipeline: preflight, research, plan, implement, QA, deliver PR with `Closes #N` | 0.7.2 | max |
 | `/issue-triage` | Dependency graph, stale detection, already-fixed detection via commit/PR scanning, priority and execution order | 0.5.2 | medium |
 | `/init-gitissue` | Auto-detect language/framework/test runner, generate `.gitissue.yml` | 0.3.2 | low |
-| `/auto-pilot` | Triage → resolve → review → merge loop. Conservative-by-default merge modes (`conservative`/`balanced`/`aggressive`), explicit issue lists for targeted runs, and a dependency-aware merge gate (`Depends on #N` / `Blocked by #N`) | 2.3.1 | max |
+| `/auto-pilot` | Triage → resolve → review → merge loop. Balanced-by-default merge modes (`conservative`/`balanced`/`aggressive`), explicit issue lists for targeted runs, and a dependency-aware merge gate (`Depends on #N` / `Blocked by #N`) | 2.3.1 | max |
 | `/issue-pr-review` | Review PR end-to-end: script pre-pass (lint/format/test auto-fix), per-criterion AC verification, five-dimension scoring (correctness, acceptance_criteria, traceability, maintainability, safety), reuses reviewer/fixer agents across cycles | 0.5.1 | high |
 
 ### Internal tooling
@@ -466,8 +466,8 @@ Merge modes (configured under `autopilot.mode` in `.gitissue.yml`):
 
 | Mode | Clean PR | Partial PR (review issues remain) |
 |------|----------|-----------------------------------|
-| `conservative` (default) | merge | leave open |
-| `balanced` | merge | leave open + create follow-up issue |
+| `conservative` | leave open | leave open + create follow-up issue |
+| `balanced` (default) | merge | leave open + create follow-up issue |
 | `aggressive` | merge | merge + create follow-up issue (requires `merge_partial: true`) |
 
 ### /idd-doctor -- Read-Only Health Check
@@ -545,7 +545,7 @@ triage:
   scan_timeout_per_issue: 30    # max seconds to scan codebase per issue
 
 autopilot:
-  mode: conservative            # conservative | balanced | aggressive
+  mode: balanced                 # conservative | balanced | aggressive
   merge_partial: false          # only meaningful when mode: aggressive
   max_iterations: 10
   review_cycles: 3              # max LLM review-fix cycles per PR

--- a/dist/skills/auto-pilot/README.md
+++ b/dist/skills/auto-pilot/README.md
@@ -8,7 +8,7 @@
 
 ## Highlights
 
-- **Conservative-by-default merge modes** — fresh installs never auto-merge. `autopilot.mode` (`conservative` | `balanced` | `aggressive`) controls when the loop is allowed to merge; aggressive partial-merge requires both `mode: aggressive` AND `merge_partial: true`. See SKILL.md *Merge Modes* for the full decision matrix.
+- **Balanced-by-default merge modes** — fresh installs auto-merge clean PRs, while PRs with unresolved review issues stay open with follow-up issues. `autopilot.mode` (`conservative` | `balanced` | `aggressive`) controls when the loop is allowed to merge; aggressive partial-merge requires both `mode: aggressive` AND `merge_partial: true`. See SKILL.md *Merge Modes* for the full decision matrix.
 - **Token-optimized review** — script pre-pass auto-fixes lint/format (zero tokens), LLM only reviews critical issues, soft pass skips nits
 - **3-cycle review-fix loop** — with script pre-pass handling mechanical issues, 3 LLM cycles suffice; follow-up issues track anything left
 - **Critical issue guard** — critical issues get human oversight: if the review can't fully resolve them, the loop stops and asks you for a decision
@@ -59,7 +59,7 @@ The auto-pilot classifies decisions into two categories:
 - **Auto-decide** (99%) — branch switching, strategy selection, failure recovery, and merging *within the bounds of `autopilot.mode`*
 - **Confirm with user** (rare) — force-push to shared branches, deleting remote branches that others might depend on, production deployments, package publishing, modifying repository settings or branch protection rules
 
-Merging itself is gated by `autopilot.mode`. The default `conservative` mode never auto-merges — the loop creates and reviews PRs but leaves the merge decision to you. Switch to `balanced` to merge clean PRs, or to `aggressive` (with `merge_partial: true`) to also merge partial PRs alongside follow-up issues.
+Merging itself is gated by `autopilot.mode`. The default `balanced` mode merges clean PRs and leaves PRs with unresolved review issues open with follow-up issues. Switch to `conservative` to never auto-merge, or to `aggressive` (with `merge_partial: true`) to also merge partial PRs alongside follow-up issues.
 
 When something fails, the auto-pilot skips and continues rather than stopping. All work is pushed to remote PRs, so nothing is lost.
 

--- a/dist/skills/auto-pilot/SKILL.md
+++ b/dist/skills/auto-pilot/SKILL.md
@@ -23,7 +23,7 @@ Fully autonomous development loop: triage, pick, resolve, review, fix, merge, re
 
 ### Changes in 2.2.0 — Conservative-by-default merge modes
 
-- New `autopilot.mode` setting (`conservative` | `balanced` | `aggressive`). Default is **`conservative`**: PRs are created and reviewed but never auto-merged.
+- New `autopilot.mode` setting (`conservative` | `balanced` | `aggressive`). Default is **`balanced`**: clean PRs are auto-merged; PRs with unresolved review issues get follow-up issues and stay open.
 - New `autopilot.merge_partial: false` setting. Aggressive partial-merge behavior now requires both `mode: aggressive` AND `merge_partial: true` — the previous "merge anyway with follow-up" path is no longer reachable by accident.
 - Final-report iteration outcomes now use the categorical labels `merged`, `left_open`, `partial_followup`, `failed`, `skipped`.
 - Legacy `autopilot.auto_merge` is honored when `autopilot.mode` is unset, but `mode` is authoritative when both are present. The schema is being consolidated separately in the autopilot/review config schema work — this release ships only the merge-mode behavior change.
@@ -137,7 +137,7 @@ Load `.gitissue.yml` from the repo root once at start. If the file does not exis
 ```
 
 Defaults:
-- `autopilot.mode: conservative` — merge mode. See **Merge Modes** below for the three values.
+- `autopilot.mode: balanced` — merge mode. See **Merge Modes** below for the three values.
 - `autopilot.merge_partial: false` — never merge a PR with unresolved fixable review issues unless explicitly opted in. Only honored when `mode: aggressive`.
 - `autopilot.max_iterations: 10` — maximum issues to process before stopping
 - `autopilot.review_cycles: 3` — maximum fix attempts per PR. After this many cycles, if issues remain the auto-pilot's behavior depends on `autopilot.mode` (see *Merge Modes* below). Reduced from 10 — the script pre-pass in issue-pr-review handles lint/format, so 3 LLM cycles suffice for logic issues. A cycle = one fix attempt + one review pass. Confirmation-only review passes (spawned after a PASS to verify, without a preceding fix) do not consume a cycle.
@@ -152,12 +152,12 @@ Do not re-read the config at each iteration.
 
 ### Merge Modes
 
-The `autopilot.mode` setting controls when the loop is allowed to merge PRs. The default is **conservative** — a fresh install will create PRs and run review-fix cycles, but never auto-merge. Aggressive partial-merge behavior is unreachable without explicit opt-in.
+The `autopilot.mode` setting controls when the loop is allowed to merge PRs. The default is **balanced** — a fresh install auto-merges clean PRs, while PRs with unresolved review issues get a follow-up issue and stay open. Default install never merges a PR with unresolved fixable review issues. Aggressive partial-merge behavior is unreachable without explicit opt-in.
 
 | Mode | Clean PR (review passes) | Partial PR (cycles exhausted, non-critical) | Critical with unresolved issues |
 |------|--------------------------|---------------------------------------------|----------------------------------|
-| `conservative` (default) | leave PR open | leave PR open + create follow-up issue | stop and ask user |
-| `balanced` | merge PR | leave PR open + create follow-up issue | stop and ask user |
+| `conservative` | leave PR open | leave PR open + create follow-up issue | stop and ask user |
+| `balanced` (default) | merge PR | leave PR open + create follow-up issue | stop and ask user |
 | `aggressive` (requires `merge_partial: true`) | merge PR | merge PR + create follow-up issue (`partial_followup`) | stop and ask user |
 | `aggressive` with `merge_partial: false` | merge PR | leave PR open + create follow-up issue (same as `balanced`) | stop and ask user |
 
@@ -422,7 +422,7 @@ All errors use the rich format from `references/error-messages.md`:
 
 ## Expected Output
 
-Each iteration prints a static block. The `Merge` line resolves to one of the five categorical outcomes (`merged`, `left_open`, `partial_followup`, `failed`, `skipped`) — the example below assumes a `balanced` or `aggressive` mode where a clean PR is merged. Under the default `conservative` mode the same iteration would end with `Merge ⚠ left_open (mode: conservative)`.
+Each iteration prints a static block. The `Merge` line resolves to one of the five categorical outcomes (`merged`, `left_open`, `partial_followup`, `failed`, `skipped`) — the example below uses the default `balanced` mode where a clean PR is merged. Under `conservative` mode the same iteration would end with `Merge ⚠ left_open (mode: conservative)`.
 
 ```
   ◆ Auto-Pilot Iteration 1

--- a/dist/skills/auto-pilot/SKILL.md
+++ b/dist/skills/auto-pilot/SKILL.md
@@ -42,7 +42,7 @@ Fully autonomous development loop: triage, pick, resolve, review, fix, merge, re
 - `auto_merge: false` no longer halts the loop — PRs that pass review are left open and the loop moves to the next issue
 - All confirmation prompts removed — the loop runs with full autonomy from start to finish
 
-The auto-pilot orchestrates existing gitissue skills into a continuous loop that processes the issue backlog with absolute autonomy. Each iteration: triage the backlog, pick the top-priority issue, resolve it via the full pipeline, review the PR with up to 3 token-optimized fix-review cycles (script pre-pass for lint/format, LLM only for critical issues), and if issues remain create a follow-up issue then merge anyway so progress is never blocked. For critical issues, the loop stops and asks the user for a decision instead of auto-continuing. The agent makes all non-critical decisions automatically, always choosing the best available path forward.
+The auto-pilot orchestrates existing gitissue skills into a continuous loop that processes the issue backlog with absolute autonomy. Each iteration: triage the backlog, pick the top-priority issue, resolve it via the full pipeline, review the PR with up to 3 token-optimized fix-review cycles (script pre-pass for lint/format, LLM only for critical issues), and merge according to `autopilot.mode`. Clean PRs merge in `balanced` or `aggressive` mode. PRs with unresolved review issues create a follow-up issue and stay open unless `mode: aggressive` and `merge_partial: true` are both explicitly set. For critical issues, the loop stops and asks the user for a decision instead of auto-continuing. The agent makes all non-critical decisions automatically, always choosing the best available path forward.
 
 ## Autonomy Philosophy
 
@@ -422,7 +422,7 @@ All errors use the rich format from `references/error-messages.md`:
 
 ## Expected Output
 
-Each iteration prints a static block. The `Merge` line resolves to one of the five categorical outcomes (`merged`, `left_open`, `partial_followup`, `failed`, `skipped`) — the example below uses the default `balanced` mode where a clean PR is merged. Under `conservative` mode the same iteration would end with `Merge ⚠ left_open (mode: conservative)`.
+Each iteration prints a static block. The `Merge` line resolves to one of the six categorical outcomes (`merged`, `left_open`, `partial_followup`, `blocked_by_dependency`, `failed`, `skipped`) — the example below uses the default `balanced` mode where a clean PR is merged. Under `conservative` mode the same iteration would end with `Merge ⚠ left_open (mode: conservative)`.
 
 ```
   ◆ Auto-Pilot Iteration 1

--- a/dist/skills/auto-pilot/references/docs/config-schema.md
+++ b/dist/skills/auto-pilot/references/docs/config-schema.md
@@ -225,14 +225,14 @@ autopilot:
   # Merge mode — controls when /auto-pilot is allowed to merge PRs.
   # Type: string
   # Values: "conservative" | "balanced" | "aggressive"
-  # Default: "conservative"
-  # "conservative": create PR, run review-fix cycles, leave PR open. Never auto-merges.
+  # Default: "balanced"
   # "balanced":     auto-merge clean PRs only. Unresolved issues create a follow-up
-  #                 and leave the PR open.
+  #                 and leave the PR open. Recommended default for most projects.
+  # "conservative": create PR, run review-fix cycles, leave PR open. Never auto-merges.
   # "aggressive":   auto-merge clean PRs AND, when merge_partial=true, merge partial
   #                 PRs with a follow-up issue. Documented as risky; opt-in only.
   # When set, this field is authoritative — autopilot.auto_merge is ignored.
-  mode: conservative
+  mode: balanced
 
   # Allow merging PRs that still have unresolved fixable review issues.
   # Type: boolean
@@ -505,7 +505,7 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `review.require_traceability_check` | `true` | Run the four traceability checks; missing `Closes #N` blocks soft-pass |
 | `review.traceability_exempt_labels` | `["refactor", "chore"]` | PR labels that exempt a PR from the `Closes #N` hard-fail (check 1 only; other three checks still run) |
 | `review.traceability_exempt_pattern` | `"^\\s*Type:\\s*(refactor\|chore)\\s*$"` | Regex (multiline, case-insensitive) matched against PR body for exemption from check 1 |
-| `autopilot.mode` | `conservative` | Merge mode: `conservative` (never merge), `balanced` (merge clean PRs), `aggressive` (merge clean + partial w/ `merge_partial: true`) |
+| `autopilot.mode` | `balanced` | Merge mode: `balanced` (auto-merge clean PRs), `conservative` (never merge), `aggressive` (merge clean + partial w/ `merge_partial: true`) |
 | `autopilot.merge_partial` | `false` | Allow merging PRs with unresolved review issues. Only honored when `mode: aggressive` |
 | `autopilot.max_iterations` | `10` | Max issues to process |
 | `autopilot.review_cycles` | `3` | Max review-fix cycles per PR |

--- a/dist/skills/auto-pilot/references/examples.md
+++ b/dist/skills/auto-pilot/references/examples.md
@@ -6,7 +6,7 @@ Detailed example runs and edge-case behaviors referenced from SKILL.md.
 
 **User says:** `/auto-pilot --limit 3`
 
-> Assumes `autopilot.mode: balanced` or `aggressive` in `.gitissue.yml`. Under the default `conservative` mode, each PR would end with `Outcome: left_open` instead of being merged automatically.
+> Uses the default `autopilot.mode: balanced`, where clean PRs are merged automatically. Under `conservative` mode, each clean PR would end with `Outcome: left_open` instead.
 
 ```
 ● Checking environment...

--- a/dist/skills/auto-pilot/references/phases.md
+++ b/dist/skills/auto-pilot/references/phases.md
@@ -246,12 +246,12 @@ For non-critical issues (no `critical` or `priority:critical` label), the auto-p
 
 | Mode (effective) | `merge_partial` | Behavior | Outcome label |
 |------------------|-----------------|----------|----------------|
-| `conservative` (default) | n/a (ignored) | follow-up created, PR left open | `left_open` |
-| `balanced` | n/a (ignored) | follow-up created, PR left open | `left_open` |
+| `conservative` | n/a (ignored) | follow-up created, PR left open | `left_open` |
+| `balanced` (default) | n/a (ignored) | follow-up created, PR left open | `left_open` |
 | `aggressive` | `false` (default) | follow-up created, PR left open | `left_open` |
 | `aggressive` | `true` | follow-up created, PR merged anyway | `partial_followup` |
 
-The default install (`mode: conservative`) **never** auto-merges a PR with unresolved fixable review issues. Aggressive partial-merge is unreachable without setting both `mode: aggressive` and `merge_partial: true` in `.gitissue.yml`.
+The default install (`mode: balanced`) **never** auto-merges a PR with unresolved fixable review issues; only clean PRs are merged. Aggressive partial-merge is unreachable without setting both `mode: aggressive` and `merge_partial: true` in `.gitissue.yml`.
 
 **Step 1 — Create follow-up issue (always, regardless of mode):**
 

--- a/dist/skills/init-gitissue/SKILL.md
+++ b/dist/skills/init-gitissue/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: Requires git. No GitHub CLI or authentication needed — generates a local config file only.
 effort: low
 metadata:
-  version: 0.3.2
+  version: 0.3.3
   creator: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -43,9 +43,21 @@ That is the only prerequisite. This skill does not need `gh` or GitHub authentic
 
 ## Configuration Check
 
-This skill GENERATES the config — it does not read one. However, check if `.gitissue.yml` already exists in the repo root before proceeding.
+This skill GENERATES the config — it does not read one. Check if `.gitissue.yml` already exists in the repo root before proceeding.
 
-If the file exists, show the prompt from `references/error-messages.md`:
+### File does NOT exist — always create
+
+When the file is missing, **always create it** without prompting. This happens regardless of context — even when the skill is invoked non-interactively from another skill. No early exit, no conditions, no cancel option.
+
+```
+○ No .gitissue.yml found — generating config...
+```
+
+Proceed directly to **Step 1 — Scan Repository**.
+
+### File exists — ask user
+
+If the file already exists, show the prompt from `references/error-messages.md`:
 
 ```
 ⚠ .gitissue.yml already exists

--- a/dist/skills/init-gitissue/references/docs/config-schema.md
+++ b/dist/skills/init-gitissue/references/docs/config-schema.md
@@ -225,14 +225,14 @@ autopilot:
   # Merge mode — controls when /auto-pilot is allowed to merge PRs.
   # Type: string
   # Values: "conservative" | "balanced" | "aggressive"
-  # Default: "conservative"
-  # "conservative": create PR, run review-fix cycles, leave PR open. Never auto-merges.
+  # Default: "balanced"
   # "balanced":     auto-merge clean PRs only. Unresolved issues create a follow-up
-  #                 and leave the PR open.
+  #                 and leave the PR open. Recommended default for most projects.
+  # "conservative": create PR, run review-fix cycles, leave PR open. Never auto-merges.
   # "aggressive":   auto-merge clean PRs AND, when merge_partial=true, merge partial
   #                 PRs with a follow-up issue. Documented as risky; opt-in only.
   # When set, this field is authoritative — autopilot.auto_merge is ignored.
-  mode: conservative
+  mode: balanced
 
   # Allow merging PRs that still have unresolved fixable review issues.
   # Type: boolean
@@ -505,7 +505,7 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `review.require_traceability_check` | `true` | Run the four traceability checks; missing `Closes #N` blocks soft-pass |
 | `review.traceability_exempt_labels` | `["refactor", "chore"]` | PR labels that exempt a PR from the `Closes #N` hard-fail (check 1 only; other three checks still run) |
 | `review.traceability_exempt_pattern` | `"^\\s*Type:\\s*(refactor\|chore)\\s*$"` | Regex (multiline, case-insensitive) matched against PR body for exemption from check 1 |
-| `autopilot.mode` | `conservative` | Merge mode: `conservative` (never merge), `balanced` (merge clean PRs), `aggressive` (merge clean + partial w/ `merge_partial: true`) |
+| `autopilot.mode` | `balanced` | Merge mode: `balanced` (auto-merge clean PRs), `conservative` (never merge), `aggressive` (merge clean + partial w/ `merge_partial: true`) |
 | `autopilot.merge_partial` | `false` | Allow merging PRs with unresolved review issues. Only honored when `mode: aggressive` |
 | `autopilot.max_iterations` | `10` | Max issues to process |
 | `autopilot.review_cycles` | `3` | Max review-fix cycles per PR |

--- a/dist/skills/init-gitissue/templates/gitissue-template.yml
+++ b/dist/skills/init-gitissue/templates/gitissue-template.yml
@@ -94,14 +94,14 @@ review:
 autopilot:
   # Merge mode — controls when /auto-pilot is allowed to merge PRs.
   # Values: "conservative" | "balanced" | "aggressive"
-  # Default: "conservative" — create PR, run review-fix cycles, leave PR open.
-  #   Never auto-merges. Safest default; recommended for most projects.
-  # "balanced":     auto-merge clean PRs (review passed). PRs with unresolved
-  #                 review issues get a follow-up issue and stay open.
+  # Default: "balanced" — auto-merge clean PRs (review passed). PRs with unresolved
+  #   review issues get a follow-up and stay open. Recommended for most projects.
+  # "conservative": create PR, run review-fix cycles, leave PR open.
+  #                 Never auto-merges.
   # "aggressive":   auto-merge clean PRs AND merge partial PRs when
   #                 merge_partial=true is also set (see below). Risky —
   #                 only enable on disposable/experimental repos.
-  mode: conservative
+  mode: balanced
 
   # Allow merging PRs that still have unresolved fixable review issues.
   # Default: false — never merge a partial PR.

--- a/dist/skills/issue-analysis/references/docs/config-schema.md
+++ b/dist/skills/issue-analysis/references/docs/config-schema.md
@@ -225,14 +225,14 @@ autopilot:
   # Merge mode — controls when /auto-pilot is allowed to merge PRs.
   # Type: string
   # Values: "conservative" | "balanced" | "aggressive"
-  # Default: "conservative"
-  # "conservative": create PR, run review-fix cycles, leave PR open. Never auto-merges.
+  # Default: "balanced"
   # "balanced":     auto-merge clean PRs only. Unresolved issues create a follow-up
-  #                 and leave the PR open.
+  #                 and leave the PR open. Recommended default for most projects.
+  # "conservative": create PR, run review-fix cycles, leave PR open. Never auto-merges.
   # "aggressive":   auto-merge clean PRs AND, when merge_partial=true, merge partial
   #                 PRs with a follow-up issue. Documented as risky; opt-in only.
   # When set, this field is authoritative — autopilot.auto_merge is ignored.
-  mode: conservative
+  mode: balanced
 
   # Allow merging PRs that still have unresolved fixable review issues.
   # Type: boolean
@@ -505,7 +505,7 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `review.require_traceability_check` | `true` | Run the four traceability checks; missing `Closes #N` blocks soft-pass |
 | `review.traceability_exempt_labels` | `["refactor", "chore"]` | PR labels that exempt a PR from the `Closes #N` hard-fail (check 1 only; other three checks still run) |
 | `review.traceability_exempt_pattern` | `"^\\s*Type:\\s*(refactor\|chore)\\s*$"` | Regex (multiline, case-insensitive) matched against PR body for exemption from check 1 |
-| `autopilot.mode` | `conservative` | Merge mode: `conservative` (never merge), `balanced` (merge clean PRs), `aggressive` (merge clean + partial w/ `merge_partial: true`) |
+| `autopilot.mode` | `balanced` | Merge mode: `balanced` (auto-merge clean PRs), `conservative` (never merge), `aggressive` (merge clean + partial w/ `merge_partial: true`) |
 | `autopilot.merge_partial` | `false` | Allow merging PRs with unresolved review issues. Only honored when `mode: aggressive` |
 | `autopilot.max_iterations` | `10` | Max issues to process |
 | `autopilot.review_cycles` | `3` | Max review-fix cycles per PR |

--- a/dist/skills/issue-resolver/references/docs/config-schema.md
+++ b/dist/skills/issue-resolver/references/docs/config-schema.md
@@ -225,14 +225,14 @@ autopilot:
   # Merge mode — controls when /auto-pilot is allowed to merge PRs.
   # Type: string
   # Values: "conservative" | "balanced" | "aggressive"
-  # Default: "conservative"
-  # "conservative": create PR, run review-fix cycles, leave PR open. Never auto-merges.
+  # Default: "balanced"
   # "balanced":     auto-merge clean PRs only. Unresolved issues create a follow-up
-  #                 and leave the PR open.
+  #                 and leave the PR open. Recommended default for most projects.
+  # "conservative": create PR, run review-fix cycles, leave PR open. Never auto-merges.
   # "aggressive":   auto-merge clean PRs AND, when merge_partial=true, merge partial
   #                 PRs with a follow-up issue. Documented as risky; opt-in only.
   # When set, this field is authoritative — autopilot.auto_merge is ignored.
-  mode: conservative
+  mode: balanced
 
   # Allow merging PRs that still have unresolved fixable review issues.
   # Type: boolean
@@ -505,7 +505,7 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `review.require_traceability_check` | `true` | Run the four traceability checks; missing `Closes #N` blocks soft-pass |
 | `review.traceability_exempt_labels` | `["refactor", "chore"]` | PR labels that exempt a PR from the `Closes #N` hard-fail (check 1 only; other three checks still run) |
 | `review.traceability_exempt_pattern` | `"^\\s*Type:\\s*(refactor\|chore)\\s*$"` | Regex (multiline, case-insensitive) matched against PR body for exemption from check 1 |
-| `autopilot.mode` | `conservative` | Merge mode: `conservative` (never merge), `balanced` (merge clean PRs), `aggressive` (merge clean + partial w/ `merge_partial: true`) |
+| `autopilot.mode` | `balanced` | Merge mode: `balanced` (auto-merge clean PRs), `conservative` (never merge), `aggressive` (merge clean + partial w/ `merge_partial: true`) |
 | `autopilot.merge_partial` | `false` | Allow merging PRs with unresolved review issues. Only honored when `mode: aggressive` |
 | `autopilot.max_iterations` | `10` | Max issues to process |
 | `autopilot.review_cycles` | `3` | Max review-fix cycles per PR |

--- a/dist/skills/issue-triage/references/docs/config-schema.md
+++ b/dist/skills/issue-triage/references/docs/config-schema.md
@@ -225,14 +225,14 @@ autopilot:
   # Merge mode — controls when /auto-pilot is allowed to merge PRs.
   # Type: string
   # Values: "conservative" | "balanced" | "aggressive"
-  # Default: "conservative"
-  # "conservative": create PR, run review-fix cycles, leave PR open. Never auto-merges.
+  # Default: "balanced"
   # "balanced":     auto-merge clean PRs only. Unresolved issues create a follow-up
-  #                 and leave the PR open.
+  #                 and leave the PR open. Recommended default for most projects.
+  # "conservative": create PR, run review-fix cycles, leave PR open. Never auto-merges.
   # "aggressive":   auto-merge clean PRs AND, when merge_partial=true, merge partial
   #                 PRs with a follow-up issue. Documented as risky; opt-in only.
   # When set, this field is authoritative — autopilot.auto_merge is ignored.
-  mode: conservative
+  mode: balanced
 
   # Allow merging PRs that still have unresolved fixable review issues.
   # Type: boolean
@@ -505,7 +505,7 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `review.require_traceability_check` | `true` | Run the four traceability checks; missing `Closes #N` blocks soft-pass |
 | `review.traceability_exempt_labels` | `["refactor", "chore"]` | PR labels that exempt a PR from the `Closes #N` hard-fail (check 1 only; other three checks still run) |
 | `review.traceability_exempt_pattern` | `"^\\s*Type:\\s*(refactor\|chore)\\s*$"` | Regex (multiline, case-insensitive) matched against PR body for exemption from check 1 |
-| `autopilot.mode` | `conservative` | Merge mode: `conservative` (never merge), `balanced` (merge clean PRs), `aggressive` (merge clean + partial w/ `merge_partial: true`) |
+| `autopilot.mode` | `balanced` | Merge mode: `balanced` (auto-merge clean PRs), `conservative` (never merge), `aggressive` (merge clean + partial w/ `merge_partial: true`) |
 | `autopilot.merge_partial` | `false` | Allow merging PRs with unresolved review issues. Only honored when `mode: aggressive` |
 | `autopilot.max_iterations` | `10` | Max issues to process |
 | `autopilot.review_cycles` | `3` | Max review-fix cycles per PR |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -169,4 +169,4 @@ A shared utility reference that skills invoke to update issue status on a repo's
 4. **Agent-agnostic** — structured issues are plain GitHub Markdown, consumable by any tool
 5. **Lean issues** — issues capture human intent only; codebase analysis is performed by consumer skills (resolver, triage, analysis) at execution time against current code
 6. **Durable memory in git** — every resolution dual-writes its Decision Record and AC verification into both the PR body and (via squash merge) the commit body, so `git log -p` is a self-contained project history independent of `.gitissue/` files
-7. **Conservative by default** — `/auto-pilot` merges only clean PRs unless the user opts into balanced or aggressive modes. Critical-labeled issues always pause for human review on partial fixes
+7. **Balanced by default** — `/auto-pilot` auto-merges clean PRs (review passed); PRs with unresolved issues get a follow-up and stay open. Users can opt into `conservative` (never merge) or `aggressive` modes. Critical-labeled issues always pause for human review on partial fixes

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -227,8 +227,7 @@ autopilot:
   # Default: "balanced"
   # "balanced":     auto-merge clean PRs only. Unresolved issues create a follow-up
   #                 and leave the PR open. Recommended default for most projects.
-  # "balanced":     auto-merge clean PRs only. Unresolved issues create a follow-up
-  #                 and leave the PR open.
+  # "conservative": create PR, run review-fix cycles, leave PR open. Never auto-merges.
   # "aggressive":   auto-merge clean PRs AND, when merge_partial=true, merge partial
   #                 PRs with a follow-up issue. Documented as risky; opt-in only.
   # When set, this field is authoritative — autopilot.auto_merge is ignored.

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -224,14 +224,15 @@ autopilot:
   # Merge mode — controls when /auto-pilot is allowed to merge PRs.
   # Type: string
   # Values: "conservative" | "balanced" | "aggressive"
-  # Default: "conservative"
-  # "conservative": create PR, run review-fix cycles, leave PR open. Never auto-merges.
+  # Default: "balanced"
+  # "balanced":     auto-merge clean PRs only. Unresolved issues create a follow-up
+  #                 and leave the PR open. Recommended default for most projects.
   # "balanced":     auto-merge clean PRs only. Unresolved issues create a follow-up
   #                 and leave the PR open.
   # "aggressive":   auto-merge clean PRs AND, when merge_partial=true, merge partial
   #                 PRs with a follow-up issue. Documented as risky; opt-in only.
   # When set, this field is authoritative — autopilot.auto_merge is ignored.
-  mode: conservative
+  mode: balanced
 
   # Allow merging PRs that still have unresolved fixable review issues.
   # Type: boolean
@@ -504,7 +505,7 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `review.require_traceability_check` | `true` | Run the four traceability checks; missing `Closes #N` blocks soft-pass |
 | `review.traceability_exempt_labels` | `["refactor", "chore"]` | PR labels that exempt a PR from the `Closes #N` hard-fail (check 1 only; other three checks still run) |
 | `review.traceability_exempt_pattern` | `"^\\s*Type:\\s*(refactor\|chore)\\s*$"` | Regex (multiline, case-insensitive) matched against PR body for exemption from check 1 |
-| `autopilot.mode` | `conservative` | Merge mode: `conservative` (never merge), `balanced` (merge clean PRs), `aggressive` (merge clean + partial w/ `merge_partial: true`) |
+| `autopilot.mode` | `balanced` | Merge mode: `balanced` (auto-merge clean PRs), `conservative` (never merge), `aggressive` (merge clean + partial w/ `merge_partial: true`) |
 | `autopilot.merge_partial` | `false` | Allow merging PRs with unresolved review issues. Only honored when `mode: aggressive` |
 | `autopilot.max_iterations` | `10` | Max issues to process |
 | `autopilot.review_cycles` | `3` | Max review-fix cycles per PR |

--- a/src/skills/auto-pilot/README.md
+++ b/src/skills/auto-pilot/README.md
@@ -8,7 +8,7 @@
 
 ## Highlights
 
-- **Conservative-by-default merge modes** — fresh installs never auto-merge. `autopilot.mode` (`conservative` | `balanced` | `aggressive`) controls when the loop is allowed to merge; aggressive partial-merge requires both `mode: aggressive` AND `merge_partial: true`. See SKILL.md *Merge Modes* for the full decision matrix.
+- **Balanced-by-default merge modes** — fresh installs auto-merge clean PRs, while PRs with unresolved review issues stay open with follow-up issues. `autopilot.mode` (`conservative` | `balanced` | `aggressive`) controls when the loop is allowed to merge; aggressive partial-merge requires both `mode: aggressive` AND `merge_partial: true`. See SKILL.md *Merge Modes* for the full decision matrix.
 - **Token-optimized review** — script pre-pass auto-fixes lint/format (zero tokens), LLM only reviews critical issues, soft pass skips nits
 - **3-cycle review-fix loop** — with script pre-pass handling mechanical issues, 3 LLM cycles suffice; follow-up issues track anything left
 - **Critical issue guard** — critical issues get human oversight: if the review can't fully resolve them, the loop stops and asks you for a decision
@@ -59,7 +59,7 @@ The auto-pilot classifies decisions into two categories:
 - **Auto-decide** (99%) — branch switching, strategy selection, failure recovery, and merging *within the bounds of `autopilot.mode`*
 - **Confirm with user** (rare) — force-push to shared branches, deleting remote branches that others might depend on, production deployments, package publishing, modifying repository settings or branch protection rules
 
-Merging itself is gated by `autopilot.mode`. The default `conservative` mode never auto-merges — the loop creates and reviews PRs but leaves the merge decision to you. Switch to `balanced` to merge clean PRs, or to `aggressive` (with `merge_partial: true`) to also merge partial PRs alongside follow-up issues.
+Merging itself is gated by `autopilot.mode`. The default `balanced` mode merges clean PRs and leaves PRs with unresolved review issues open with follow-up issues. Switch to `conservative` to never auto-merge, or to `aggressive` (with `merge_partial: true`) to also merge partial PRs alongside follow-up issues.
 
 When something fails, the auto-pilot skips and continues rather than stopping. All work is pushed to remote PRs, so nothing is lost.
 

--- a/src/skills/auto-pilot/SKILL.md
+++ b/src/skills/auto-pilot/SKILL.md
@@ -23,7 +23,7 @@ Fully autonomous development loop: triage, pick, resolve, review, fix, merge, re
 
 ### Changes in 2.2.0 — Conservative-by-default merge modes
 
-- New `autopilot.mode` setting (`conservative` | `balanced` | `aggressive`). Default is **`conservative`**: PRs are created and reviewed but never auto-merged.
+- New `autopilot.mode` setting (`conservative` | `balanced` | `aggressive`). Default is **`balanced`**: clean PRs are auto-merged; PRs with unresolved review issues get follow-up issues and stay open.
 - New `autopilot.merge_partial: false` setting. Aggressive partial-merge behavior now requires both `mode: aggressive` AND `merge_partial: true` — the previous "merge anyway with follow-up" path is no longer reachable by accident.
 - Final-report iteration outcomes now use the categorical labels `merged`, `left_open`, `partial_followup`, `failed`, `skipped`.
 - Legacy `autopilot.auto_merge` is honored when `autopilot.mode` is unset, but `mode` is authoritative when both are present. The schema is being consolidated separately in the autopilot/review config schema work — this release ships only the merge-mode behavior change.
@@ -137,7 +137,7 @@ Load `.gitissue.yml` from the repo root once at start. If the file does not exis
 ```
 
 Defaults:
-- `autopilot.mode: conservative` — merge mode. See **Merge Modes** below for the three values.
+- `autopilot.mode: balanced` — merge mode. See **Merge Modes** below for the three values.
 - `autopilot.merge_partial: false` — never merge a PR with unresolved fixable review issues unless explicitly opted in. Only honored when `mode: aggressive`.
 - `autopilot.max_iterations: 10` — maximum issues to process before stopping
 - `autopilot.review_cycles: 3` — maximum fix attempts per PR. After this many cycles, if issues remain the auto-pilot's behavior depends on `autopilot.mode` (see *Merge Modes* below). Reduced from 10 — the script pre-pass in issue-pr-review handles lint/format, so 3 LLM cycles suffice for logic issues. A cycle = one fix attempt + one review pass. Confirmation-only review passes (spawned after a PASS to verify, without a preceding fix) do not consume a cycle.
@@ -152,12 +152,12 @@ Do not re-read the config at each iteration.
 
 ### Merge Modes
 
-The `autopilot.mode` setting controls when the loop is allowed to merge PRs. The default is **conservative** — a fresh install will create PRs and run review-fix cycles, but never auto-merge. Aggressive partial-merge behavior is unreachable without explicit opt-in.
+The `autopilot.mode` setting controls when the loop is allowed to merge PRs. The default is **balanced** — a fresh install auto-merges clean PRs, while PRs with unresolved review issues get a follow-up issue and stay open. Default install never merges a PR with unresolved fixable review issues. Aggressive partial-merge behavior is unreachable without explicit opt-in.
 
 | Mode | Clean PR (review passes) | Partial PR (cycles exhausted, non-critical) | Critical with unresolved issues |
 |------|--------------------------|---------------------------------------------|----------------------------------|
-| `conservative` (default) | leave PR open | leave PR open + create follow-up issue | stop and ask user |
-| `balanced` | merge PR | leave PR open + create follow-up issue | stop and ask user |
+| `conservative` | leave PR open | leave PR open + create follow-up issue | stop and ask user |
+| `balanced` (default) | merge PR | leave PR open + create follow-up issue | stop and ask user |
 | `aggressive` (requires `merge_partial: true`) | merge PR | merge PR + create follow-up issue (`partial_followup`) | stop and ask user |
 | `aggressive` with `merge_partial: false` | merge PR | leave PR open + create follow-up issue (same as `balanced`) | stop and ask user |
 
@@ -422,7 +422,7 @@ All errors use the rich format from `references/error-messages.md`:
 
 ## Expected Output
 
-Each iteration prints a static block. The `Merge` line resolves to one of the five categorical outcomes (`merged`, `left_open`, `partial_followup`, `failed`, `skipped`) — the example below assumes a `balanced` or `aggressive` mode where a clean PR is merged. Under the default `conservative` mode the same iteration would end with `Merge ⚠ left_open (mode: conservative)`.
+Each iteration prints a static block. The `Merge` line resolves to one of the five categorical outcomes (`merged`, `left_open`, `partial_followup`, `failed`, `skipped`) — the example below uses the default `balanced` mode where a clean PR is merged. Under `conservative` mode the same iteration would end with `Merge ⚠ left_open (mode: conservative)`.
 
 ```
   ◆ Auto-Pilot Iteration 1

--- a/src/skills/auto-pilot/SKILL.md
+++ b/src/skills/auto-pilot/SKILL.md
@@ -42,7 +42,7 @@ Fully autonomous development loop: triage, pick, resolve, review, fix, merge, re
 - `auto_merge: false` no longer halts the loop — PRs that pass review are left open and the loop moves to the next issue
 - All confirmation prompts removed — the loop runs with full autonomy from start to finish
 
-The auto-pilot orchestrates existing gitissue skills into a continuous loop that processes the issue backlog with absolute autonomy. Each iteration: triage the backlog, pick the top-priority issue, resolve it via the full pipeline, review the PR with up to 3 token-optimized fix-review cycles (script pre-pass for lint/format, LLM only for critical issues), and if issues remain create a follow-up issue then merge anyway so progress is never blocked. For critical issues, the loop stops and asks the user for a decision instead of auto-continuing. The agent makes all non-critical decisions automatically, always choosing the best available path forward.
+The auto-pilot orchestrates existing gitissue skills into a continuous loop that processes the issue backlog with absolute autonomy. Each iteration: triage the backlog, pick the top-priority issue, resolve it via the full pipeline, review the PR with up to 3 token-optimized fix-review cycles (script pre-pass for lint/format, LLM only for critical issues), and merge according to `autopilot.mode`. Clean PRs merge in `balanced` or `aggressive` mode. PRs with unresolved review issues create a follow-up issue and stay open unless `mode: aggressive` and `merge_partial: true` are both explicitly set. For critical issues, the loop stops and asks the user for a decision instead of auto-continuing. The agent makes all non-critical decisions automatically, always choosing the best available path forward.
 
 ## Autonomy Philosophy
 
@@ -422,7 +422,7 @@ All errors use the rich format from `references/error-messages.md`:
 
 ## Expected Output
 
-Each iteration prints a static block. The `Merge` line resolves to one of the five categorical outcomes (`merged`, `left_open`, `partial_followup`, `failed`, `skipped`) — the example below uses the default `balanced` mode where a clean PR is merged. Under `conservative` mode the same iteration would end with `Merge ⚠ left_open (mode: conservative)`.
+Each iteration prints a static block. The `Merge` line resolves to one of the six categorical outcomes (`merged`, `left_open`, `partial_followup`, `blocked_by_dependency`, `failed`, `skipped`) — the example below uses the default `balanced` mode where a clean PR is merged. Under `conservative` mode the same iteration would end with `Merge ⚠ left_open (mode: conservative)`.
 
 ```
   ◆ Auto-Pilot Iteration 1

--- a/src/skills/auto-pilot/references/examples.md
+++ b/src/skills/auto-pilot/references/examples.md
@@ -6,7 +6,7 @@ Detailed example runs and edge-case behaviors referenced from SKILL.md.
 
 **User says:** `/auto-pilot --limit 3`
 
-> Assumes `autopilot.mode: balanced` or `aggressive` in `.gitissue.yml`. Under the default `conservative` mode, each PR would end with `Outcome: left_open` instead of being merged automatically.
+> Uses the default `autopilot.mode: balanced`, where clean PRs are merged automatically. Under `conservative` mode, each clean PR would end with `Outcome: left_open` instead.
 
 ```
 ● Checking environment...

--- a/src/skills/auto-pilot/references/phases.md
+++ b/src/skills/auto-pilot/references/phases.md
@@ -246,12 +246,12 @@ For non-critical issues (no `critical` or `priority:critical` label), the auto-p
 
 | Mode (effective) | `merge_partial` | Behavior | Outcome label |
 |------------------|-----------------|----------|----------------|
-| `conservative` (default) | n/a (ignored) | follow-up created, PR left open | `left_open` |
-| `balanced` | n/a (ignored) | follow-up created, PR left open | `left_open` |
+| `conservative` | n/a (ignored) | follow-up created, PR left open | `left_open` |
+| `balanced` (default) | n/a (ignored) | follow-up created, PR left open | `left_open` |
 | `aggressive` | `false` (default) | follow-up created, PR left open | `left_open` |
 | `aggressive` | `true` | follow-up created, PR merged anyway | `partial_followup` |
 
-The default install (`mode: conservative`) **never** auto-merges a PR with unresolved fixable review issues. Aggressive partial-merge is unreachable without setting both `mode: aggressive` and `merge_partial: true` in `.gitissue.yml`.
+The default install (`mode: balanced`) **never** auto-merges a PR with unresolved fixable review issues; only clean PRs are merged. Aggressive partial-merge is unreachable without setting both `mode: aggressive` and `merge_partial: true` in `.gitissue.yml`.
 
 **Step 1 — Create follow-up issue (always, regardless of mode):**
 

--- a/src/skills/init-gitissue/SKILL.md
+++ b/src/skills/init-gitissue/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: Requires git. No GitHub CLI or authentication needed — generates a local config file only.
 effort: low
 metadata:
-  version: 0.3.2
+  version: 0.3.3
   creator: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -43,9 +43,21 @@ That is the only prerequisite. This skill does not need `gh` or GitHub authentic
 
 ## Configuration Check
 
-This skill GENERATES the config — it does not read one. However, check if `.gitissue.yml` already exists in the repo root before proceeding.
+This skill GENERATES the config — it does not read one. Check if `.gitissue.yml` already exists in the repo root before proceeding.
 
-If the file exists, show the prompt from `references/error-messages.md`:
+### File does NOT exist — always create
+
+When the file is missing, **always create it** without prompting. This happens regardless of context — even when the skill is invoked non-interactively from another skill. No early exit, no conditions, no cancel option.
+
+```
+○ No .gitissue.yml found — generating config...
+```
+
+Proceed directly to **Step 1 — Scan Repository**.
+
+### File exists — ask user
+
+If the file already exists, show the prompt from `references/error-messages.md`:
 
 ```
 ⚠ .gitissue.yml already exists

--- a/src/skills/init-gitissue/templates/gitissue-template.yml
+++ b/src/skills/init-gitissue/templates/gitissue-template.yml
@@ -97,7 +97,7 @@ autopilot:
   # Default: "balanced" — auto-merge clean PRs (review passed). PRs with unresolved
   #   review issues get a follow-up and stay open. Recommended for most projects.
   # "conservative": create PR, run review-fix cycles, leave PR open.
-  #                 review issues get a follow-up issue and stay open.
+  #                 Never auto-merges.
   # "aggressive":   auto-merge clean PRs AND merge partial PRs when
   #                 merge_partial=true is also set (see below). Risky —
   #                 only enable on disposable/experimental repos.

--- a/src/skills/init-gitissue/templates/gitissue-template.yml
+++ b/src/skills/init-gitissue/templates/gitissue-template.yml
@@ -94,14 +94,14 @@ review:
 autopilot:
   # Merge mode — controls when /auto-pilot is allowed to merge PRs.
   # Values: "conservative" | "balanced" | "aggressive"
-  # Default: "conservative" — create PR, run review-fix cycles, leave PR open.
-  #   Never auto-merges. Safest default; recommended for most projects.
-  # "balanced":     auto-merge clean PRs (review passed). PRs with unresolved
+  # Default: "balanced" — auto-merge clean PRs (review passed). PRs with unresolved
+  #   review issues get a follow-up and stay open. Recommended for most projects.
+  # "conservative": create PR, run review-fix cycles, leave PR open.
   #                 review issues get a follow-up issue and stay open.
   # "aggressive":   auto-merge clean PRs AND merge partial PRs when
   #                 merge_partial=true is also set (see below). Risky —
   #                 only enable on disposable/experimental repos.
-  mode: conservative
+  mode: balanced
 
   # Allow merging PRs that still have unresolved fixable review issues.
   # Default: false — never merge a partial PR.

--- a/tests/test-autopilot-modes.sh
+++ b/tests/test-autopilot-modes.sh
@@ -6,8 +6,8 @@
 #  - Default install never merges a PR with unresolved fixable review issues
 #  - Aggressive behavior is unreachable without explicit config (no casual flag)
 #  - /init-gitissue emits balanced defaults
-#  - /auto-pilot final report uses the five categories: merged, left_open,
-#    partial_followup, failed, skipped
+#  - /auto-pilot final report uses the six categories: merged, left_open,
+#    partial_followup, blocked_by_dependency, failed, skipped
 #
 # Usage: bash tests/test-autopilot-modes.sh
 # Returns: exit 0 if all tests pass, exit 1 on first failure
@@ -138,8 +138,8 @@ else
   fail "T3.4: SKILL.md does not reference autopilot.merge_partial"
 fi
 
-# Final-report uses the five categorical labels
-for category in merged left_open partial_followup failed skipped; do
+# Final-report uses the six categorical labels
+for category in merged left_open partial_followup blocked_by_dependency failed skipped; do
   if grep -qE "\b${category}\b" "$SKILL"; then
     pass "T3.5.${category}: SKILL.md final report mentions outcome '${category}'"
   else

--- a/tests/test-autopilot-modes.sh
+++ b/tests/test-autopilot-modes.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-# test-autopilot-modes.sh — Validate the conservative-by-default merge modes
+# test-autopilot-modes.sh — Validate balanced-by-default merge modes
 #
 # This script verifies issue #33 acceptance criteria:
 #  - .gitissue.yml supports `autopilot.mode` with values conservative|balanced|aggressive
 #  - Default install never merges a PR with unresolved fixable review issues
 #  - Aggressive behavior is unreachable without explicit config (no casual flag)
-#  - /init-gitissue emits conservative defaults
+#  - /init-gitissue emits balanced defaults
 #  - /auto-pilot final report uses the five categories: merged, left_open,
 #    partial_followup, failed, skipped
 #
@@ -28,11 +28,11 @@ fail() {
   FAIL=$((FAIL + 1))
 }
 
-echo "◆ Auto-Pilot Conservative Merge Modes Tests (issue #33)"
+echo "◆ Auto-Pilot Balanced Merge Modes Tests (issue #33)"
 echo "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄"
 
 # ───────────────────────────────────────────────────────────
-# T1: init-gitissue template ships conservative defaults
+# T1: init-gitissue template ships balanced defaults
 # ───────────────────────────────────────────────────────────
 TEMPLATE="$REPO_ROOT/src/skills/init-gitissue/templates/gitissue-template.yml"
 
@@ -42,10 +42,10 @@ else
   fail "T1.0: $TEMPLATE not found"
 fi
 
-if grep -qE '^\s*mode:\s*conservative\b' "$TEMPLATE"; then
-  pass "T1.1: template ships 'mode: conservative' as the default"
+if grep -qE '^\s*mode:\s*balanced\b' "$TEMPLATE"; then
+  pass "T1.1: template ships 'mode: balanced' as the default"
 else
-  fail "T1.1: template does not ship 'mode: conservative' as default"
+  fail "T1.1: template does not ship 'mode: balanced' as default"
 fi
 
 if grep -qE '^\s*merge_partial:\s*false\b' "$TEMPLATE"; then
@@ -86,11 +86,11 @@ for mode_value in conservative balanced aggressive; do
   fi
 done
 
-# Default in defaults table is conservative
-if grep -qE '\| \`autopilot\.mode\` \| \`conservative\`' "$SCHEMA"; then
-  pass "T2.4: defaults table lists conservative as the default mode"
+# Default in defaults table is balanced
+if grep -qE '\| \`autopilot\.mode\` \| \`balanced\`' "$SCHEMA"; then
+  pass "T2.4: defaults table lists balanced as the default mode"
 else
-  fail "T2.4: defaults table does not list conservative as the default mode"
+  fail "T2.4: defaults table does not list balanced as the default mode"
 fi
 
 # Default merge_partial is false
@@ -158,7 +158,7 @@ else
   fail "T4.1: phases.md does not describe mode gating"
 fi
 
-if grep -qiE 'mode:\s*conservative.*manual\s+merge|conservative.*leave PR open|leave PR open.*conservative' "$PHASES"; then
+if grep -qiE 'mode:\s*balanced.*manual\s+merge|conservative.*leave PR open|leave PR open.*conservative' "$PHASES"; then
   pass "T4.2: phases.md describes conservative-mode leave-open behavior"
 else
   fail "T4.2: phases.md does not describe conservative-mode leave-open behavior"
@@ -186,7 +186,7 @@ for category in merged left_open partial_followup; do
 done
 
 # ───────────────────────────────────────────────────────────
-# T5: README highlights conservative-by-default
+# T5: README highlights merge modes
 # ───────────────────────────────────────────────────────────
 README="$REPO_ROOT/src/skills/auto-pilot/README.md"
 
@@ -213,12 +213,12 @@ else
 fi
 
 # AC #2: default install never merges a PR with unresolved fixable review issues
-# This is enforced by the conservative default + merge_partial: false default.
+# This is enforced by the balanced default + merge_partial: false default.
 # Verify the SKILL.md merge-modes table makes this explicit.
 if grep -qiE 'Default install never merges|never auto-merge' "$SKILL"; then
-  pass "T6.2: SKILL.md states default never auto-merges (AC #2)"
+  pass "T6.2: SKILL.md states default never merges unresolved PRs (AC #2)"
 else
-  fail "T6.2: SKILL.md does not explicitly state default never auto-merges"
+  fail "T6.2: SKILL.md does not explicitly state default never merges unresolved PRs"
 fi
 
 # ───────────────────────────────────────────────────────────

--- a/tests/test-config-schema-38.sh
+++ b/tests/test-config-schema-38.sh
@@ -4,7 +4,7 @@
 #
 # This script verifies issue #38 acceptance criteria:
 #  AC1. .gitissue.yml schema documents the four keys with defaults:
-#         autopilot.mode (conservative), autopilot.merge_partial (false),
+#         autopilot.mode (balanced), autopilot.merge_partial (false),
 #         review.require_acceptance_criteria_check (true),
 #         review.require_traceability_check (true).
 #  AC2. /init-gitissue emits these defaults on a fresh install.
@@ -63,18 +63,18 @@ done
 # ───────────────────────────────────────────────────────────
 # T1: AC1 — schema documents all four keys with their defaults
 # ───────────────────────────────────────────────────────────
-# autopilot.mode = conservative (already shipped in #33; covered here for
+# autopilot.mode = balanced (already shipped in #33; covered here for
 # the unified-schema AC)
-if grep -qE '^\s*mode:\s*conservative\b' "$SCHEMA"; then
-  pass "T1.AC1.1: schema yaml block has 'mode: conservative'"
+if grep -qE '^\s*mode:\s*balanced\b' "$SCHEMA"; then
+  pass "T1.AC1.1: schema yaml block has 'mode: balanced'"
 else
-  fail "T1.AC1.1: schema yaml block missing 'mode: conservative'"
+  fail "T1.AC1.1: schema yaml block missing 'mode: balanced'"
 fi
 
-if grep -qE '\| \`autopilot\.mode\` \| \`conservative\`' "$SCHEMA"; then
-  pass "T1.AC1.2: defaults table lists autopilot.mode = conservative"
+if grep -qE '\| \`autopilot\.mode\` \| \`balanced\`' "$SCHEMA"; then
+  pass "T1.AC1.2: defaults table lists autopilot.mode = balanced"
 else
-  fail "T1.AC1.2: defaults table missing autopilot.mode = conservative"
+  fail "T1.AC1.2: defaults table missing autopilot.mode = balanced"
 fi
 
 # autopilot.merge_partial = false
@@ -134,10 +134,10 @@ fi
 # ───────────────────────────────────────────────────────────
 # autopilot.mode and merge_partial come from #33; verify they are still
 # emitted as part of the unified schema.
-if grep -qE '^\s*mode:\s*conservative\b' "$TEMPLATE"; then
-  pass "T2.AC2.1: init template emits 'mode: conservative'"
+if grep -qE '^\s*mode:\s*balanced\b' "$TEMPLATE"; then
+  pass "T2.AC2.1: init template emits 'mode: balanced'"
 else
-  fail "T2.AC2.1: init template missing 'mode: conservative'"
+  fail "T2.AC2.1: init template missing 'mode: balanced'"
 fi
 
 if grep -qE '^\s*merge_partial:\s*false\b' "$TEMPLATE"; then


### PR DESCRIPTION
## Changes

### Merge Strategy Default `conservative` → `balanced`

- `autopilot.mode` default changed from `conservative` to `balanced`
- `balanced`: auto-merge clean PRs (review passed); PRs with unresolved issues get a follow-up and stay open
- Updated in: `config-schema.md`, `gitissue-template.yml`, `ARCHITECTURE.md`
- Defaults table in schema also updated

### Always Create Config When Missing

- init-gitissue now **always creates** `.gitissue.yml` when it does not exist
- No prompting, no early exit, no cancel option
- Applies even when invoked non-interactively from another skill
- Clarified in SKILL.md with explicit "File does NOT exist — always create" section

### Files Changed

- `docs/config-schema.md` — schema defaults
- `docs/ARCHITECTURE.md` — architecture description
- `AGENTS.md` — conventions note
- `src/skills/init-gitissue/SKILL.md` — v0.3.3, always-create logic
- `src/skills/init-gitissue/templates/gitissue-template.yml` — template default value