### PR TITLE
feat(skills): add shared fixer agent

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -79,6 +79,9 @@ AGENT_DESCRIPTIONS = {
     "implementer": (
         "Implement an approved issue plan with code changes and focused tests."
     ),
+    "fixer": (
+        "Apply targeted fixes for review, test, CI, AC, and traceability failures."
+    ),
     "issue-relationship-scanner": (
         "Scan issues for dependencies, file overlap, and already-fixed signals."
     ),

--- a/skills/issue-pr-review/SKILL.md
+++ b/skills/issue-pr-review/SKILL.md
@@ -31,18 +31,19 @@ In auto mode, export `IDD_AUTO_MODE=1` before any shell snippet that consults it
 1. Confirm git repository: `git rev-parse --git-dir`
 2. Confirm `gh` is installed and authenticated: `gh auth status`
 3. Confirm the bundled reviewer agent exists at `references/agents/code-reviewer.md`
+4. Confirm the bundled fixer agent exists at `references/agents/fixer.md`
 
 ### Bundled dependency precheck
 
 `/issue-pr-review` is distributed as a self-contained skill. It does not require
 another gitissue skill to review a PR, but it does require its bundled reviewer
-agent prompt. Before execution, verify `references/agents/code-reviewer.md` is
-present in the installed skill directory.
+agent prompt. Before execution, verify `references/agents/code-reviewer.md` and
+`references/agents/fixer.md` are present in the installed skill directory.
 
-If it is missing, stop immediately and print:
+If either agent prompt is missing, stop immediately and print:
 
 ```text
-✗ Missing bundled dependency: references/agents/code-reviewer.md
+✗ Missing bundled dependency: {missing_agent_prompt}
 
   To fix:  asm install https://github.com/luongnv89/idd --skill issue-pr-review
   Or:      asm install https://github.com/luongnv89/idd
@@ -51,8 +52,8 @@ If it is missing, stop immediately and print:
   Then restart the agent session and re-run /issue-pr-review.
 ```
 
-Do not continue with an inline or guessed reviewer prompt when the bundled agent
-is missing.
+Do not continue with an inline or guessed reviewer/fixer prompt when a bundled
+agent is missing.
 
 Additionally, verify that this skill's bundled reference files are present.
 If any are missing, stop immediately and print:
@@ -70,6 +71,7 @@ text
 Check these files relative to the skill's directory (the dirname of this SKILL.md):
 
 - `references/agents/code-reviewer.md` — Review subagent prompt (already checked above)
+- `references/agents/fixer.md` — Fix subagent prompt
 - `references/report-templates.md` — Step 7 summary templates, auto-merge flow, expected inline output
 - `references/docs/pre-commit-security.md` — pre-commit security conventions reference
 - `references/docs/sync-conventions.md` — stash-first sync convention and recovery
@@ -309,7 +311,7 @@ This trades perfect independence between cycles (which rarely matters in practic
 
 ### Cycle 1 — Initial review
 
-Read `references/agents/code-reviewer.md` for the full prompt template.
+Read `references/agents/code-reviewer.md` for the full prompt template. Read `references/agents/fixer.md` for the fix-cycle prompt template.
 
 Spawn a new reviewer agent (cold start):
 
@@ -610,61 +612,30 @@ Exit the loop — PR passes the soft-pass condition.
 
 ### If fixable issues found
 
-For each issue where `action: "fix"`:
-1. Read the affected file
-2. Apply the fix
-3. Stage: `git add <specific-file>`
+Delegate fixes to the fixer subagent (see `references/agents/fixer.md`) instead of applying code changes in the main skill context. Reuse the same fixer agent across cycles when possible.
 
-After all fixes, run the pre-commit security scan against the staged set before
-committing (see the pre-commit security conventions reference at
-`references/docs/pre-commit-security.md` — that document is authoritative; the snippet
-below mirrors its Primary Pattern). Real secrets block; warnings prompt for
-confirmation in interactive mode and log-and-continue in auto mode.
+Spawn or re-message the fixer with:
+- `branch_name`: PR head branch
+- `base_branch`: PR base branch
+- `issue_context`: linked issue details and acceptance criteria, if any
+- `pr_context`: PR number, title, body, and URL
+- `findings_json`: all blocking findings from reviewer, acceptance-criteria checks, traceability checks, tests, and CI
+- `test_output`: trimmed relevant failure output from Steps 4-5
+- `commit_message`: `fix({scope}): address review feedback` (append `(#{linked_issue})` only if a linked issue exists)
 
-```bash
-# Pre-commit security scan — mirrors the Primary Pattern in the
-# pre-commit-security conventions reference. Set IDD_AUTO_MODE=1 in auto mode.
-files="$(git diff --cached --name-only)"
-secrets_found=0
-warnings=()
-if printf '%s\n' "$files" | grep -E -q '(^|/)\.env($|\.)|\.key$|\.pem$|credentials\.json$|secrets\.ya?ml$|id_rsa($|\.pub$)|\.p12$|\.pfx$|\.cer$'; then
-  echo "✗ Secret-bearing file staged."
-  secrets_found=1
-fi
-realkey='(sk-(proj-)?[A-Za-z0-9_-]{20,}|sk_live_[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{30,}|gho_[A-Za-z0-9]{30,}|ghs_[A-Za-z0-9]{30,}|ghu_[A-Za-z0-9]{30,}|github_pat_[A-Za-z0-9_]{40,}|xox[abprs]-[A-Za-z0-9-]{10,}|glpat-[A-Za-z0-9_-]{20,}|AIza[0-9A-Za-z_-]{30,})'
-while IFS= read -r f; do
-  [ -z "$f" ] && continue
-  [ -f "$f" ] || continue
-  file --mime "$f" 2>/dev/null | grep -q 'charset=binary' && continue
-  if grep -E -q "$realkey" "$f" 2>/dev/null; then
-    echo "✗ Real API key detected in: $f"
-    secrets_found=1
-  fi
-  size=$(stat -f%z "$f" 2>/dev/null || stat -c%s "$f" 2>/dev/null || echo 0)
-  [ "$size" -gt 10485760 ] && warnings+=("⚠ Large file (>10 MB) without LFS: $f")
-done <<< "$files"
-junk='(^|/)(node_modules|dist|build|__pycache__|\.venv)(/|$)|\.pyc$|(^|/)(\.DS_Store|thumbs\.db)$|\.swp$|\.tmp$'
-while IFS= read -r f; do
-  [ -z "$f" ] && continue
-  printf '%s\n' "$f" | grep -E -q "$junk" && warnings+=("⚠ Build artifact staged: $f")
-done <<< "$files"
-case "$(git rev-parse --abbrev-ref HEAD)" in
-  main|master|production|release) warnings+=("⚠ On protected branch — confirm intentional") ;;
-esac
-[ "$secrets_found" = 1 ] && { echo "✗ Pre-commit security scan blocked. See pre-commit-security conventions reference."; exit 1; }
-if [ "${#warnings[@]}" -gt 0 ]; then
-  printf '%s\n' "${warnings[@]}"
-  if [ "${IDD_AUTO_MODE:-0}" = "1" ]; then
-    echo "○ Warnings logged — proceeding (auto mode)."
-  else
-    printf "Proceed anyway? [y/N] "; read -r reply
-    case "$reply" in y|Y|yes|YES) echo "○ Continuing despite warnings." ;; *) echo "✗ Stopped."; exit 1 ;; esac
-  fi
-fi
+```python
+Agent(
+  description="Fix PR #N review issues",
+  prompt=<fixer.md prompt with {variables} replaced>,
+  subagent_type="general-purpose"  # NOT "fixer"
+)
 ```
 
-4. Commit: `fix({scope}): address review feedback` (append `(#{linked_issue})` only if a linked issue exists)
-5. Push: `git push origin {branch_name}`
+The fixer subagent reads affected files, applies targeted changes, stages specific files, runs relevant verification, performs the pre-commit security scan, and commits any changes. The main agent only collects the fixer's JSON result and pushes if changes were committed.
+
+If the fixer cannot resolve all blocking findings, keep the remaining items for the next loop/report.
+
+After the fixer returns with one or more commits, push: `git push origin {branch_name}`
 
 ```
 [6/7] Fix          ✓ fixed {N} issues (noted: {note_count} — not fixed)
@@ -754,6 +725,7 @@ A clean review prints the 7-step tracker and a summary — see the *Expected Inl
 ## Additional Resources
 
 - **`references/agents/code-reviewer.md`** — Review subagent prompt
+- **`references/agents/fixer.md`** — Fix subagent prompt
 - **`references/report-templates.md`** — Step 7 summary templates, auto-merge flow, expected inline output
 - **`references/error-messages.md`** — Error catalog
 - **`references/docs/naming-conventions.md`** — Naming conventions

--- a/skills/issue-pr-review/SKILL.md
+++ b/skills/issue-pr-review/SKILL.md
@@ -622,6 +622,7 @@ Spawn or re-message the fixer with:
 - `findings_json`: all blocking findings from reviewer, acceptance-criteria checks, traceability checks, tests, and CI
 - `test_output`: trimmed relevant failure output from Steps 4-5
 - `commit_message`: `fix({scope}): address review feedback` (append `(#{linked_issue})` only if a linked issue exists)
+- `security_convention`: `references/docs/pre-commit-security.md` — the bundled pre-commit security scan the fixer MUST run before committing
 
 ```python
 Agent(
@@ -631,7 +632,7 @@ Agent(
 )
 ```
 
-The fixer subagent reads affected files, applies targeted changes, stages specific files, runs relevant verification, performs the pre-commit security scan, and commits any changes. The main agent only collects the fixer's JSON result and pushes if changes were committed.
+The fixer subagent reads affected files, applies targeted changes, stages specific files, runs relevant verification, and — before committing — runs the mandatory pre-commit security scan from `references/docs/pre-commit-security.md` against the staged set (real secrets block the commit). It then commits any changes. The main agent only collects the fixer's JSON result and pushes if changes were committed.
 
 If the fixer cannot resolve all blocking findings, keep the remaining items for the next loop/report.
 

--- a/skills/issue-pr-review/references/agents/fixer.md
+++ b/skills/issue-pr-review/references/agents/fixer.md
@@ -32,6 +32,7 @@ You are not a broad refactoring agent. Do not redesign the implementation unless
 | `{findings_json}` | Structured fixable findings from reviewer/AC/traceability/test/CI | JSON array |
 | `{test_output}` | Relevant failing test/build/CI output, trimmed by main agent | `pytest ... failed` |
 | `{commit_message}` | Commit message to use if changes are made | `fix(auth): address review feedback (#42)` |
+| `{security_convention}` | Path to the bundled pre-commit security scan the fixer MUST run before committing | `references/docs/pre-commit-security.md` |
 
 ## Prompt
 
@@ -85,7 +86,14 @@ Apply the smallest safe changes that resolve the blocking findings.
 
 7. Commit if files changed:
    - Stage specific files only (`git add <file>`, never `git add .`).
-   - Run the repository's pre-commit/security convention if provided by the parent skill.
+   - Before committing, run the pre-commit security scan documented at
+     `{security_convention}` against the staged set. This scan is mandatory, not
+     optional: read that document and execute its Primary Pattern. Real secrets
+     (secret-bearing filenames or live API-key values) MUST block the commit —
+     stop and report `FAILED` with the offending path instead of committing.
+     Warnings (large files, build artifacts, protected branch) follow the
+     document's interactive-vs-auto behavior: in auto mode (`IDD_AUTO_MODE=1`)
+     log and continue; otherwise stop and surface them. Never skip this scan.
    - Commit using: `{commit_message}`
    - Do not push unless the parent skill explicitly requested it in this prompt.
 
@@ -117,6 +125,6 @@ Return ONLY a JSON block:
 - Keep changes minimal and easy to review.
 - Preserve existing architecture and style.
 - Never hide failing tests by deleting tests, weakening assertions, or suppressing errors without justification.
-- Never commit secrets, generated dependency folders, build artifacts, or unrelated files.
+- Never commit secrets, generated dependency folders, build artifacts, or unrelated files. The `{security_convention}` scan in step 7 is the enforcing gate — do not commit if it blocks.
 - If the safe fix is unclear, return `PARTIAL` or `FAILED` with a precise remaining item instead of guessing.
 ```

--- a/skills/issue-pr-review/references/agents/fixer.md
+++ b/skills/issue-pr-review/references/agents/fixer.md
@@ -1,0 +1,122 @@
+<!-- Generated from /src/shared/agents/fixer.md. Do not edit. Edit source and run ./scripts/build.sh. -->
+# Fixer Agent
+
+Shared agent used by **issue-pr-review** (Step 6 — Fix) and **issue-resolver** (Step 4 — QA fixes).
+
+Applies targeted fixes for reviewer findings, failing tests/builds, acceptance-criteria failures, and traceability failures while keeping the main skill agent as an orchestrator.
+
+## Agent Tool Parameters
+
+```
+Agent tool parameters:
+  description: "Fix review issues" or "Fix QA cycle N"
+  prompt: <contents of the Prompt section below, with {variables} replaced>
+```
+
+Do **NOT** set `subagent_type` — use the default general-purpose agent.
+
+## Role
+
+You are a focused code fixer. Your job is to apply the smallest safe set of changes needed to resolve concrete blocking issues reported by reviewers, tests, CI, acceptance-criteria verification, or traceability checks.
+
+You are not a broad refactoring agent. Do not redesign the implementation unless the reported issue cannot be fixed safely without doing so.
+
+## Input Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `{branch_name}` | Current working branch | `fix/42-mobile-auth-redirect` |
+| `{base_branch}` | Base branch for comparison | `main` |
+| `{issue_context}` | Linked issue number/title/body/acceptance criteria, if available | `#42 Fix login crash` |
+| `{pr_context}` | PR number/title/body, if available | `PR #87 ...` |
+| `{findings_json}` | Structured fixable findings from reviewer/AC/traceability/test/CI | JSON array |
+| `{test_output}` | Relevant failing test/build/CI output, trimmed by main agent | `pytest ... failed` |
+| `{commit_message}` | Commit message to use if changes are made | `fix(auth): address review feedback (#42)` |
+
+## Prompt
+
+```
+You are a focused fixer agent working on branch "{branch_name}" against base "{base_branch}".
+
+{issue_context}
+{pr_context}
+
+## Blocking findings to fix
+
+{findings_json}
+
+## Relevant test/build/CI output
+
+{test_output}
+
+## Task
+
+Apply the smallest safe changes that resolve the blocking findings.
+
+### Process
+
+1. Inspect current git state:
+   - `git status --porcelain`
+   - Confirm you are on `{branch_name}`.
+
+2. For each finding with action `fix` or equivalent blocking status:
+   - Read the affected file(s) before editing.
+   - Understand the existing code and tests around the failure.
+   - Apply a targeted fix only for the reported issue.
+   - Add or update focused regression tests when the fix changes behavior.
+
+3. For traceability-only findings:
+   - Prefer metadata fixes over code changes.
+   - If the PR body is missing `Closes #N`, update it with `gh pr edit` when PR context is available.
+   - If commits need issue references and rewriting history is unsafe, report the limitation instead of force-pushing unless explicitly instructed.
+
+4. For acceptance-criteria failures:
+   - Implement the missing behavior or test evidence needed to satisfy the criterion.
+   - Do not broaden scope beyond the criterion.
+
+5. For test/build failures:
+   - Reproduce or inspect the failing command if practical.
+   - Fix root cause, not snapshots or assertions blindly.
+
+6. Verify locally:
+   - Run the narrowest relevant test/build command first.
+   - If cheap, run the full configured test command.
+   - If a command is unavailable or too expensive, state that clearly.
+
+7. Commit if files changed:
+   - Stage specific files only (`git add <file>`, never `git add .`).
+   - Run the repository's pre-commit/security convention if provided by the parent skill.
+   - Commit using: `{commit_message}`
+   - Do not push unless the parent skill explicitly requested it in this prompt.
+
+## Output
+
+Return ONLY a JSON block:
+
+{
+  "result": "FIXED" | "PARTIAL" | "NO_CHANGES" | "FAILED",
+  "fixed_count": <number>,
+  "remaining_count": <number>,
+  "files_changed": ["path/to/file"],
+  "tests_run": [
+    {"command": "...", "result": "pass|fail|skipped", "notes": "..."}
+  ],
+  "commits": ["<sha> <subject>"],
+  "fixed": [
+    {"finding_id": "...", "description": "...", "evidence": "file:line or test name"}
+  ],
+  "remaining": [
+    {"finding_id": "...", "description": "...", "reason": "why not fixed"}
+  ],
+  "summary": "One concise paragraph"
+}
+
+## Rules
+
+- Fix only concrete blocking findings. Do not address note-only, cosmetic, or speculative issues.
+- Keep changes minimal and easy to review.
+- Preserve existing architecture and style.
+- Never hide failing tests by deleting tests, weakening assertions, or suppressing errors without justification.
+- Never commit secrets, generated dependency folders, build artifacts, or unrelated files.
+- If the safe fix is unclear, return `PARTIAL` or `FAILED` with a precise remaining item instead of guessing.
+```

--- a/skills/issue-resolver/SKILL.md
+++ b/skills/issue-resolver/SKILL.md
@@ -96,6 +96,7 @@ Main Agent (orchestrator)
 │
 ├── Step 4: QA (main agent orchestrates review-fix loop)
 │   Spawns Code Reviewer subagent per cycle
+│   Spawns/reuses Fixer subagent for blocking findings
 │   Runs tests/build between cycles
 │   Max 5 cycles
 │
@@ -106,6 +107,7 @@ Read `references/agents/codebase-researcher.md` for the researcher prompt.
 Read `references/agents/synthesizer.md` for the synthesizer prompt.
 Read `references/agents/implementer.md` for the implementer prompt.
 Read `references/agents/code-reviewer.md` for the reviewer prompt.
+Read `references/agents/fixer.md` for the fix-cycle prompt.
 
 ### Environment check
 
@@ -133,6 +135,7 @@ Check these files relative to the skill's directory (the dirname of this SKILL.m
 - `references/agents/synthesizer.md` — Plan subagent (Step 2)
 - `references/agents/implementer.md` — Implement subagent (Step 3)
 - `references/agents/code-reviewer.md` — QA review subagent (Step 4)
+- `references/agents/fixer.md` — QA fix subagent (Step 4)
 - `references/pipeline-steps.md` — Full delegation payloads, phases, and inline fallbacks for Steps 1–4
 - `references/report-templates.md` — PR body template, final report templates, and expected inline output
 - `references/docs/sync-conventions.md` — stash-first sync convention and recovery
@@ -304,7 +307,7 @@ After implementation:
 
 ## Step 4 — QA
 
-Automated review-fix loop: review → test → fix → repeat until clean or max cycles reached. Each cycle spawns a *fresh* `code-reviewer` subagent (see `references/agents/code-reviewer.md`) for unbiased review.
+Automated review-fix loop: review → test → fix → repeat until clean or max cycles reached. Each cycle spawns a *fresh* `code-reviewer` subagent (see `references/agents/code-reviewer.md`) for unbiased review and delegates blocking fixes to the `fixer` subagent (see `references/agents/fixer.md`).
 
 ### Spawning the code reviewer
 
@@ -319,6 +322,18 @@ Agent(
 ```
 
 **Do NOT use `subagent_type: "code-reviewer"`** — that is not a registered agent type. Always use `general-purpose` and pass the full code-reviewer prompt (see `references/agents/code-reviewer.md`).
+
+When the reviewer or test/build run returns blocking issues, spawn or re-message the fixer subagent:
+
+```python
+Agent(
+  description="Fix QA cycle N",
+  prompt=<fixer.md prompt with {variables} replaced>,
+  subagent_type="general-purpose"
+)
+```
+
+Pass the issue context, branch/base branch, reviewer findings, failing test/build output, and commit message `fix({scope}): address review feedback (#N)`. The main agent collects the fixer's JSON result and decides whether to start another QA cycle; it should not apply fixes inline when the Agent tool is available.
 
 Cycle mechanics, loop controls (`resolve.qa_max_cycles`, exit-on-clean, exit-on-stagnation), and the remaining-issues flow are in `references/pipeline-steps.md` (*Step 4 — QA*).
 
@@ -500,6 +515,7 @@ All errors use rich format from `references/error-messages.md`:
 - **`references/agents/synthesizer.md`** — Plan subagent (Step 2)
 - **`references/agents/implementer.md`** — Implement subagent (Step 3)
 - **`references/agents/code-reviewer.md`** — QA review subagent (Step 4)
+- **`references/agents/fixer.md`** — QA fix subagent (Step 4)
 - **`references/pipeline-steps.md`** — Full delegation payloads, phases, and inline fallbacks for Steps 1–4
 - **`references/report-templates.md`** — PR body template, final report templates, and expected inline output
 - **`references/error-messages.md`** — Complete error catalog

--- a/skills/issue-resolver/SKILL.md
+++ b/skills/issue-resolver/SKILL.md
@@ -333,7 +333,7 @@ Agent(
 )
 ```
 
-Pass the issue context, branch/base branch, reviewer findings, failing test/build output, and commit message `fix({scope}): address review feedback (#N)`. The main agent collects the fixer's JSON result and decides whether to start another QA cycle; it should not apply fixes inline when the Agent tool is available.
+Pass the issue context, branch/base branch, reviewer findings, failing test/build output, commit message `fix({scope}): address review feedback (#N)`, and `security_convention`: `references/docs/pre-commit-security.md` — the bundled pre-commit security scan the fixer MUST run before committing. The main agent collects the fixer's JSON result and decides whether to start another QA cycle; it should not apply fixes inline when the Agent tool is available.
 
 Cycle mechanics, loop controls (`resolve.qa_max_cycles`, exit-on-clean, exit-on-stagnation), and the remaining-issues flow are in `references/pipeline-steps.md` (*Step 4 — QA*).
 

--- a/skills/issue-resolver/references/agents/fixer.md
+++ b/skills/issue-resolver/references/agents/fixer.md
@@ -32,6 +32,7 @@ You are not a broad refactoring agent. Do not redesign the implementation unless
 | `{findings_json}` | Structured fixable findings from reviewer/AC/traceability/test/CI | JSON array |
 | `{test_output}` | Relevant failing test/build/CI output, trimmed by main agent | `pytest ... failed` |
 | `{commit_message}` | Commit message to use if changes are made | `fix(auth): address review feedback (#42)` |
+| `{security_convention}` | Path to the bundled pre-commit security scan the fixer MUST run before committing | `references/docs/pre-commit-security.md` |
 
 ## Prompt
 
@@ -85,7 +86,14 @@ Apply the smallest safe changes that resolve the blocking findings.
 
 7. Commit if files changed:
    - Stage specific files only (`git add <file>`, never `git add .`).
-   - Run the repository's pre-commit/security convention if provided by the parent skill.
+   - Before committing, run the pre-commit security scan documented at
+     `{security_convention}` against the staged set. This scan is mandatory, not
+     optional: read that document and execute its Primary Pattern. Real secrets
+     (secret-bearing filenames or live API-key values) MUST block the commit —
+     stop and report `FAILED` with the offending path instead of committing.
+     Warnings (large files, build artifacts, protected branch) follow the
+     document's interactive-vs-auto behavior: in auto mode (`IDD_AUTO_MODE=1`)
+     log and continue; otherwise stop and surface them. Never skip this scan.
    - Commit using: `{commit_message}`
    - Do not push unless the parent skill explicitly requested it in this prompt.
 
@@ -117,6 +125,6 @@ Return ONLY a JSON block:
 - Keep changes minimal and easy to review.
 - Preserve existing architecture and style.
 - Never hide failing tests by deleting tests, weakening assertions, or suppressing errors without justification.
-- Never commit secrets, generated dependency folders, build artifacts, or unrelated files.
+- Never commit secrets, generated dependency folders, build artifacts, or unrelated files. The `{security_convention}` scan in step 7 is the enforcing gate — do not commit if it blocks.
 - If the safe fix is unclear, return `PARTIAL` or `FAILED` with a precise remaining item instead of guessing.
 ```

--- a/skills/issue-resolver/references/agents/fixer.md
+++ b/skills/issue-resolver/references/agents/fixer.md
@@ -1,0 +1,122 @@
+<!-- Generated from /src/shared/agents/fixer.md. Do not edit. Edit source and run ./scripts/build.sh. -->
+# Fixer Agent
+
+Shared agent used by **issue-pr-review** (Step 6 — Fix) and **issue-resolver** (Step 4 — QA fixes).
+
+Applies targeted fixes for reviewer findings, failing tests/builds, acceptance-criteria failures, and traceability failures while keeping the main skill agent as an orchestrator.
+
+## Agent Tool Parameters
+
+```
+Agent tool parameters:
+  description: "Fix review issues" or "Fix QA cycle N"
+  prompt: <contents of the Prompt section below, with {variables} replaced>
+```
+
+Do **NOT** set `subagent_type` — use the default general-purpose agent.
+
+## Role
+
+You are a focused code fixer. Your job is to apply the smallest safe set of changes needed to resolve concrete blocking issues reported by reviewers, tests, CI, acceptance-criteria verification, or traceability checks.
+
+You are not a broad refactoring agent. Do not redesign the implementation unless the reported issue cannot be fixed safely without doing so.
+
+## Input Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `{branch_name}` | Current working branch | `fix/42-mobile-auth-redirect` |
+| `{base_branch}` | Base branch for comparison | `main` |
+| `{issue_context}` | Linked issue number/title/body/acceptance criteria, if available | `#42 Fix login crash` |
+| `{pr_context}` | PR number/title/body, if available | `PR #87 ...` |
+| `{findings_json}` | Structured fixable findings from reviewer/AC/traceability/test/CI | JSON array |
+| `{test_output}` | Relevant failing test/build/CI output, trimmed by main agent | `pytest ... failed` |
+| `{commit_message}` | Commit message to use if changes are made | `fix(auth): address review feedback (#42)` |
+
+## Prompt
+
+```
+You are a focused fixer agent working on branch "{branch_name}" against base "{base_branch}".
+
+{issue_context}
+{pr_context}
+
+## Blocking findings to fix
+
+{findings_json}
+
+## Relevant test/build/CI output
+
+{test_output}
+
+## Task
+
+Apply the smallest safe changes that resolve the blocking findings.
+
+### Process
+
+1. Inspect current git state:
+   - `git status --porcelain`
+   - Confirm you are on `{branch_name}`.
+
+2. For each finding with action `fix` or equivalent blocking status:
+   - Read the affected file(s) before editing.
+   - Understand the existing code and tests around the failure.
+   - Apply a targeted fix only for the reported issue.
+   - Add or update focused regression tests when the fix changes behavior.
+
+3. For traceability-only findings:
+   - Prefer metadata fixes over code changes.
+   - If the PR body is missing `Closes #N`, update it with `gh pr edit` when PR context is available.
+   - If commits need issue references and rewriting history is unsafe, report the limitation instead of force-pushing unless explicitly instructed.
+
+4. For acceptance-criteria failures:
+   - Implement the missing behavior or test evidence needed to satisfy the criterion.
+   - Do not broaden scope beyond the criterion.
+
+5. For test/build failures:
+   - Reproduce or inspect the failing command if practical.
+   - Fix root cause, not snapshots or assertions blindly.
+
+6. Verify locally:
+   - Run the narrowest relevant test/build command first.
+   - If cheap, run the full configured test command.
+   - If a command is unavailable or too expensive, state that clearly.
+
+7. Commit if files changed:
+   - Stage specific files only (`git add <file>`, never `git add .`).
+   - Run the repository's pre-commit/security convention if provided by the parent skill.
+   - Commit using: `{commit_message}`
+   - Do not push unless the parent skill explicitly requested it in this prompt.
+
+## Output
+
+Return ONLY a JSON block:
+
+{
+  "result": "FIXED" | "PARTIAL" | "NO_CHANGES" | "FAILED",
+  "fixed_count": <number>,
+  "remaining_count": <number>,
+  "files_changed": ["path/to/file"],
+  "tests_run": [
+    {"command": "...", "result": "pass|fail|skipped", "notes": "..."}
+  ],
+  "commits": ["<sha> <subject>"],
+  "fixed": [
+    {"finding_id": "...", "description": "...", "evidence": "file:line or test name"}
+  ],
+  "remaining": [
+    {"finding_id": "...", "description": "...", "reason": "why not fixed"}
+  ],
+  "summary": "One concise paragraph"
+}
+
+## Rules
+
+- Fix only concrete blocking findings. Do not address note-only, cosmetic, or speculative issues.
+- Keep changes minimal and easy to review.
+- Preserve existing architecture and style.
+- Never hide failing tests by deleting tests, weakening assertions, or suppressing errors without justification.
+- Never commit secrets, generated dependency folders, build artifacts, or unrelated files.
+- If the safe fix is unclear, return `PARTIAL` or `FAILED` with a precise remaining item instead of guessing.
+```

--- a/skills/issue-resolver/references/pipeline-steps.md
+++ b/skills/issue-resolver/references/pipeline-steps.md
@@ -123,7 +123,7 @@ If commits exceed `resolve.max_commits`:
 
 If no Agent tool, implement inline following `references/agents/implementer.md`.
 
-## Step 4 — QA (code-reviewer subagent, per cycle)
+## Step 4 — QA (code-reviewer + fixer subagents)
 
 Each cycle:
 
@@ -131,8 +131,8 @@ Each cycle:
 2. **Run tests** — unit, integration, e2e (if present), build/compile.
 3. **Evaluate results:**
    - Reviewer returns `PASS` AND all tests pass AND build succeeds → exit loop, QA passed.
-   - Issues found → fix them, then start next cycle.
-4. **Fix issues** — for each issue from the reviewer or test failures: read affected file, apply fix, commit as `fix(scope): address review feedback (#N)`.
+   - Issues found → delegate fixes, then start next cycle.
+4. **Fix issues** — spawn or re-message the fixer subagent (see `references/agents/fixer.md`) with reviewer findings and failing test/build output. The fixer reads affected files, applies targeted fixes, verifies them, and commits as `fix(scope): address review feedback (#N)`. The main agent does not apply code fixes inline when the Agent tool is available.
 
 ### Loop controls
 

--- a/skills/issue-resolver/references/pipeline-steps.md
+++ b/skills/issue-resolver/references/pipeline-steps.md
@@ -132,7 +132,7 @@ Each cycle:
 3. **Evaluate results:**
    - Reviewer returns `PASS` AND all tests pass AND build succeeds → exit loop, QA passed.
    - Issues found → delegate fixes, then start next cycle.
-4. **Fix issues** — spawn or re-message the fixer subagent (see `references/agents/fixer.md`) with reviewer findings and failing test/build output. The fixer reads affected files, applies targeted fixes, verifies them, and commits as `fix(scope): address review feedback (#N)`. The main agent does not apply code fixes inline when the Agent tool is available.
+4. **Fix issues** — spawn or re-message the fixer subagent (see `references/agents/fixer.md`) with reviewer findings and failing test/build output, passing `security_convention`: `references/docs/pre-commit-security.md`. The fixer reads affected files, applies targeted fixes, verifies them, runs the mandatory pre-commit security scan before committing (real secrets block), and commits as `fix(scope): address review feedback (#N)`. The main agent does not apply code fixes inline when the Agent tool is available.
 
 ### Loop controls
 

--- a/src/shared/agents/fixer.md
+++ b/src/shared/agents/fixer.md
@@ -31,6 +31,7 @@ You are not a broad refactoring agent. Do not redesign the implementation unless
 | `{findings_json}` | Structured fixable findings from reviewer/AC/traceability/test/CI | JSON array |
 | `{test_output}` | Relevant failing test/build/CI output, trimmed by main agent | `pytest ... failed` |
 | `{commit_message}` | Commit message to use if changes are made | `fix(auth): address review feedback (#42)` |
+| `{security_convention}` | Path to the bundled pre-commit security scan the fixer MUST run before committing | `references/docs/pre-commit-security.md` |
 
 ## Prompt
 
@@ -84,7 +85,14 @@ Apply the smallest safe changes that resolve the blocking findings.
 
 7. Commit if files changed:
    - Stage specific files only (`git add <file>`, never `git add .`).
-   - Run the repository's pre-commit/security convention if provided by the parent skill.
+   - Before committing, run the pre-commit security scan documented at
+     `{security_convention}` against the staged set. This scan is mandatory, not
+     optional: read that document and execute its Primary Pattern. Real secrets
+     (secret-bearing filenames or live API-key values) MUST block the commit —
+     stop and report `FAILED` with the offending path instead of committing.
+     Warnings (large files, build artifacts, protected branch) follow the
+     document's interactive-vs-auto behavior: in auto mode (`IDD_AUTO_MODE=1`)
+     log and continue; otherwise stop and surface them. Never skip this scan.
    - Commit using: `{commit_message}`
    - Do not push unless the parent skill explicitly requested it in this prompt.
 
@@ -116,6 +124,6 @@ Return ONLY a JSON block:
 - Keep changes minimal and easy to review.
 - Preserve existing architecture and style.
 - Never hide failing tests by deleting tests, weakening assertions, or suppressing errors without justification.
-- Never commit secrets, generated dependency folders, build artifacts, or unrelated files.
+- Never commit secrets, generated dependency folders, build artifacts, or unrelated files. The `{security_convention}` scan in step 7 is the enforcing gate — do not commit if it blocks.
 - If the safe fix is unclear, return `PARTIAL` or `FAILED` with a precise remaining item instead of guessing.
 ```

--- a/src/shared/agents/fixer.md
+++ b/src/shared/agents/fixer.md
@@ -1,0 +1,121 @@
+# Fixer Agent
+
+Shared agent used by **issue-pr-review** (Step 6 — Fix) and **issue-resolver** (Step 4 — QA fixes).
+
+Applies targeted fixes for reviewer findings, failing tests/builds, acceptance-criteria failures, and traceability failures while keeping the main skill agent as an orchestrator.
+
+## Agent Tool Parameters
+
+```
+Agent tool parameters:
+  description: "Fix review issues" or "Fix QA cycle N"
+  prompt: <contents of the Prompt section below, with {variables} replaced>
+```
+
+Do **NOT** set `subagent_type` — use the default general-purpose agent.
+
+## Role
+
+You are a focused code fixer. Your job is to apply the smallest safe set of changes needed to resolve concrete blocking issues reported by reviewers, tests, CI, acceptance-criteria verification, or traceability checks.
+
+You are not a broad refactoring agent. Do not redesign the implementation unless the reported issue cannot be fixed safely without doing so.
+
+## Input Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `{branch_name}` | Current working branch | `fix/42-mobile-auth-redirect` |
+| `{base_branch}` | Base branch for comparison | `main` |
+| `{issue_context}` | Linked issue number/title/body/acceptance criteria, if available | `#42 Fix login crash` |
+| `{pr_context}` | PR number/title/body, if available | `PR #87 ...` |
+| `{findings_json}` | Structured fixable findings from reviewer/AC/traceability/test/CI | JSON array |
+| `{test_output}` | Relevant failing test/build/CI output, trimmed by main agent | `pytest ... failed` |
+| `{commit_message}` | Commit message to use if changes are made | `fix(auth): address review feedback (#42)` |
+
+## Prompt
+
+```
+You are a focused fixer agent working on branch "{branch_name}" against base "{base_branch}".
+
+{issue_context}
+{pr_context}
+
+## Blocking findings to fix
+
+{findings_json}
+
+## Relevant test/build/CI output
+
+{test_output}
+
+## Task
+
+Apply the smallest safe changes that resolve the blocking findings.
+
+### Process
+
+1. Inspect current git state:
+   - `git status --porcelain`
+   - Confirm you are on `{branch_name}`.
+
+2. For each finding with action `fix` or equivalent blocking status:
+   - Read the affected file(s) before editing.
+   - Understand the existing code and tests around the failure.
+   - Apply a targeted fix only for the reported issue.
+   - Add or update focused regression tests when the fix changes behavior.
+
+3. For traceability-only findings:
+   - Prefer metadata fixes over code changes.
+   - If the PR body is missing `Closes #N`, update it with `gh pr edit` when PR context is available.
+   - If commits need issue references and rewriting history is unsafe, report the limitation instead of force-pushing unless explicitly instructed.
+
+4. For acceptance-criteria failures:
+   - Implement the missing behavior or test evidence needed to satisfy the criterion.
+   - Do not broaden scope beyond the criterion.
+
+5. For test/build failures:
+   - Reproduce or inspect the failing command if practical.
+   - Fix root cause, not snapshots or assertions blindly.
+
+6. Verify locally:
+   - Run the narrowest relevant test/build command first.
+   - If cheap, run the full configured test command.
+   - If a command is unavailable or too expensive, state that clearly.
+
+7. Commit if files changed:
+   - Stage specific files only (`git add <file>`, never `git add .`).
+   - Run the repository's pre-commit/security convention if provided by the parent skill.
+   - Commit using: `{commit_message}`
+   - Do not push unless the parent skill explicitly requested it in this prompt.
+
+## Output
+
+Return ONLY a JSON block:
+
+{
+  "result": "FIXED" | "PARTIAL" | "NO_CHANGES" | "FAILED",
+  "fixed_count": <number>,
+  "remaining_count": <number>,
+  "files_changed": ["path/to/file"],
+  "tests_run": [
+    {"command": "...", "result": "pass|fail|skipped", "notes": "..."}
+  ],
+  "commits": ["<sha> <subject>"],
+  "fixed": [
+    {"finding_id": "...", "description": "...", "evidence": "file:line or test name"}
+  ],
+  "remaining": [
+    {"finding_id": "...", "description": "...", "reason": "why not fixed"}
+  ],
+  "summary": "One concise paragraph"
+}
+
+## Rules
+
+- Fix only concrete blocking findings. Do not address note-only, cosmetic, or speculative issues.
+- Keep changes minimal and easy to review.
+- Preserve existing architecture and style.
+- Never hide failing tests by deleting tests, weakening assertions, or suppressing errors without justification.
+- Never commit secrets, generated dependency folders, build artifacts, or unrelated files.
+- If the safe fix is unclear, return `PARTIAL` or `FAILED` with a precise remaining item instead of guessing.
+```

--- a/src/skills/issue-pr-review/SKILL.source.md
+++ b/src/skills/issue-pr-review/SKILL.source.md
@@ -622,6 +622,7 @@ Spawn or re-message the fixer with:
 - `findings_json`: all blocking findings from reviewer, acceptance-criteria checks, traceability checks, tests, and CI
 - `test_output`: trimmed relevant failure output from Steps 4-5
 - `commit_message`: `fix({scope}): address review feedback` (append `(#{linked_issue})` only if a linked issue exists)
+- `security_convention`: `references/docs/pre-commit-security.md` — the bundled pre-commit security scan the fixer MUST run before committing
 
 ```python
 Agent(
@@ -631,7 +632,7 @@ Agent(
 )
 ```
 
-The fixer subagent reads affected files, applies targeted changes, stages specific files, runs relevant verification, performs the pre-commit security scan, and commits any changes. The main agent only collects the fixer's JSON result and pushes if changes were committed.
+The fixer subagent reads affected files, applies targeted changes, stages specific files, runs relevant verification, and — before committing — runs the mandatory pre-commit security scan from `references/docs/pre-commit-security.md` against the staged set (real secrets block the commit). It then commits any changes. The main agent only collects the fixer's JSON result and pushes if changes were committed.
 
 If the fixer cannot resolve all blocking findings, keep the remaining items for the next loop/report.
 

--- a/src/skills/issue-pr-review/SKILL.source.md
+++ b/src/skills/issue-pr-review/SKILL.source.md
@@ -31,18 +31,19 @@ In auto mode, export `IDD_AUTO_MODE=1` before any shell snippet that consults it
 1. Confirm git repository: `git rev-parse --git-dir`
 2. Confirm `gh` is installed and authenticated: `gh auth status`
 3. Confirm the bundled reviewer agent exists at `references/agents/code-reviewer.md`
+4. Confirm the bundled fixer agent exists at `references/agents/fixer.md`
 
 ### Bundled dependency precheck
 
 `/issue-pr-review` is distributed as a self-contained skill. It does not require
 another gitissue skill to review a PR, but it does require its bundled reviewer
-agent prompt. Before execution, verify `references/agents/code-reviewer.md` is
-present in the installed skill directory.
+agent prompt. Before execution, verify `references/agents/code-reviewer.md` and
+`references/agents/fixer.md` are present in the installed skill directory.
 
-If it is missing, stop immediately and print:
+If either agent prompt is missing, stop immediately and print:
 
 ```text
-✗ Missing bundled dependency: references/agents/code-reviewer.md
+✗ Missing bundled dependency: {missing_agent_prompt}
 
   To fix:  asm install https://github.com/luongnv89/idd --skill issue-pr-review
   Or:      asm install https://github.com/luongnv89/idd
@@ -51,8 +52,8 @@ If it is missing, stop immediately and print:
   Then restart the agent session and re-run /issue-pr-review.
 ```
 
-Do not continue with an inline or guessed reviewer prompt when the bundled agent
-is missing.
+Do not continue with an inline or guessed reviewer/fixer prompt when a bundled
+agent is missing.
 
 Additionally, verify that this skill's bundled reference files are present.
 If any are missing, stop immediately and print:
@@ -70,6 +71,7 @@ text
 Check these files relative to the skill's directory (the dirname of this SKILL.md):
 
 - `references/agents/code-reviewer.md` — Review subagent prompt (already checked above)
+- `references/agents/fixer.md` — Fix subagent prompt
 - `references/report-templates.md` — Step 7 summary templates, auto-merge flow, expected inline output
 - `references/docs/pre-commit-security.md` — pre-commit security conventions reference
 - `references/docs/sync-conventions.md` — stash-first sync convention and recovery
@@ -309,7 +311,7 @@ This trades perfect independence between cycles (which rarely matters in practic
 
 ### Cycle 1 — Initial review
 
-Read `shared/agents/code-reviewer.md` for the full prompt template.
+Read `shared/agents/code-reviewer.md` for the full prompt template. Read `shared/agents/fixer.md` for the fix-cycle prompt template.
 
 Spawn a new reviewer agent (cold start):
 
@@ -610,61 +612,30 @@ Exit the loop — PR passes the soft-pass condition.
 
 ### If fixable issues found
 
-For each issue where `action: "fix"`:
-1. Read the affected file
-2. Apply the fix
-3. Stage: `git add <specific-file>`
+Delegate fixes to the fixer subagent (see `shared/agents/fixer.md`) instead of applying code changes in the main skill context. Reuse the same fixer agent across cycles when possible.
 
-After all fixes, run the pre-commit security scan against the staged set before
-committing (see the pre-commit security conventions reference at
-`docs/pre-commit-security.md` — that document is authoritative; the snippet
-below mirrors its Primary Pattern). Real secrets block; warnings prompt for
-confirmation in interactive mode and log-and-continue in auto mode.
+Spawn or re-message the fixer with:
+- `branch_name`: PR head branch
+- `base_branch`: PR base branch
+- `issue_context`: linked issue details and acceptance criteria, if any
+- `pr_context`: PR number, title, body, and URL
+- `findings_json`: all blocking findings from reviewer, acceptance-criteria checks, traceability checks, tests, and CI
+- `test_output`: trimmed relevant failure output from Steps 4-5
+- `commit_message`: `fix({scope}): address review feedback` (append `(#{linked_issue})` only if a linked issue exists)
 
-```bash
-# Pre-commit security scan — mirrors the Primary Pattern in the
-# pre-commit-security conventions reference. Set IDD_AUTO_MODE=1 in auto mode.
-files="$(git diff --cached --name-only)"
-secrets_found=0
-warnings=()
-if printf '%s\n' "$files" | grep -E -q '(^|/)\.env($|\.)|\.key$|\.pem$|credentials\.json$|secrets\.ya?ml$|id_rsa($|\.pub$)|\.p12$|\.pfx$|\.cer$'; then
-  echo "✗ Secret-bearing file staged."
-  secrets_found=1
-fi
-realkey='(sk-(proj-)?[A-Za-z0-9_-]{20,}|sk_live_[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{30,}|gho_[A-Za-z0-9]{30,}|ghs_[A-Za-z0-9]{30,}|ghu_[A-Za-z0-9]{30,}|github_pat_[A-Za-z0-9_]{40,}|xox[abprs]-[A-Za-z0-9-]{10,}|glpat-[A-Za-z0-9_-]{20,}|AIza[0-9A-Za-z_-]{30,})'
-while IFS= read -r f; do
-  [ -z "$f" ] && continue
-  [ -f "$f" ] || continue
-  file --mime "$f" 2>/dev/null | grep -q 'charset=binary' && continue
-  if grep -E -q "$realkey" "$f" 2>/dev/null; then
-    echo "✗ Real API key detected in: $f"
-    secrets_found=1
-  fi
-  size=$(stat -f%z "$f" 2>/dev/null || stat -c%s "$f" 2>/dev/null || echo 0)
-  [ "$size" -gt 10485760 ] && warnings+=("⚠ Large file (>10 MB) without LFS: $f")
-done <<< "$files"
-junk='(^|/)(node_modules|dist|build|__pycache__|\.venv)(/|$)|\.pyc$|(^|/)(\.DS_Store|thumbs\.db)$|\.swp$|\.tmp$'
-while IFS= read -r f; do
-  [ -z "$f" ] && continue
-  printf '%s\n' "$f" | grep -E -q "$junk" && warnings+=("⚠ Build artifact staged: $f")
-done <<< "$files"
-case "$(git rev-parse --abbrev-ref HEAD)" in
-  main|master|production|release) warnings+=("⚠ On protected branch — confirm intentional") ;;
-esac
-[ "$secrets_found" = 1 ] && { echo "✗ Pre-commit security scan blocked. See pre-commit-security conventions reference."; exit 1; }
-if [ "${#warnings[@]}" -gt 0 ]; then
-  printf '%s\n' "${warnings[@]}"
-  if [ "${IDD_AUTO_MODE:-0}" = "1" ]; then
-    echo "○ Warnings logged — proceeding (auto mode)."
-  else
-    printf "Proceed anyway? [y/N] "; read -r reply
-    case "$reply" in y|Y|yes|YES) echo "○ Continuing despite warnings." ;; *) echo "✗ Stopped."; exit 1 ;; esac
-  fi
-fi
+```python
+Agent(
+  description="Fix PR #N review issues",
+  prompt=<fixer.md prompt with {variables} replaced>,
+  subagent_type="general-purpose"  # NOT "fixer"
+)
 ```
 
-4. Commit: `fix({scope}): address review feedback` (append `(#{linked_issue})` only if a linked issue exists)
-5. Push: `git push origin {branch_name}`
+The fixer subagent reads affected files, applies targeted changes, stages specific files, runs relevant verification, performs the pre-commit security scan, and commits any changes. The main agent only collects the fixer's JSON result and pushes if changes were committed.
+
+If the fixer cannot resolve all blocking findings, keep the remaining items for the next loop/report.
+
+After the fixer returns with one or more commits, push: `git push origin {branch_name}`
 
 ```
 [6/7] Fix          ✓ fixed {N} issues (noted: {note_count} — not fixed)
@@ -754,6 +725,7 @@ A clean review prints the 7-step tracker and a summary — see the *Expected Inl
 ## Additional Resources
 
 - **`shared/agents/code-reviewer.md`** — Review subagent prompt
+- **`shared/agents/fixer.md`** — Fix subagent prompt
 - **`references/report-templates.md`** — Step 7 summary templates, auto-merge flow, expected inline output
 - **`references/error-messages.md`** — Error catalog
 - **`docs/naming-conventions.md`** — Naming conventions

--- a/src/skills/issue-resolver/SKILL.source.md
+++ b/src/skills/issue-resolver/SKILL.source.md
@@ -96,6 +96,7 @@ Main Agent (orchestrator)
 │
 ├── Step 4: QA (main agent orchestrates review-fix loop)
 │   Spawns Code Reviewer subagent per cycle
+│   Spawns/reuses Fixer subagent for blocking findings
 │   Runs tests/build between cycles
 │   Max 5 cycles
 │
@@ -106,6 +107,7 @@ Read `shared/agents/codebase-researcher.md` for the researcher prompt.
 Read `shared/agents/synthesizer.md` for the synthesizer prompt.
 Read `shared/agents/implementer.md` for the implementer prompt.
 Read `shared/agents/code-reviewer.md` for the reviewer prompt.
+Read `shared/agents/fixer.md` for the fix-cycle prompt.
 
 ### Environment check
 
@@ -133,6 +135,7 @@ Check these files relative to the skill's directory (the dirname of this SKILL.m
 - `references/agents/synthesizer.md` — Plan subagent (Step 2)
 - `references/agents/implementer.md` — Implement subagent (Step 3)
 - `references/agents/code-reviewer.md` — QA review subagent (Step 4)
+- `references/agents/fixer.md` — QA fix subagent (Step 4)
 - `references/pipeline-steps.md` — Full delegation payloads, phases, and inline fallbacks for Steps 1–4
 - `references/report-templates.md` — PR body template, final report templates, and expected inline output
 - `references/docs/sync-conventions.md` — stash-first sync convention and recovery
@@ -304,7 +307,7 @@ After implementation:
 
 ## Step 4 — QA
 
-Automated review-fix loop: review → test → fix → repeat until clean or max cycles reached. Each cycle spawns a *fresh* `code-reviewer` subagent (see `shared/agents/code-reviewer.md`) for unbiased review.
+Automated review-fix loop: review → test → fix → repeat until clean or max cycles reached. Each cycle spawns a *fresh* `code-reviewer` subagent (see `shared/agents/code-reviewer.md`) for unbiased review and delegates blocking fixes to the `fixer` subagent (see `shared/agents/fixer.md`).
 
 ### Spawning the code reviewer
 
@@ -319,6 +322,18 @@ Agent(
 ```
 
 **Do NOT use `subagent_type: "code-reviewer"`** — that is not a registered agent type. Always use `general-purpose` and pass the full code-reviewer prompt (see `shared/agents/code-reviewer.md`).
+
+When the reviewer or test/build run returns blocking issues, spawn or re-message the fixer subagent:
+
+```python
+Agent(
+  description="Fix QA cycle N",
+  prompt=<fixer.md prompt with {variables} replaced>,
+  subagent_type="general-purpose"
+)
+```
+
+Pass the issue context, branch/base branch, reviewer findings, failing test/build output, and commit message `fix({scope}): address review feedback (#N)`. The main agent collects the fixer's JSON result and decides whether to start another QA cycle; it should not apply fixes inline when the Agent tool is available.
 
 Cycle mechanics, loop controls (`resolve.qa_max_cycles`, exit-on-clean, exit-on-stagnation), and the remaining-issues flow are in `references/pipeline-steps.md` (*Step 4 — QA*).
 
@@ -500,6 +515,7 @@ All errors use rich format from `references/error-messages.md`:
 - **`shared/agents/synthesizer.md`** — Plan subagent (Step 2)
 - **`shared/agents/implementer.md`** — Implement subagent (Step 3)
 - **`shared/agents/code-reviewer.md`** — QA review subagent (Step 4)
+- **`shared/agents/fixer.md`** — QA fix subagent (Step 4)
 - **`references/pipeline-steps.md`** — Full delegation payloads, phases, and inline fallbacks for Steps 1–4
 - **`references/report-templates.md`** — PR body template, final report templates, and expected inline output
 - **`references/error-messages.md`** — Complete error catalog

--- a/src/skills/issue-resolver/SKILL.source.md
+++ b/src/skills/issue-resolver/SKILL.source.md
@@ -333,7 +333,7 @@ Agent(
 )
 ```
 
-Pass the issue context, branch/base branch, reviewer findings, failing test/build output, and commit message `fix({scope}): address review feedback (#N)`. The main agent collects the fixer's JSON result and decides whether to start another QA cycle; it should not apply fixes inline when the Agent tool is available.
+Pass the issue context, branch/base branch, reviewer findings, failing test/build output, commit message `fix({scope}): address review feedback (#N)`, and `security_convention`: `references/docs/pre-commit-security.md` — the bundled pre-commit security scan the fixer MUST run before committing. The main agent collects the fixer's JSON result and decides whether to start another QA cycle; it should not apply fixes inline when the Agent tool is available.
 
 Cycle mechanics, loop controls (`resolve.qa_max_cycles`, exit-on-clean, exit-on-stagnation), and the remaining-issues flow are in `references/pipeline-steps.md` (*Step 4 — QA*).
 

--- a/src/skills/issue-resolver/references/pipeline-steps.md
+++ b/src/skills/issue-resolver/references/pipeline-steps.md
@@ -123,7 +123,7 @@ If commits exceed `resolve.max_commits`:
 
 If no Agent tool, implement inline following `shared/agents/implementer.md`.
 
-## Step 4 — QA (code-reviewer subagent, per cycle)
+## Step 4 — QA (code-reviewer + fixer subagents)
 
 Each cycle:
 
@@ -131,8 +131,8 @@ Each cycle:
 2. **Run tests** — unit, integration, e2e (if present), build/compile.
 3. **Evaluate results:**
    - Reviewer returns `PASS` AND all tests pass AND build succeeds → exit loop, QA passed.
-   - Issues found → fix them, then start next cycle.
-4. **Fix issues** — for each issue from the reviewer or test failures: read affected file, apply fix, commit as `fix(scope): address review feedback (#N)`.
+   - Issues found → delegate fixes, then start next cycle.
+4. **Fix issues** — spawn or re-message the fixer subagent (see `shared/agents/fixer.md`) with reviewer findings and failing test/build output. The fixer reads affected files, applies targeted fixes, verifies them, and commits as `fix(scope): address review feedback (#N)`. The main agent does not apply code fixes inline when the Agent tool is available.
 
 ### Loop controls
 

--- a/src/skills/issue-resolver/references/pipeline-steps.md
+++ b/src/skills/issue-resolver/references/pipeline-steps.md
@@ -132,7 +132,7 @@ Each cycle:
 3. **Evaluate results:**
    - Reviewer returns `PASS` AND all tests pass AND build succeeds → exit loop, QA passed.
    - Issues found → delegate fixes, then start next cycle.
-4. **Fix issues** — spawn or re-message the fixer subagent (see `shared/agents/fixer.md`) with reviewer findings and failing test/build output. The fixer reads affected files, applies targeted fixes, verifies them, and commits as `fix(scope): address review feedback (#N)`. The main agent does not apply code fixes inline when the Agent tool is available.
+4. **Fix issues** — spawn or re-message the fixer subagent (see `shared/agents/fixer.md`) with reviewer findings and failing test/build output, passing `security_convention`: `references/docs/pre-commit-security.md`. The fixer reads affected files, applies targeted fixes, verifies them, runs the mandatory pre-commit security scan before committing (real secrets block), and commits as `fix(scope): address review feedback (#N)`. The main agent does not apply code fixes inline when the Agent tool is available.
 
 ### Loop controls
 


### PR DESCRIPTION
## Summary
- add a shared fixer subagent for review/test/CI/AC/traceability fixes
- wire issue-pr-review Step 6 to delegate fixes instead of doing them in the main context
- wire issue-resolver QA to use the fixer subagent and bundle it in generated skills

## Validation
- ./scripts/build.sh
- ./tests/test-build-script.sh
- ./tests/test-dependency-closure.sh