### PR TITLE
chore(skills): add bundled dependency precheck to all 8 IDD skills

### DIFF
--- a/src/internal-skills/idd-doctor/SKILL.md
+++ b/src/internal-skills/idd-doctor/SKILL.md
@@ -52,6 +52,27 @@ Before any check, verify the environment. On failure, output the exact error fro
 
 `gh` is **optional**. The merge-strategy check (Check 4) requires `gh` and authentication; if either is missing, that check is skipped with an `○` note rather than failing the whole run.
 
+### Bundled dependency precheck
+
+Verify that this skill's bundled reference files are present.
+If any are missing, stop immediately and print:
+
+```
+text
+✗ Missing bundled dependency: {missing_file}
+
+  To fix:  asm install https://github.com/luongnv89/idd --skill idd-doctor
+           (or reinstall the full distribution)
+
+  Then restart the agent session and re-run /idd-doctor.
+```
+
+Check these files relative to the skill's directory (the dirname of this SKILL.md):
+
+- `references/error-messages.md` — Error catalog
+- `references/docs/config-schema.md` — configuration schema reference (Check 3)
+- `references/docs/naming-conventions.md` — naming conventions (context reference)
+
 ## Configuration
 
 This skill **reads** `.gitissue.yml` (only to determine whether `autopilot.mode` is set in Check 3) and is otherwise config-free. There is no `doctor:` section in `.gitissue.yml` and no per-check toggles in v1.

--- a/src/internal-skills/idd-doctor/SKILL.md
+++ b/src/internal-skills/idd-doctor/SKILL.md
@@ -70,8 +70,6 @@ text
 Check these files relative to the skill's directory (the dirname of this SKILL.md):
 
 - `references/error-messages.md` — Error catalog
-- `references/docs/config-schema.md` — configuration schema reference (Check 3)
-- `references/docs/naming-conventions.md` — naming conventions (context reference)
 
 ## Configuration
 

--- a/src/skills/auto-pilot/SKILL.md
+++ b/src/skills/auto-pilot/SKILL.md
@@ -116,6 +116,30 @@ Do not continue with partial auto-pilot execution when required skills are
 missing. `issue-creator` is optional; if it is missing, skip mid-loop issue
 normalization and print a warning instead of stopping.
 
+### Bundled dependency precheck
+
+Verify that this skill's bundled reference files are present. If any are
+missing, stop immediately and print:
+
+```
+text
+✗ Missing bundled dependency: {missing_file}
+
+  To fix:  asm install https://github.com/luongnv89/idd --skill auto-pilot
+           (or reinstall the full distribution)
+
+  Then restart the agent session and re-run /auto-pilot.
+```
+
+Check these files relative to the skill's directory (the dirname of this SKILL.md):
+
+- `references/phases.md` — phase-by-phase execution spec
+- `references/subagent-prompts.md` — resolver, reviewer, analyzer, batch-resolver subagent prompts
+- `references/docs/idd-methodology.md` — IDD methodology (issue dependencies, etc.)
+- `references/docs/sync-conventions.md` — stash-first sync convention and recovery
+- `references/docs/config-schema.md` — configuration schema reference
+- `references/explicit-list-mode.md` — explicit list mode parsing rules and dependency scan
+
 If the working tree is dirty, auto-stash and continue:
 ```bash
 git stash --include-untracked -m "auto-pilot: stash before run"

--- a/src/skills/init-gitissue/SKILL.md
+++ b/src/skills/init-gitissue/SKILL.md
@@ -41,6 +41,27 @@ Before any operation, verify the environment. On failure, output the exact error
 
 That is the only prerequisite. This skill does not need `gh` or GitHub authentication — it generates a local config file.
 
+### Bundled dependency precheck
+
+Verify that this skill's bundled template files are present. If any are missing,
+stop immediately and print:
+
+```
+text
+✗ Missing bundled dependency: {missing_file}
+
+  To fix:  asm install https://github.com/luongnv89/idd --skill init-gitissue
+           (or reinstall the full distribution)
+
+  Then restart the agent session and re-run /init-gitissue.
+```
+
+Check these files relative to the skill's directory (the dirname of this SKILL.md):
+
+- `templates/gitissue-template.yml` — canonical config template with all schema fields
+- `references/docs/config-schema.md` — full configuration schema
+- `references/docs/naming-conventions.md` — naming conventions (referenced by generated config)
+
 ## Configuration Check
 
 This skill GENERATES the config — it does not read one. Check if `.gitissue.yml` already exists in the repo root before proceeding.

--- a/src/skills/init-gitissue/SKILL.md
+++ b/src/skills/init-gitissue/SKILL.md
@@ -43,7 +43,7 @@ That is the only prerequisite. This skill does not need `gh` or GitHub authentic
 
 ### Bundled dependency precheck
 
-Verify that this skill's bundled template files are present. If any are missing,
+Verify that this skill's bundled template and reference files are present. If any are missing,
 stop immediately and print:
 
 ```

--- a/src/skills/issue-analysis/SKILL.md
+++ b/src/skills/issue-analysis/SKILL.md
@@ -154,6 +154,31 @@ If not (e.g., Claude.ai), execute each phase inline instead:
 - Steps 6-7: Perform analysis inline
 - Step 8: Output as normal
 
+### Bundled dependency precheck
+
+Verify that this skill's bundled subagent prompts and reference files are present.
+If any are missing, stop immediately and print:
+
+```
+text
+✗ Missing bundled dependency: {missing_file}
+
+  To fix:  asm install https://github.com/luongnv89/idd --skill issue-analysis
+           (or reinstall the full distribution)
+
+  Then restart the agent session and re-run /issue-analysis.
+```
+
+Check these files relative to the skill's directory (the dirname of this SKILL.md):
+
+- `references/agents/codebase-researcher.md` — Codebase Researcher subagent prompt (Steps 2-5)
+- `references/agents/synthesizer.md` — Synthesizer subagent prompt (Steps 6-7)
+- `references/subagent-steps.md` — per-step prompts and tool budgets for subagents
+- `references/output-and-persist.md` — terminal report rendering spec and JSON schema
+- `references/docs/sync-conventions.md` — stash-first sync convention and recovery
+- `references/docs/idd-methodology.md` — IDD methodology (durable analysis fields)
+- `references/docs/config-schema.md` — configuration schema reference
+
 The steps below include both the subagent delegation path and the inline fallback.
 
 ---

--- a/src/skills/issue-creator/SKILL.md
+++ b/src/skills/issue-creator/SKILL.md
@@ -95,6 +95,31 @@ Read `shared/agents/duplicate-detector.md` for the full duplicate detector promp
 If the Agent tool is available, use the duplicate-detector subagent as described above for Step 3.
 If not (e.g., Claude.ai or environments without the Agent tool), execute duplicate checking inline using the fallback instructions included in Step 3.
 
+### Bundled dependency precheck
+
+Verify that this skill's bundled agent prompt and template files are present.
+If any are missing, stop immediately and print:
+
+```
+text
+✗ Missing bundled dependency: {missing_file}
+
+  To fix:  asm install https://github.com/luongnv89/idd --skill issue-creator
+           (or reinstall the full distribution)
+
+  Then restart the agent session and re-run /issue-creator.
+```
+
+Check these files relative to the skill's directory (the dirname of this SKILL.md):
+
+- `references/agents/duplicate-detector.md` — duplicate detection subagent prompt
+- `templates/bug.md` — bug issue template
+- `templates/feature.md` — feature request template
+- `templates/improvement.md` — improvement request template
+- `references/docs/naming-conventions.md` — issue title and labeling conventions
+- `references/docs/github-projects-sync.md` — GitHub Projects status sync reference
+- `references/modes.md` — Normalize and Batch mode step specs and error paths
+
 ### Parallel execution — Batch mode
 
 In batch mode, the duplicate detector and template generation can run in parallel since they are independent:

--- a/src/skills/issue-pr-review/SKILL.md
+++ b/src/skills/issue-pr-review/SKILL.md
@@ -54,6 +54,28 @@ If it is missing, stop immediately and print:
 Do not continue with an inline or guessed reviewer prompt when the bundled agent
 is missing.
 
+Additionally, verify that this skill's bundled reference files are present.
+If any are missing, stop immediately and print:
+
+```
+text
+✗ Missing bundled dependency: {missing_file}
+
+  To fix:  asm install https://github.com/luongnv89/idd --skill issue-pr-review
+           (or reinstall the full distribution)
+
+  Then restart the agent session and re-run /issue-pr-review.
+```
+
+Check these files relative to the skill's directory (the dirname of this SKILL.md):
+
+- `references/agents/code-reviewer.md` — Review subagent prompt (already checked above)
+- `references/report-templates.md` — Step 7 summary templates, auto-merge flow, expected inline output
+- `references/docs/pre-commit-security.md` — pre-commit security conventions reference
+- `references/docs/sync-conventions.md` — stash-first sync convention and recovery
+- `references/docs/idd-methodology.md` — IDD methodology (durable analysis fields)
+- `references/docs/naming-conventions.md` — naming conventions
+
 ## Repo Sync Before Edits (mandatory)
 
 Before making any fixes, sync with remote using the stash-first pattern (see `docs/sync-conventions.md` for the full convention and recovery procedure):

--- a/src/skills/issue-resolver/SKILL.md
+++ b/src/skills/issue-resolver/SKILL.md
@@ -112,6 +112,36 @@ Read `shared/agents/code-reviewer.md` for the reviewer prompt.
 If the Agent tool is available, use subagents as described above.
 If not (e.g., Claude.ai), execute each step inline using the fallback instructions.
 
+### Bundled dependency precheck
+
+Verify that this skill's bundled subagent prompts and reference files are present.
+If any are missing, stop immediately and print:
+
+```
+text
+✗ Missing bundled dependency: {missing_file}
+
+  To fix:  asm install https://github.com/luongnv89/idd --skill issue-resolver
+           (or reinstall the full distribution)
+
+  Then restart the agent session and re-run /issue-resolver.
+```
+
+Check these files relative to the skill's directory (the dirname of this SKILL.md):
+
+- `references/agents/codebase-researcher.md` — Research subagent (Step 1)
+- `references/agents/synthesizer.md` — Plan subagent (Step 2)
+- `references/agents/implementer.md` — Implement subagent (Step 3)
+- `references/agents/code-reviewer.md` — QA review subagent (Step 4)
+- `references/pipeline-steps.md` — Full delegation payloads, phases, and inline fallbacks for Steps 1–4
+- `references/report-templates.md` — PR body template, final report templates, and expected inline output
+- `references/docs/sync-conventions.md` — stash-first sync convention and recovery
+- `references/docs/naming-conventions.md` — branch, commit, PR naming conventions
+- `references/docs/pre-commit-security.md` — pre-commit security conventions reference
+- `references/docs/idd-methodology.md` — IDD methodology (durable analysis fields)
+- `references/docs/github-projects-sync.md` — GitHub Projects status sync
+- `references/docs/config-schema.md` — configuration schema reference
+
 ---
 
 ## Pipeline Overview

--- a/src/skills/issue-triage/SKILL.md
+++ b/src/skills/issue-triage/SKILL.md
@@ -236,6 +236,31 @@ If the Agent tool is available, use subagents as described above.
 If not (e.g., Claude.ai), execute history scanning and dependency analysis inline — the steps below include the full procedure for both modes.
 When the Agent tool is available and there are 10+ issues, split dependency scanning into parallel batches of ~5 issues each for faster execution.
 
+### Bundled dependency precheck
+
+Verify that this skill's bundled subagent prompts and reference files are present.
+If any are missing, stop immediately and print:
+
+```
+text
+✗ Missing bundled dependency: {missing_file}
+
+  To fix:  asm install https://github.com/luongnv89/idd --skill issue-triage
+           (or reinstall the full distribution)
+
+  Then restart the agent session and re-run /issue-triage.
+```
+
+Check these files relative to the skill's directory (the dirname of this SKILL.md):
+
+- `references/agents/issue-relationship-scanner.md` — Combined dependency + history scanner prompt
+- `references/detection.md` — Confidence-scoring rules and merge logic for detection
+- `references/output-and-persist.md` — Terminal report rendering spec and JSON schema
+- `references/docs/sync-conventions.md` — stash-first sync convention and recovery
+- `references/docs/idd-methodology.md` — IDD methodology (durable analysis fields)
+- `references/docs/github-projects-sync.md` — GitHub Projects status sync reference
+- `references/docs/config-schema.md` — configuration schema reference
+
 ---
 
 ## Step 1 — Fetch Issues


### PR DESCRIPTION
Type: chore

## Summary

Every skill that references bundled files (subagent prompts, templates, reference docs) now verifies they exist **before execution**. Missing files produce a structured, actionable error instead of a confusing mid-run failure.

## Problem

Only \`/issue-pr-review\` had a bundled dependency precheck. The other 7 skills would fail mid-execution with cryptic errors (e.g., \"can't read file\", \"agent prompt not found\") when installed partially or corrupted — no clear path to fix.

## Solution

Added a \`\`\`### Bundled dependency precheck\`\`\` section to all 8 skills. Each lists every bundled file the skill depends on and produces:

\`\`\`
text
✗ Missing bundled dependency: {missing_file}

  To fix:  asm install https://github.com/luongnv89/idd --skill {skill_name}
           (or reinstall the full distribution)

  Then restart the agent session and re-run /{skill_command}.
\`\`\`

## Skills Updated

| Skill | Bundled files checked |
|-------|----------------------|
| \`auto-pilot\` | 6 files — phases.md, subagent-prompts.md, explicit-list-mode.md, docs/ |
| \`init-gitissue\` | 3 files — gitissue-template.yml, config-schema.md, naming-conventions.md |
| \`issue-analysis\` | 7 files — agents/, subagent-steps.md, output-and-persist.md, docs/ |
| \`issue-creator\` | 7 files — duplicate-detector.md, templates/, modes.md, docs/ |
| \`issue-pr-review\` | 6 files — report-templates.md, docs/ (already had code-reviewer.md) |
| \`issue-resolver\` | 12 files — 4 agents/, pipeline-steps.md, report-templates.md, docs/ |
| \`issue-triage\` | 7 files — scanner.md, detection.md, output-and-persist.md, docs/ |
| \`idd-doctor\` | 3 files — error-messages.md, docs/ |

## Design Decisions

- **Relative paths**: All file checks use \`references/...\` relative to the skill's directory (the dirname of this SKILL.md), matching how skills reference them during execution
- **Comprehensive**: Checks include subagent prompts, templates, reference docs, and methodology docs — anything the skill reads at runtime
- **Consistent pattern**: Every precheck uses the same error format for easy agent parsing and consistent UX
- **No breaking changes**: This is purely additive — existing correct installs are unaffected