### PR TITLE
chore(skills): bring all 7 IDD skills up to skill-creator standard

### DIFF
--- a/skills/auto-pilot/SKILL.md
+++ b/skills/auto-pilot/SKILL.md
@@ -1,46 +1,19 @@
 ---
 name: auto-pilot
-description: "Run a fully autonomous triage-resolve-review-merge loop over the GitHub issue backlog with zero user prompts. Use when asked to auto-pilot, autopilot, resolve everything, work through the backlog, run the loop, or keep going until done. Don't use for single-issue work (use /issue-resolver), one-shot triage (use /issue-triage), or interactive PR review (use /issue-pr-review)."
+description: "Autonomous triage-resolve-review-merge loop over the GitHub issue backlog with zero prompts. Use when asked to auto-pilot, resolve everything, work through the backlog, or keep going until done. Don't use for single-issue work (use /issue-resolver), one-shot triage (use /issue-triage), or interactive PR review (use /issue-pr-review)."
 license: MIT
 compatibility: "Requires git and GitHub CLI (gh) with auth and push access. Requires merge permission for auto-merge. Requires issue-triage, issue-resolver, issue-analysis, and issue-pr-review to be installed from the same distribution. Optional: issue-creator for normalizing unstructured issues mid-loop."
 effort: max
 metadata:
-  version: 2.3.1
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 2.3.2
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # /auto-pilot
 
 Fully autonomous development loop: triage, pick, resolve, review, fix, merge, repeat — zero user prompts.
 
-### Changes in 2.3.0 — Dependency-aware merge gating
-
-- New Phase 5 pre-merge gate honors `Depends on #N` / `Blocked by #N` markers in issue bodies. Before merging PR-A, the loop verifies that every dependency referenced from issue A is closed and its associated PR is merged. If any dependency is still open or its PR is unmerged, the auto-pilot pauses with a structured alert (mirroring the critical-issue alert shape) — the user merges the dependency, then re-runs `/auto-pilot` to resume.
-- New iteration outcome label: `blocked_by_dependency`. The PR is left open, the issue stays open, and the loop stops cleanly.
-- New config: `autopilot.respect_dependencies: true` (default on). Set to `false` to skip the gate entirely for repos that don't use the convention.
-- The `Depends on #N` convention is documented in `references/docs/idd-methodology.md` (Issue Dependencies). The marker is plain prose — case-insensitive, list/sentence-shape agnostic, cross-repo references ignored.
-- This is the second documented exception to the autonomy philosophy (alongside critical-issue review failures): merging a PR out of dependency order is effectively irreversible (squash-merge into history), so the loop pauses rather than guessing.
-
-### Changes in 2.2.0 — Conservative-by-default merge modes
-
-- New `autopilot.mode` setting (`conservative` | `balanced` | `aggressive`). Default is **`balanced`**: clean PRs are auto-merged; PRs with unresolved review issues get follow-up issues and stay open.
-- New `autopilot.merge_partial: false` setting. Aggressive partial-merge behavior now requires both `mode: aggressive` AND `merge_partial: true` — the previous "merge anyway with follow-up" path is no longer reachable by accident.
-- Final-report iteration outcomes now use the categorical labels `merged`, `left_open`, `partial_followup`, `failed`, `skipped`.
-- Legacy `autopilot.auto_merge` is honored when `autopilot.mode` is unset, but `mode` is authoritative when both are present. The schema is being consolidated separately in the autopilot/review config schema work — this release ships only the merge-mode behavior change.
-
-### Changes in 2.1.0 — Token optimization
-
-- Review cycles reduced from 10 to **3** — script pre-pass handles lint/format, so fewer LLM cycles needed
-- `/issue-pr-review` now runs a **script pre-pass** (lint, format, test auto-fix) before spawning LLM reviewers — zero token cost for mechanical fixes
-- Code reviewer now classifies issues as `"fix"` or `"note"` — only "fix" issues trigger fix cycles, "note" issues are reported but don't consume tokens
-- **Soft pass condition** — PR passes when zero "fix" issues remain, even with ≤ 2 medium "note" issues
-- Lint/format violations no longer consume LLM review cycles — handled entirely by tooling
-
-### Breaking changes in 2.0.0
-
-- The loop no longer pauses on failure by default — failed issues are skipped and the loop continues (`pause_on_failure` defaults to `false`)
-- `auto_merge: false` no longer halts the loop — PRs that pass review are left open and the loop moves to the next issue
-- All confirmation prompts removed — the loop runs with full autonomy from start to finish
+> Version history lives in `docs/CHANGELOG.md` and `docs/release-notes/`, not in this skill body.
 
 The auto-pilot orchestrates existing gitissue skills into a continuous loop that processes the issue backlog with absolute autonomy. Each iteration: triage the backlog, pick the top-priority issue, resolve it via the full pipeline, review the PR with up to 3 token-optimized fix-review cycles (script pre-pass for lint/format, LLM only for critical issues), and merge according to `autopilot.mode`. Clean PRs merge in `balanced` or `aggressive` mode. PRs with unresolved review issues create a follow-up issue and stay open unless `mode: aggressive` and `merge_partial: true` are both explicitly set. For critical issues, the loop stops and asks the user for a decision instead of auto-continuing. The agent makes all non-critical decisions automatically, always choosing the best available path forward.
 

--- a/skills/auto-pilot/SKILL.md
+++ b/skills/auto-pilot/SKILL.md
@@ -35,7 +35,7 @@ Inspired by the auto-adapt-mode pattern: **always proceed, never block on recove
    - Modifying repository settings or branch protection rules
    - Any action that matches the dangerous patterns list (destructive ops, production deployment, package publishing)
    - **Critical issues with unresolved review problems** — if the issue has a `critical` or `priority:critical` label and the review-fix loop exhausts its cycles without resolving all issues, stop and ask
-   - **PR blocked by an unmerged dependency** — if the originating issue has a `Depends on #N` / `Blocked by #N` marker and any referenced issue is still open (or its PR is unmerged), stop and ask. Merging out of dependency order is effectively irreversible (squash-merge lands on the default branch and rewrites history), so the loop pauses rather than guessing. Disabled by `autopilot.respect_dependencies: false`.
+   - **PR blocked by an unmerged dependency** — if the originating issue has a `Depends on #N` / `Blocked by #N` marker and any referenced issue is still open (or its PR is unmerged), stop and ask. Merging out of dependency order is effectively irreversible (squash-merge lands on the default branch and rewrites history), so the loop pauses rather than guessing. Disabled by `autopilot.respect_dependencies: false`. This is the second documented exception to the autonomy philosophy (alongside critical-issue review failures).
 
 When in doubt, the auto-pilot proceeds with the safer option rather than stopping to ask. A skipped issue can always be retried; a blocked loop wastes time.
 

--- a/skills/init-gitissue/SKILL.md
+++ b/skills/init-gitissue/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: init-gitissue
-description: "Generate a project-specific .gitissue.yml by auto-detecting language, framework, test runner, and repo size. Use when asked to init gitissue, setup gitissue, configure gitissue, first time setup, /init-gitissue, or to set up IDD on a new repo. Don't use for editing an existing .gitissue.yml (edit directly), creating GitHub issues (use /issue-creator), or general git/repo initialization like git init or npm init."
+description: "Generate a project-specific .gitissue.yml by auto-detecting language, framework, test runner, and repo size. Use to init, setup, or configure gitissue, or set up IDD on a new repo. Don't use for editing an existing .gitissue.yml (edit directly), creating GitHub issues (use /issue-creator), or general git/repo initialization like git init or npm init."
 license: MIT
-compatibility: Requires git. No GitHub CLI or authentication needed — generates a local config file only.
+compatibility: "Requires git. No GitHub CLI or authentication needed — generates a local config file only."
 effort: low
 metadata:
-  version: 0.3.3
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 0.3.4
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # /init-gitissue

--- a/skills/issue-analysis/SKILL.md
+++ b/skills/issue-analysis/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: issue-analysis
-description: "Analyze a single GitHub issue for root cause, affected files, implementation options, complexity, and risk; persists to .gitissue/analysis-N.json. Use when asked to analyze issue #N, investigate issue, impact analysis, how hard is #N, or /issue-analysis. Don't use for creating/filing issues (use /issue-creator), bulk triaging (use /issue-triage), or actually resolving the issue (use /issue-resolver)."
+description: "Analyze one GitHub issue for root cause, affected files, options, complexity, and risk; persists to .gitissue/analysis-N.json. Use for analyze issue #N, investigate, impact analysis, or how hard is #N. Don't use for creating/filing issues (use /issue-creator), bulk triaging (use /issue-triage), or actually resolving the issue (use /issue-resolver)."
 license: MIT
-compatibility: Requires git and GitHub CLI (gh) with authentication. View mode (`/issue-analysis N view`) needs only local file access — no gh required.
+compatibility: "Requires git and GitHub CLI (gh) with authentication. View mode (`/issue-analysis N view`) needs only local file access — no gh required."
 effort: high
 metadata:
-  version: 0.4.1
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 0.4.2
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # /issue-analysis N

--- a/skills/issue-creator/SKILL.md
+++ b/skills/issue-creator/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: issue-creator
-description: "Creates structured, intent-focused GitHub issues from text, screenshots, or lists. Preserves reporter context and generates acceptance criteria without guessing implementation details. Use for filing bugs/features, batch creation, or template cleanup. Don't use for resolving, triaging, or deep issue analysis."
+description: "Create structured GitHub issues from text, screenshots, or lists, with acceptance criteria and preserved reporter context. Use for filing bugs/features, batch creation, or template cleanup. Don't use for resolving, triaging, or deep issue analysis."
 license: MIT
-compatibility: Requires git and GitHub CLI (gh) with authentication. Run `gh auth status` to verify.
+compatibility: "Requires git and GitHub CLI (gh) with authentication. Run `gh auth status` to verify."
 effort: medium
 metadata:
-  version: 0.4.1
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 0.5.0
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # /issue-creator
@@ -52,6 +52,29 @@ Before any operation, verify the environment. On failure, output the exact error
 2. Confirm `gh` is installed: `which gh`
 3. Confirm authentication: `gh auth status`
 4. Confirm GitHub remote exists: `git remote -v`
+
+## Repo Sync Before Edits (mandatory)
+
+This skill can write to the repository: in Normalize mode it edits issue bodies, and when images are supplied it commits them to `.github/issue-assets/` via the GitHub contents API. Before any such write, sync with remote using the stash-first pattern (see `references/docs/sync-conventions.md` for the full convention and recovery procedure):
+
+```bash
+branch="$(git rev-parse --abbrev-ref HEAD)"
+dirty=0
+if [ -n "$(git status --porcelain)" ]; then
+  git stash push -u -m "pre-sync: ${branch}"
+  dirty=1
+fi
+git fetch origin
+git pull --rebase origin "$branch"
+if [ "$dirty" -eq 1 ]; then
+  git stash pop || {
+    echo "✗ Stash pop failed — recover with: git stash list && git stash show -p stash@{0}"
+    exit 1
+  }
+fi
+```
+
+If `origin` is missing or rebase conflicts occur, stop and ask the user before continuing. In a pure Create-from-text run with no image upload, this sync is a no-op safeguard and adds negligible cost.
 
 ## Configuration
 
@@ -120,19 +143,7 @@ Check these files relative to the skill's directory (the dirname of this SKILL.m
 - `references/docs/github-projects-sync.md` — GitHub Projects status sync reference
 - `references/modes.md` — Normalize and Batch mode step specs and error paths
 
-### Parallel execution — Batch mode
-
-In batch mode, the duplicate detector and template generation can run in parallel since they are independent:
-
-```
-Batch mode — Step 2 completes (items classified)
-    ├── Spawn duplicate-detector (Step 3)       ─┐
-    └── Pre-generate template content (for S5)   ─┤  parallel
-                                                  │
-    Collect both results ◄────────────────────────┘
-Step 4 (Approval) continues with merged data
-Step 5 (Create Issues) uses pre-generated templates
-```
+In batch mode, the duplicate detector (Step 3) and template pre-generation (for Step 5) run in parallel since they are independent; both results are merged before the Step 4 approval gate.
 
 ---
 

--- a/skills/issue-creator/references/docs/sync-conventions.md
+++ b/skills/issue-creator/references/docs/sync-conventions.md
@@ -1,0 +1,103 @@
+<!-- Generated from /docs/sync-conventions.md. Do not edit. Edit source and run ./scripts/build.sh. -->
+# Sync Conventions
+
+Standard convention for syncing a working branch with the remote before any IDD skill modifies files. Centralizing this here ensures every skill that performs a `git pull --rebase` first protects uncommitted changes — the unsafe pattern (bare rebase on a dirty tree) can silently destroy staged or unstaged work, so it must never appear in skill instructions.
+
+## Why This Matters
+
+`git pull --rebase` rewrites local history. When the working tree has uncommitted changes that overlap with incoming commits, rebase either fails outright or — worse — leaves the tree in a confusing intermediate state where the user's work appears lost. The fix is mechanical: stash before, pop after. This document is the canonical reference; skills should link here rather than copy-pasting the snippet, so the convention can be updated in one place.
+
+---
+
+## Primary Pattern: Stash-First Sync
+
+This is the **only** documented sync path. Every skill that runs `git pull --rebase` MUST follow it.
+
+```bash
+branch="$(git rev-parse --abbrev-ref HEAD)"
+
+# Protect any uncommitted changes (staged + unstaged + untracked).
+# The descriptive message lets the user identify the stash later.
+dirty=0
+if [ -n "$(git status --porcelain)" ]; then
+  git stash push -u -m "pre-sync: ${branch} $(date +%Y-%m-%dT%H:%M:%S)"
+  dirty=1
+fi
+
+# Sync with remote.
+git fetch origin
+git pull --rebase origin "$branch"
+
+# Restore uncommitted changes.
+if [ "$dirty" -eq 1 ]; then
+  git stash pop || {
+    echo "✗ Stash pop failed — your changes are still safe in the stash"
+    echo "  Recovery:"
+    echo "    git stash list                       # find the stash ref (e.g. stash@{0})"
+    echo "    git stash show -p stash@{0}          # preview what's in it"
+    echo "    git checkout stash@{0} -- <path>     # restore individual files"
+    echo "    git stash pop --index stash@{0}      # retry pop after resolving conflicts"
+    exit 1
+  }
+fi
+```
+
+### Behavior Notes
+
+- **`git status --porcelain`** is the canonical dirty-tree check — empty output means clean, any output means dirty (modified, staged, or untracked).
+- **`git stash push -u`** includes untracked files (`-u` = `--include-untracked`). Without `-u`, new files are left exposed and can collide with the rebase.
+- **The stash message** must be descriptive (branch name + timestamp) so the user can identify it via `git stash list`. Generic messages like `"pre-sync"` make recovery harder when multiple stashes accumulate.
+- **`git stash pop`** can fail with merge conflicts. When it does, the stash is preserved on the stash stack — the user's changes are not lost. The recovery output above tells the user exactly how to access them.
+- **Stash ref stability:** newly pushed stashes always become `stash@{0}`. The recovery instructions assume this; if a script creates additional stashes between push and pop, capture the ref returned by `git stash push` instead.
+
+---
+
+## When the Sync Fails
+
+| Failure | Cause | Recovery |
+|---------|-------|----------|
+| `fatal: 'origin' does not appear to be a git repository` | No remote configured | Stop and ask the user to add a remote: `git remote add origin <url>`. In auto mode, abort with a clear error. |
+| `error: Could not apply <commit>` (rebase conflict) | Local commits conflict with incoming | Stop. In interactive mode, ask the user to resolve. In auto mode, run `git rebase --abort` and report. |
+| `error: Your local changes to the following files would be overwritten by merge` | Stash-first was skipped (do not let this reach the user) | Indicates a skill bypassed the convention. Report the skill bug. |
+| `CONFLICT (content): Merge conflict in <file>` (during stash pop) | Rebased commits touch the same lines as the stash | Use the recovery output above. Stash is preserved on the stack. |
+
+---
+
+## Skill-Side Responsibilities
+
+Every IDD skill that performs a sync step MUST:
+
+1. **Use the stash-first block above** — never document a bare `git pull --rebase` as the primary path.
+2. **Link to this document** — write `(see the sync conventions reference)` next to the snippet so users find this reference.
+3. **Document the recovery** — at minimum, instruct on `git stash list` and `git stash show -p stash@{0}` if a pop conflict occurs. Skills are free to inline the full recovery block from this document.
+4. **Honor the mode contract** — in interactive mode, prompt the user before stashing or aborting on conflict. In auto mode (`--auto`), perform the stash-first sync without prompting; abort cleanly with a recovery hint if it fails.
+
+---
+
+## Lint Enforcement
+
+`tests/test-sync-safety.sh` greps `src/skills/**/*.md` and `src/skills/**/references/*.md` for `git pull --rebase` and asserts that each occurrence is preceded (within ~12 lines) by a `git stash` invocation or by a comment that defers to this document. Failing the lint blocks merges. This is the regression guard — without it, future skill edits could silently reintroduce the unsafe form.
+
+---
+
+## Quick Reference (Copy-Paste Snippet)
+
+For skills that want the minimal form inline:
+
+```bash
+# Stash-first sync — see the sync conventions reference for full recovery procedure.
+branch="$(git rev-parse --abbrev-ref HEAD)"
+dirty=0
+if [ -n "$(git status --porcelain)" ]; then
+  git stash push -u -m "pre-sync: ${branch}"
+  dirty=1
+fi
+git fetch origin
+git pull --rebase origin "$branch"
+if [ "$dirty" -eq 1 ]; then
+  git stash pop || {
+    echo "✗ Stash pop failed — recover with: git stash list && git stash show -p stash@{0}"
+    exit 1
+  }
+fi
+```

--- a/skills/issue-pr-review/SKILL.md
+++ b/skills/issue-pr-review/SKILL.md
@@ -2,11 +2,11 @@
 name: issue-pr-review
 description: "Review a PR end-to-end with CI checks, fix cycles, and optional auto-merge. Use for PR review, cleanup, or readiness checks. Don't use for creating PRs, raw issue analysis, or non-PR code review."
 license: MIT
-compatibility: Requires git and GitHub CLI (gh) with authentication. Self-contained — uses shared agents from shared/agents/.
+compatibility: "Requires git and GitHub CLI (gh) with authentication. Self-contained — uses shared agents from shared/agents/."
 effort: high
 metadata:
-  version: 1.0.0
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 2.0.0
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # /issue-pr-review [PR_NUMBER]
@@ -35,31 +35,9 @@ In auto mode, export `IDD_AUTO_MODE=1` before any shell snippet that consults it
 
 ### Bundled dependency precheck
 
-`/issue-pr-review` is distributed as a self-contained skill. It does not require
-another gitissue skill to review a PR, but it does require its bundled reviewer
-agent prompt. Before execution, verify `references/agents/code-reviewer.md` and
-`references/agents/fixer.md` are present in the installed skill directory.
-
-If either agent prompt is missing, stop immediately and print:
+`/issue-pr-review` is distributed as a self-contained skill — it does not require another gitissue skill to review a PR, but it does require its bundled agent prompts and reference files. Before execution, verify the files below are present relative to the skill's directory (the dirname of this SKILL.md). If any is missing, stop immediately and print the error, then do not continue with an inline or guessed reviewer/fixer prompt:
 
 ```text
-✗ Missing bundled dependency: {missing_agent_prompt}
-
-  To fix:  asm install https://github.com/luongnv89/idd --skill issue-pr-review
-  Or:      asm install https://github.com/luongnv89/idd
-           Select: issue-pr-review
-
-  Then restart the agent session and re-run /issue-pr-review.
-```
-
-Do not continue with an inline or guessed reviewer/fixer prompt when a bundled
-agent is missing.
-
-Additionally, verify that this skill's bundled reference files are present.
-If any are missing, stop immediately and print:
-
-```
-text
 ✗ Missing bundled dependency: {missing_file}
 
   To fix:  asm install https://github.com/luongnv89/idd --skill issue-pr-review
@@ -68,10 +46,10 @@ text
   Then restart the agent session and re-run /issue-pr-review.
 ```
 
-Check these files relative to the skill's directory (the dirname of this SKILL.md):
-
-- `references/agents/code-reviewer.md` — Review subagent prompt (already checked above)
+- `references/agents/code-reviewer.md` — Review subagent prompt
 - `references/agents/fixer.md` — Fix subagent prompt
+- `references/verification-checks.md` — AC + traceability check procedure (Step 3)
+- `references/review-loop-mechanics.md` — reviewer/fixer spawn + reuse mechanics
 - `references/report-templates.md` — Step 7 summary templates, auto-merge flow, expected inline output
 - `references/docs/pre-commit-security.md` — pre-commit security conventions reference
 - `references/docs/sync-conventions.md` — stash-first sync convention and recovery
@@ -113,10 +91,12 @@ Load `.gitissue.yml` once. Defaults:
 - `review.ci_timeout: 600` (seconds, 10 minutes)
 - `review.test_timeout: 300` (seconds)
 - `review.soft_pass: true` — pass when zero "fix" issues remain, even if "note" issues exist (≤ 2 medium allowed)
-- `review.require_acceptance_criteria_check: true` — when `false`, skip per-criterion AC verification; report acceptance_criteria as `pass` with a "verification disabled" note (never blocks soft-pass). Default `true` preserves the issue #36 contract.
-- `review.require_traceability_check: true` — when `false`, skip the four traceability checks; report traceability as `pass` with a "verification disabled" note (never blocks soft-pass). Default `true` preserves the issue #36 contract.
-- `review.traceability_exempt_labels: ["refactor", "chore"]` — PR labels that exempt a PR from the `Closes #N` hard-fail (check 1 only; the other three traceability checks still run). Set to `[]` to disable label-based exemption.
-- `review.traceability_exempt_pattern: "^\\s*Type:\\s*(refactor|chore)\\s*$"` — case-insensitive multiline regex; if the PR body contains a matching line, the PR is exempt from the `Closes #N` hard-fail (check 1 only). Set to empty string `""` to disable pattern-based exemption.
+- `review.require_acceptance_criteria_check: true` — gate for per-criterion AC verification
+- `review.require_traceability_check: true` — gate for the four traceability checks
+- `review.traceability_exempt_labels: ["refactor", "chore"]` — labels that exempt a PR from the `Closes #N` hard-fail
+- `review.traceability_exempt_pattern: "^\\s*Type:\\s*(refactor|chore)\\s*$"` — body-line regex exempting a PR from the `Closes #N` hard-fail
+
+The last four flags default to `true`/the values shown, which preserve the issue #36 contract. Their full semantics (what `false` does, exemption scope, disabling) are in `references/verification-checks.md`.
 
 ---
 
@@ -134,17 +114,7 @@ Load `.gitissue.yml` once. Defaults:
   [7/7] Report       ✓ PR is clean — ready to merge
 ```
 
-Step 2 (Pre-pass) runs once before the review loop. Steps 3-6 repeat up to `review.max_cycles` times (default: 3). Step 7 runs once at the end.
-
-### Token optimization strategy
-
-The pipeline is designed to minimize LLM token usage:
-
-1. **Script pre-pass (Step 2)** — Lint, format, and test tools run via shell scripts, not LLM agents. Auto-fixes mechanical issues for free (zero tokens). This handles the bulk of lint/format violations that previously consumed full review cycles.
-2. **Agent reuse (Steps 3-6)** — The same reviewer and fixer agents are reused across fix cycles via `SendMessage`. Only the final confirmation pass spawns a fresh agent. This cuts agent spawn cost from 2 per cycle to ~1.3 average (reuse in cycles 2-3, fresh only for confirmation).
-3. **Severity-based filtering** — The code reviewer classifies each issue with `action: "fix"` or `action: "note"`. Only "fix" issues trigger a fix cycle. "Note" issues are reported but don't consume tokens.
-4. **Soft pass condition** — The review passes when zero "fix" issues remain, even if some medium "note" issues exist. This avoids burning cycles on diminishing-return fixes.
-5. **Reduced cycles (3 max)** — With mechanical issues handled by scripts and only critical issues triggering fixes, 3 LLM cycles are sufficient.
+Step 2 (Pre-pass) runs once before the review loop. Steps 3-6 repeat up to `review.max_cycles` times (default: 3). Step 7 runs once at the end. The pipeline minimizes LLM tokens via a zero-token script pre-pass (Step 2), reviewer/fixer reuse across cycles, severity-based `fix`/`note` filtering (Step 6), and the soft-pass condition (Review Loop).
 
 ---
 
@@ -232,52 +202,20 @@ npm test          # or pytest, go test ./..., cargo test, etc.
 
 ### Commit auto-fixes
 
-If any files were modified by the auto-fix tools, run the pre-commit security
-scan before staging (see the pre-commit security conventions reference at
-`references/docs/pre-commit-security.md` — that document is authoritative; the snippet
-below mirrors its Primary Pattern). Real secrets block; warnings prompt for
-confirmation in interactive mode and log-and-continue in auto mode.
+If any files were modified by the auto-fix tools, you MUST run the pre-commit
+security scan before staging. The authoritative scan is the **Primary Pattern**
+in `references/docs/pre-commit-security.md` — run that exact pattern against the working
+tree; do not improvise a weaker check. In auto mode, export `IDD_AUTO_MODE=1`
+first so the scan logs-and-continues on warnings instead of prompting.
+
+The scan enforces, in order:
+
+1. **Block on real secrets** — secret-bearing filenames (`.env`, `*.key`, `*.pem`, `credentials.json`, `id_rsa`, …) or real API-key patterns (OpenAI, AWS, GitHub, Slack, GitLab, Google) in any staged text file → print the offending file and `exit 1`. Never commit.
+2. **Warn (non-blocking) on** large files (>10 MB without LFS), staged build artifacts (`node_modules`, `dist`, `__pycache__`, `*.pyc`, …), and being on a protected branch (`main`/`master`/`production`/`release`). In interactive mode prompt `Proceed anyway? [y/N]`; in auto mode (`IDD_AUTO_MODE=1`) log and continue.
+
+Only after the scan passes (or warnings are accepted), commit and push:
 
 ```bash
-# Pre-commit security scan — mirrors the Primary Pattern in the
-# pre-commit-security conventions reference. Set IDD_AUTO_MODE=1 in auto mode.
-files="$(git status --porcelain | awk '{print $2}')"
-secrets_found=0
-warnings=()
-if printf '%s\n' "$files" | grep -E -q '(^|/)\.env($|\.)|\.key$|\.pem$|credentials\.json$|secrets\.ya?ml$|id_rsa($|\.pub$)|\.p12$|\.pfx$|\.cer$'; then
-  echo "✗ Secret-bearing file in working tree."
-  secrets_found=1
-fi
-realkey='(sk-(proj-)?[A-Za-z0-9_-]{20,}|sk_live_[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{30,}|gho_[A-Za-z0-9]{30,}|ghs_[A-Za-z0-9]{30,}|ghu_[A-Za-z0-9]{30,}|github_pat_[A-Za-z0-9_]{40,}|xox[abprs]-[A-Za-z0-9-]{10,}|glpat-[A-Za-z0-9_-]{20,}|AIza[0-9A-Za-z_-]{30,})'
-while IFS= read -r f; do
-  [ -z "$f" ] && continue
-  [ -f "$f" ] || continue
-  file --mime "$f" 2>/dev/null | grep -q 'charset=binary' && continue
-  if grep -E -q "$realkey" "$f" 2>/dev/null; then
-    echo "✗ Real API key detected in: $f"
-    secrets_found=1
-  fi
-  size=$(stat -f%z "$f" 2>/dev/null || stat -c%s "$f" 2>/dev/null || echo 0)
-  [ "$size" -gt 10485760 ] && warnings+=("⚠ Large file (>10 MB) without LFS: $f")
-done <<< "$files"
-junk='(^|/)(node_modules|dist|build|__pycache__|\.venv)(/|$)|\.pyc$|(^|/)(\.DS_Store|thumbs\.db)$|\.swp$|\.tmp$'
-while IFS= read -r f; do
-  [ -z "$f" ] && continue
-  printf '%s\n' "$f" | grep -E -q "$junk" && warnings+=("⚠ Build artifact staged: $f")
-done <<< "$files"
-case "$(git rev-parse --abbrev-ref HEAD)" in
-  main|master|production|release) warnings+=("⚠ On protected branch — confirm intentional") ;;
-esac
-[ "$secrets_found" = 1 ] && { echo "✗ Pre-commit security scan blocked. See pre-commit-security conventions reference."; exit 1; }
-if [ "${#warnings[@]}" -gt 0 ]; then
-  printf '%s\n' "${warnings[@]}"
-  if [ "${IDD_AUTO_MODE:-0}" = "1" ]; then
-    echo "○ Warnings logged — proceeding (auto mode)."
-  else
-    printf "Proceed anyway? [y/N] "; read -r reply
-    case "$reply" in y|Y|yes|YES) echo "○ Continuing despite warnings." ;; *) echo "✗ Stopped."; exit 1 ;; esac
-  fi
-fi
 git add -A
 git commit -m "style: auto-fix lint and format issues"
 git push origin {branch_name}
@@ -299,72 +237,18 @@ If tests fail at this stage, continue to the review loop — test failures will 
 
 ## Step 3 — Analyze & Review [3/7]
 
-### Agent reuse strategy
+### Reviewer agents and cycle reuse
 
-To minimize token usage, the review loop **reuses the same reviewer agent** across fix cycles instead of spawning a fresh one each time. The reviewer already has the codebase context loaded, so subsequent reviews are cheaper.
+Read `references/agents/code-reviewer.md` for the reviewer prompt template and `references/agents/fixer.md` for the fix-cycle prompt. Both are spawned with `subagent_type="general-purpose"` (NOT a custom `code-reviewer`/`fixer` type). Pass the reviewer `branch_name`, `base_branch`, `pr_context` (PR title + body), and `diff_command` (`gh pr diff {N}`).
 
-- **Cycle 1:** Spawn a new reviewer agent (cold start — reads diff, files, context)
-- **Cycles 2-3:** Send the reviewer a follow-up message via `SendMessage` asking it to re-review the diff after fixes were applied. The agent retains its context and only needs to re-read the updated diff, not re-discover the entire codebase.
-- **Confirmation pass:** After the fixer reports all issues resolved, spawn a **fresh confirmation reviewer** (separate agent, no memory of prior cycles) for an unbiased final check. This is the only fresh spawn after cycle 1.
+To minimize tokens, the loop **reuses the same reviewer across cycles**: cycle 1 is a cold-start spawn; cycles 2+ re-message that agent via `SendMessage` to re-review the updated diff; after the fixer reports zero fixable issues, one **fresh** confirmation reviewer does an unbiased final check. The full mechanics (exact spawn calls, the SendMessage re-review prompt, and the token-trade rationale) live in `references/review-loop-mechanics.md`.
 
-This trades perfect independence between cycles (which rarely matters in practice — the reviewer was already correct about what the issues were) for significant token savings. The fresh confirmation pass at the end catches anything the reused reviewer might have missed.
-
-### Cycle 1 — Initial review
-
-Read `references/agents/code-reviewer.md` for the full prompt template. Read `references/agents/fixer.md` for the fix-cycle prompt template.
-
-Spawn a new reviewer agent (cold start):
-
-```python
-Agent(
-  description="Review PR #N",
-  prompt=<code-reviewer.md prompt with {variables} replaced>,
-  subagent_type="general-purpose"  # NOT "code-reviewer"
-)
-```
-
-Pass to the reviewer:
-- `branch_name`: PR head branch
-- `base_branch`: PR base branch
-- `pr_context`: PR title and body
-- `diff_command`: `gh pr diff {N}`
-
-### Cycles 2+ — Re-review via SendMessage
-
-Send a message to the existing reviewer agent:
-```
-The fixer applied changes. Re-review the PR diff to check if the issues were resolved and find any new issues.
-
-Run: {diff_command}
-
-Return the same JSON format as before.
-```
-
-### Confirmation pass
-
-After the fix cycle reports zero fixable issues, spawn a **fresh** confirmation reviewer (new agent, no memory of prior cycles):
-
-```python
-Agent(
-  description="Confirmation review for PR #N",
-  prompt=<code-reviewer.md prompt with {variables} replaced>,
-  subagent_type="general-purpose"  # NOT "code-reviewer"
-)
-```
-
-If it finds new fixable issues, they go back to the existing fixer. If it confirms clean, the PR passes.
+Also fetch the linked issue for acceptance-criteria verification: `gh issue view {linked_issue} --json number,title,body,labels`.
 
 ```
 [3/7] Review       ✓ correctness:pass  ac:pass  trace:pass  maint:partial  safety:pass
                      {fixable_count} fixable, {note_count} noted
 ```
-
-Also fetch linked issues for acceptance criteria verification:
-```bash
-gh issue view {linked_issue} --json number,title,body,labels
-```
-
-Parse the `## Acceptance Criteria` section into one entry per checklist item and check each criterion against the PR changes — see *Acceptance-criteria verification (per criterion)* below.
 
 ### Order within Step 3
 
@@ -388,124 +272,18 @@ Step 3 produces a single review verdict organized into **five dimensions**. The 
 
 Each dimension reports `pass`, `partial`, or `fail`. A PR can pass tests and still fail on `traceability` or `acceptance_criteria` — those dimensions are not gated by test results.
 
-### Verification gates
+### Verification gates and the AC + traceability checks
 
-Two `.gitissue.yml` flags decide whether the acceptance-criteria and traceability checks run at all:
+Two of the five dimensions — `acceptance_criteria` and `traceability` — are produced by this skill, not the reviewer subagent. Their full procedure (per-criterion AC verification, the four traceability checks, the refactor/chore exemption, and the reviewer-category → dimension mapping) lives in `references/verification-checks.md`. **Read that file and apply it now**, before aggregating the cycle report.
 
-| Flag | Default | When `true` (default) | When `false` |
-|------|---------|----------------------|--------------|
-| `review.require_acceptance_criteria_check` | `true` | Run per-criterion verification described below; any `fail` blocks soft-pass. | Skip the check entirely. Report `○ acceptance_criteria: pass` with the explicit note `verification disabled (review.require_acceptance_criteria_check: false)`. Never blocks soft-pass; emit no fixable issues for this dimension. |
-| `review.require_traceability_check` | `true` | Run the four traceability checks below; missing `Closes #N` blocks soft-pass. | Skip the check entirely. Report `○ traceability: pass` with the explicit note `verification disabled (review.require_traceability_check: false)`. Never blocks soft-pass; emit no fixable issues for this dimension. |
+The gating rules that the rest of this skill depends on — keep these in mind here and enforce them in the Review Loop below:
 
-Both default to `true`, which preserves the issue #36 contract verbatim. Setting either flag to `false` is an explicit opt-out — the corresponding hard-block conditions in *Loop controls* below no longer apply for that dimension.
+- `review.require_acceptance_criteria_check` (default `true`) gates the AC check; `review.require_traceability_check` (default `true`) gates traceability. When either is `false`, that dimension reports `pass — verification disabled` and never blocks soft-pass.
+- **Any `acceptance_criteria: fail`** (a criterion the PR does not satisfy) → fixable issue in Step 6, `category: acceptance_criteria`. **Hard-blocks** soft-pass.
+- **`Closes #{N}` absent** (traceability check 1, unless the PR is refactor/chore-exempt) → fixable issue in Step 6, `category: traceability`, suggested fix "Add `Closes #{N}` to the PR body." **Hard-blocks** soft-pass.
+- All other traceability outcomes (missing commit ref, missing Decision Record on a human-authored PR, etc.) report `partial` and do **not** block.
 
-A separate, narrower opt-out exists for refactor/chore PRs (see *Refactor/chore exemption* below). It relaxes only check 1 (`Closes #N`) for the matching PR; the other three traceability checks still run.
-
-### Acceptance-criteria verification (per criterion)
-
-> Run only when `review.require_acceptance_criteria_check` is `true`. When `false`, skip this entire subsection and emit `○ acceptance_criteria: pass — verification disabled (review.require_acceptance_criteria_check: false)`.
-
-Fetch the linked issue and parse its `## Acceptance Criteria` section into individual checklist items. For each criterion, evaluate against the PR diff and produce one of three statuses:
-
-| Status | When |
-|--------|------|
-| `pass` | The PR demonstrably satisfies the criterion. Evidence is required: a file path with line range, a test name, or a one-line description of how the change fulfills the criterion. |
-| `fail` | The PR does not satisfy the criterion. Evidence is required: what's missing or what contradicts the criterion. |
-| `unverified` | The criterion cannot be verified from the diff alone (e.g., needs production validation, manual user testing, or behavior outside the change set). Explanation is required. |
-
-Output a structured block:
-
-```
-○ Acceptance Criteria
-  | # | Criterion | Status | Evidence |
-  |---|-----------|--------|----------|
-  | 1 | "{criterion text}" | pass | tests/foo.test.ts: case 'rejects empty' |
-  | 2 | "{criterion text}" | fail | exclusion list still hard-codes /login |
-  | 3 | "{criterion text}" | unverified | needs manual mobile-device test |
-```
-
-If the issue has no acceptance criteria:
-
-```
-○ Acceptance Criteria — none defined; manual review recommended
-```
-
-**Pass/partial/fail rule for the dimension:**
-- All criteria `pass` → ✓ acceptance_criteria: pass
-- Any criterion `fail` → ✗ acceptance_criteria: fail (blocks soft-pass; treat as fixable)
-- No fails, but at least one `unverified` → ⚠ acceptance_criteria: partial (does not block soft-pass; surfaced in report)
-- No criteria defined → ○ acceptance_criteria: pass (with the "manual review recommended" note)
-
-Each `fail` criterion becomes a fixable issue in Step 6 with `category: acceptance_criteria`, `action: fix`, evidence as the description, and the criterion text as the suggested fix target.
-
-### Traceability checks
-
-> Run only when `review.require_traceability_check` is `true`. When `false`, skip this entire subsection and emit `○ traceability: pass — verification disabled (review.require_traceability_check: false)`.
-
-Per the dual-write rule (see *Analysis Artifacts and Durable Memory* in `references/docs/idd-methodology.md`), the durable analysis signal must survive the squash-merge into git history. Run the following four checks against the PR body and the commits in the PR:
-
-1. **Issue link** — PR body contains `Closes #{N}`, `Fixes #{N}`, or `Resolves #{N}` for the linked issue. Detected with the same regex used by GitHub itself: `(?i)(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#\d+`. See *Refactor/chore exemption* below — the `Closes #N` requirement is relaxed for refactor/chore PRs (the other three checks still run).
-2. **Commit references issue** — at least one commit between base and head references the issue number:
-   ```bash
-   git log "{base_branch}..{head_branch}" --grep="#{N}" --oneline
-   ```
-   The reference may live in the subject or body. A reference inside a `Co-authored-by:` trailer does not count.
-3. **Durable analysis fields in PR body** — the PR body contains a `## Decision Record` section with the five stable labels (`Root cause`, `Options considered`, `Options rejected`, `Selected option`, `Residual risk`) and a `## Acceptance Criteria Verification` section (table or the explicit `No acceptance criteria defined` note). The labels are the contract — match them as exact strings, do not rewrite.
-4. **Squash-commit-body assumption** — under squash-merge (the project default per `references/docs/idd-methodology.md`), GitHub copies the PR body verbatim into the commit message. Treat passing check 3 as evidence the squash commit will carry the durable summary; no separate check is needed pre-merge. Note this assumption explicitly in the report so reviewers know what is and is not verified.
-
-**Pass/partial/fail rule for the dimension:**
-
-| Outcome | Conditions | Status |
-|---------|-----------|--------|
-| All four checks pass | Closes #N + commit ref + Decision Record + AC Verification block all present | ✓ traceability: pass |
-| `Closes #{N}` absent on a refactor/chore-exempt PR | check 1 skipped via the *Refactor/chore exemption* below; checks 2-4 still run | ○ traceability: pass — exempt (refactor/chore PR; no Closes #N required), with any check 2-4 partial findings appended |
-| `Closes #{N}` absent | check 1 fails (regardless of other checks) | ✗ traceability: fail (blocking — see below) |
-| Decision Record absent on a human-authored PR | check 3 partially fails: PR was not produced by `/issue-resolver` and has no Decision Record | ⚠ traceability: partial — "PR not produced by `/issue-resolver`; Decision Record absent" |
-| Commit reference absent | check 2 fails but check 1 passes (PR body has Closes #N but no commit references the issue) | ⚠ traceability: partial — "no commit references #{N}" |
-| Acceptance Criteria Verification block absent on a `/issue-resolver` PR | check 3 fails on a PR that does include a Decision Record | ⚠ traceability: partial — "Acceptance Criteria Verification block missing" |
-
-The `Closes #{N}` failure is the only traceability outcome that **blocks** the soft-pass. All other partial outcomes are reported but do not block. This matches issue #36's contract: a PR missing `Closes #N` reports a traceability failure even if tests pass; a human-authored PR without a Decision Record reports `partial`, not `fail`.
-
-When traceability fails on `Closes #{N}`, emit a fixable issue in Step 6 with `category: traceability`, `action: fix`, suggested fix: "Add `Closes #{N}` to the PR body."
-
-### Refactor/chore exemption
-
-Some PRs aren't tied to a single tracked issue — skill quality passes, dependency bumps, doc-only updates. Forcing each one to open a tracking issue purely to satisfy the `Closes #N` gate is workflow ceremony with no information gain. To accommodate this, check 1 (`Closes #N`) is **skipped** when either of the following holds:
-
-1. The PR has any label whose name appears in `review.traceability_exempt_labels` (default: `["refactor", "chore"]`). Match is exact and case-sensitive against GitHub label names.
-2. The PR body contains a line matching `review.traceability_exempt_pattern` (default: `"^\\s*Type:\\s*(refactor|chore)\\s*$"`, case-insensitive, evaluated multiline-anchored against the body). The line may appear anywhere in the body. The default is shown in YAML double-quoted form, so `\\s` is the correct value to copy into `.gitissue.yml`.
-
-The exemption applies **only to check 1**. Checks 2-4 (commit reference, Decision Record, Acceptance Criteria Verification block) still run; their absence is reported as `partial`, never `fail`. Note that check 2 (`git log --grep="#{N}"`) is well-defined only when there is a tracked issue number; an exempt refactor/chore PR with no linked issue has no `#{N}` to grep for, so check 2 is reported as `n/a — no linked issue`, not `partial`. When an exempt PR _does_ have a linked issue (e.g., a refactor scoped under a tracking ticket) but no commit references it, the report is `○ pass — exempt; no commit references #{N} (note)`, not `fail`.
-
-Report wording:
-
-```
-traceability:        ○ pass — exempt (refactor/chore PR; no Closes #N required)
-```
-
-If checks 2-4 produce partial findings on an exempt PR, append them as in the human-authored case:
-
-```
-traceability:        ○ pass — exempt (refactor/chore PR; no Closes #N required);
-                       no commit references #{N}
-```
-
-To **disable** the exemption entirely (restore the strict issue #36 behavior), set `traceability_exempt_labels: []` and `traceability_exempt_pattern: ""` in `.gitissue.yml`.
-
-The exemption check runs before the four traceability checks; if a PR matches, log which mechanism matched (label name or pattern) so reviewers can audit the decision in the report.
-
-### Reviewer call-out for the other three dimensions
-
-Pass the reviewer the issue body alongside the diff (the existing `pr_context` field is fine). The reviewer's JSON output already partitions findings by category — at the end of Step 3, this skill aggregates:
-
-- `correctness` findings → `correctness` dimension
-- `code_quality` + `test_coverage` findings → `maintainability` dimension
-- `security` + `edge_cases` findings → `safety` dimension
-
-Each dimension's status is computed from its findings:
-- Any `action: fix` finding in the dimension → ✗ `fail`
-- Only `action: note` findings → ⚠ `partial`
-- No findings → ✓ `pass`
+These two hard-blocks are the issue #36 contract: a PR can pass tests and still be blocked on `acceptance_criteria: fail` or a missing `Closes #N`.
 
 ---
 
@@ -612,31 +390,7 @@ Exit the loop — PR passes the soft-pass condition.
 
 ### If fixable issues found
 
-Delegate fixes to the fixer subagent (see `references/agents/fixer.md`) instead of applying code changes in the main skill context. Reuse the same fixer agent across cycles when possible.
-
-Spawn or re-message the fixer with:
-- `branch_name`: PR head branch
-- `base_branch`: PR base branch
-- `issue_context`: linked issue details and acceptance criteria, if any
-- `pr_context`: PR number, title, body, and URL
-- `findings_json`: all blocking findings from reviewer, acceptance-criteria checks, traceability checks, tests, and CI
-- `test_output`: trimmed relevant failure output from Steps 4-5
-- `commit_message`: `fix({scope}): address review feedback` (append `(#{linked_issue})` only if a linked issue exists)
-- `security_convention`: `references/docs/pre-commit-security.md` — the bundled pre-commit security scan the fixer MUST run before committing
-
-```python
-Agent(
-  description="Fix PR #N review issues",
-  prompt=<fixer.md prompt with {variables} replaced>,
-  subagent_type="general-purpose"  # NOT "fixer"
-)
-```
-
-The fixer subagent reads affected files, applies targeted changes, stages specific files, runs relevant verification, and — before committing — runs the mandatory pre-commit security scan from `references/docs/pre-commit-security.md` against the staged set (real secrets block the commit). It then commits any changes. The main agent only collects the fixer's JSON result and pushes if changes were committed.
-
-If the fixer cannot resolve all blocking findings, keep the remaining items for the next loop/report.
-
-After the fixer returns with one or more commits, push: `git push origin {branch_name}`
+Delegate fixes to the fixer subagent (`references/agents/fixer.md`) — never apply code changes in the main skill context — and reuse the same fixer across cycles when possible. The fixer reads affected files, applies targeted changes, runs the mandatory pre-commit security scan from `references/docs/pre-commit-security.md` against the staged set (real secrets block the commit), then commits. The main agent collects the fixer's JSON result and pushes any commits (`git push origin {branch_name}`); unresolved blocking findings carry to the next cycle. The exact spawn variables and `Agent(...)` call are in `references/review-loop-mechanics.md`.
 
 ```
 [6/7] Fix          ✓ fixed {N} issues (noted: {note_count} — not fixed)
@@ -678,16 +432,7 @@ Print a structured step-by-step summary showing the review pipeline results. Use
 
 In interactive mode: never auto-merge — just report status.
 
----
-
-## Review-Only Mode
-
-When invoked with `--review-only`:
-
-1. Run Steps 1-5 once (PR info, pre-pass, review, test, CI check)
-2. Skip Step 6 (no fixes)
-3. Report findings in Step 7
-4. Never loop, never fix, never merge
+**Review-only mode (`--review-only`):** run Steps 1-5 once, skip Step 6, report in Step 7 — never loop, fix, or merge.
 
 ---
 
@@ -721,12 +466,13 @@ A clean review prints the 7-step tracker and a summary — see the *Expected Inl
 - **CI still running** — waits up to `review.ci_timeout`, then prints the current state and stops without merging.
 - **Critical issue unresolvable after 3 cycles** — stops, prints remaining issues, does not merge, asks the user to take over.
 - **Merge conflict with base** — prints the exact rebase command and stops.
-- **Review-only mode (`--review-only`)** — never fixes or merges, always reports.
 
 ## Additional Resources
 
 - **`references/agents/code-reviewer.md`** — Review subagent prompt
 - **`references/agents/fixer.md`** — Fix subagent prompt
+- **`references/verification-checks.md`** — AC + traceability check procedure (Step 3)
+- **`references/review-loop-mechanics.md`** — reviewer/fixer spawn + reuse mechanics
 - **`references/report-templates.md`** — Step 7 summary templates, auto-merge flow, expected inline output
 - **`references/error-messages.md`** — Error catalog
 - **`references/docs/naming-conventions.md`** — Naming conventions

--- a/skills/issue-pr-review/references/review-loop-mechanics.md
+++ b/skills/issue-pr-review/references/review-loop-mechanics.md
@@ -1,0 +1,82 @@
+# Review Loop Mechanics — Agent Reuse
+
+Exact spawn calls and the token-trade rationale for the reviewer/fixer agents used in Step 3 and the Review Loop of `/issue-pr-review`. SKILL.md keeps the summary (cold start → SendMessage re-review → fresh confirmation); this file holds the detail.
+
+## Why reuse the reviewer
+
+To minimize token usage, the review loop **reuses the same reviewer agent** across fix cycles instead of spawning a fresh one each time. The reviewer already has the codebase context loaded, so subsequent reviews are cheaper.
+
+- **Cycle 1:** Spawn a new reviewer agent (cold start — reads diff, files, context).
+- **Cycles 2-3:** Send the reviewer a follow-up message via `SendMessage` asking it to re-review the diff after fixes were applied. The agent retains its context and only needs to re-read the updated diff, not re-discover the entire codebase.
+- **Confirmation pass:** After the fixer reports all issues resolved, spawn a **fresh confirmation reviewer** (separate agent, no memory of prior cycles) for an unbiased final check. This is the only fresh spawn after cycle 1.
+
+This trades perfect independence between cycles (which rarely matters in practice — the reviewer was already correct about what the issues were) for significant token savings. The fresh confirmation pass at the end catches anything the reused reviewer might have missed.
+
+## Cycle 1 — Initial review
+
+Read `references/agents/code-reviewer.md` for the full prompt template. Read `references/agents/fixer.md` for the fix-cycle prompt template.
+
+Spawn a new reviewer agent (cold start):
+
+```python
+Agent(
+  description="Review PR #N",
+  prompt=<code-reviewer.md prompt with {variables} replaced>,
+  subagent_type="general-purpose"  # NOT "code-reviewer"
+)
+```
+
+Pass to the reviewer:
+- `branch_name`: PR head branch
+- `base_branch`: PR base branch
+- `pr_context`: PR title and body
+- `diff_command`: `gh pr diff {N}`
+
+## Cycles 2+ — Re-review via SendMessage
+
+Send a message to the existing reviewer agent:
+
+```
+The fixer applied changes. Re-review the PR diff to check if the issues were resolved and find any new issues.
+
+Run: {diff_command}
+
+Return the same JSON format as before.
+```
+
+## Confirmation pass
+
+After the fix cycle reports zero fixable issues, spawn a **fresh** confirmation reviewer (new agent, no memory of prior cycles):
+
+```python
+Agent(
+  description="Confirmation review for PR #N",
+  prompt=<code-reviewer.md prompt with {variables} replaced>,
+  subagent_type="general-purpose"  # NOT "code-reviewer"
+)
+```
+
+If it finds new fixable issues, they go back to the existing fixer. If it confirms clean, the PR passes.
+
+## Fixer spawn (Step 6)
+
+Delegate fixes to the fixer subagent instead of applying code changes in the main skill context. Reuse the same fixer agent across cycles when possible. Spawn or re-message the fixer with:
+
+- `branch_name`: PR head branch
+- `base_branch`: PR base branch
+- `issue_context`: linked issue details and acceptance criteria, if any
+- `pr_context`: PR number, title, body, and URL
+- `findings_json`: all blocking findings from reviewer, acceptance-criteria checks, traceability checks, tests, and CI
+- `test_output`: trimmed relevant failure output from Steps 4-5
+- `commit_message`: `fix({scope}): address review feedback` (append `(#{linked_issue})` only if a linked issue exists)
+- `security_convention`: `references/docs/pre-commit-security.md` — the bundled pre-commit security scan the fixer MUST run before committing
+
+```python
+Agent(
+  description="Fix PR #N review issues",
+  prompt=<fixer.md prompt with {variables} replaced>,
+  subagent_type="general-purpose"  # NOT "fixer"
+)
+```
+
+The fixer subagent reads affected files, applies targeted changes, stages specific files, runs relevant verification, and — before committing — runs the mandatory pre-commit security scan from `references/docs/pre-commit-security.md` against the staged set (real secrets block the commit). It then commits any changes. The main agent only collects the fixer's JSON result and pushes if changes were committed. If the fixer cannot resolve all blocking findings, keep the remaining items for the next loop/report. After the fixer returns with one or more commits, push: `git push origin {branch_name}`.

--- a/skills/issue-pr-review/references/verification-checks.md
+++ b/skills/issue-pr-review/references/verification-checks.md
@@ -1,0 +1,115 @@
+# Verification Checks — Acceptance Criteria & Traceability
+
+Full specification for the two verification dimensions that Step 3 of `/issue-pr-review` adds on top of the reviewer subagent's findings: **acceptance-criteria verification** (per criterion) and **traceability**. SKILL.md keeps the pass/fail and hard-block rules; this file holds the detailed procedure for each check, plus the refactor/chore exemption.
+
+Apply this file during Step 3, after collecting the reviewer subagent's findings and before aggregating the five user-facing dimensions for the cycle report.
+
+## Verification gates
+
+Two `.gitissue.yml` flags decide whether the acceptance-criteria and traceability checks run at all:
+
+| Flag | Default | When `true` (default) | When `false` |
+|------|---------|----------------------|--------------|
+| `review.require_acceptance_criteria_check` | `true` | Run per-criterion verification described below; any `fail` blocks soft-pass. | Skip the check entirely. Report `○ acceptance_criteria: pass` with the explicit note `verification disabled (review.require_acceptance_criteria_check: false)`. Never blocks soft-pass; emit no fixable issues for this dimension. |
+| `review.require_traceability_check` | `true` | Run the four traceability checks below; missing `Closes #N` blocks soft-pass. | Skip the check entirely. Report `○ traceability: pass` with the explicit note `verification disabled (review.require_traceability_check: false)`. Never blocks soft-pass; emit no fixable issues for this dimension. |
+
+Both default to `true`, which preserves the issue #36 contract verbatim. Setting either flag to `false` is an explicit opt-out — the corresponding hard-block conditions in *Loop controls* (see SKILL.md Review Loop) no longer apply for that dimension.
+
+A separate, narrower opt-out exists for refactor/chore PRs (see *Refactor/chore exemption* below). It relaxes only check 1 (`Closes #N`) for the matching PR; the other three traceability checks still run.
+
+## Reviewer-category → dimension mapping
+
+The five user-facing dimensions and the fixed mapping from reviewer categories live in SKILL.md (*Dimensional review output*). The reviewer's JSON output partitions findings by its own categories; this skill aggregates them: `correctness` → `correctness`; `code_quality` + `test_coverage` → `maintainability`; `security` + `edge_cases` → `safety`. The remaining two dimensions (`acceptance_criteria`, `traceability`) are produced by the checks below. Each dimension's status: any `action: fix` finding → ✗ `fail`; only `action: note` findings → ⚠ `partial`; no findings → ✓ `pass`.
+
+## Acceptance-criteria verification (per criterion)
+
+> Run only when `review.require_acceptance_criteria_check` is `true`. When `false`, skip this entire subsection and emit `○ acceptance_criteria: pass — verification disabled (review.require_acceptance_criteria_check: false)`.
+
+Fetch the linked issue and parse its `## Acceptance Criteria` section into individual checklist items. For each criterion, evaluate against the PR diff and produce one of three statuses:
+
+| Status | When |
+|--------|------|
+| `pass` | The PR demonstrably satisfies the criterion. Evidence is required: a file path with line range, a test name, or a one-line description of how the change fulfills the criterion. |
+| `fail` | The PR does not satisfy the criterion. Evidence is required: what's missing or what contradicts the criterion. |
+| `unverified` | The criterion cannot be verified from the diff alone (e.g., needs production validation, manual user testing, or behavior outside the change set). Explanation is required. |
+
+Output a structured block:
+
+```
+○ Acceptance Criteria
+  | # | Criterion | Status | Evidence |
+  |---|-----------|--------|----------|
+  | 1 | "{criterion text}" | pass | tests/foo.test.ts: case 'rejects empty' |
+  | 2 | "{criterion text}" | fail | exclusion list still hard-codes /login |
+  | 3 | "{criterion text}" | unverified | needs manual mobile-device test |
+```
+
+If the issue has no acceptance criteria:
+
+```
+○ Acceptance Criteria — none defined; manual review recommended
+```
+
+**Pass/partial/fail rule for the dimension:**
+- All criteria `pass` → ✓ acceptance_criteria: pass
+- Any criterion `fail` → ✗ acceptance_criteria: fail (blocks soft-pass; treat as fixable)
+- No fails, but at least one `unverified` → ⚠ acceptance_criteria: partial (does not block soft-pass; surfaced in report)
+- No criteria defined → ○ acceptance_criteria: pass (with the "manual review recommended" note)
+
+Each `fail` criterion becomes a fixable issue in Step 6 with `category: acceptance_criteria`, `action: fix`, evidence as the description, and the criterion text as the suggested fix target.
+
+## Traceability checks
+
+> Run only when `review.require_traceability_check` is `true`. When `false`, skip this entire subsection and emit `○ traceability: pass — verification disabled (review.require_traceability_check: false)`.
+
+Per the dual-write rule (see *Analysis Artifacts and Durable Memory* in `references/docs/idd-methodology.md`), the durable analysis signal must survive the squash-merge into git history. Run the following four checks against the PR body and the commits in the PR:
+
+1. **Issue link** — PR body contains `Closes #{N}`, `Fixes #{N}`, or `Resolves #{N}` for the linked issue. Detected with the same regex used by GitHub itself: `(?i)(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#\d+`. See *Refactor/chore exemption* below — the `Closes #N` requirement is relaxed for refactor/chore PRs (the other three checks still run).
+2. **Commit references issue** — at least one commit between base and head references the issue number:
+   ```bash
+   git log "{base_branch}..{head_branch}" --grep="#{N}" --oneline
+   ```
+   The reference may live in the subject or body. A reference inside a `Co-authored-by:` trailer does not count.
+3. **Durable analysis fields in PR body** — the PR body contains a `## Decision Record` section with the five stable labels (`Root cause`, `Options considered`, `Options rejected`, `Selected option`, `Residual risk`) and a `## Acceptance Criteria Verification` section (table or the explicit `No acceptance criteria defined` note). The labels are the contract — match them as exact strings, do not rewrite.
+4. **Squash-commit-body assumption** — under squash-merge (the project default per `references/docs/idd-methodology.md`), GitHub copies the PR body verbatim into the commit message. Treat passing check 3 as evidence the squash commit will carry the durable summary; no separate check is needed pre-merge. Note this assumption explicitly in the report so reviewers know what is and is not verified.
+
+**Pass/partial/fail rule for the dimension:**
+
+| Outcome | Conditions | Status |
+|---------|-----------|--------|
+| All four checks pass | Closes #N + commit ref + Decision Record + AC Verification block all present | ✓ traceability: pass |
+| `Closes #{N}` absent on a refactor/chore-exempt PR | check 1 skipped via the *Refactor/chore exemption* below; checks 2-4 still run | ○ traceability: pass — exempt (refactor/chore PR; no Closes #N required), with any check 2-4 partial findings appended |
+| `Closes #{N}` absent | check 1 fails (regardless of other checks) | ✗ traceability: fail (blocking — see below) |
+| Decision Record absent on a human-authored PR | check 3 partially fails: PR was not produced by `/issue-resolver` and has no Decision Record | ⚠ traceability: partial — "PR not produced by `/issue-resolver`; Decision Record absent" |
+| Commit reference absent | check 2 fails but check 1 passes (PR body has Closes #N but no commit references the issue) | ⚠ traceability: partial — "no commit references #{N}" |
+| Acceptance Criteria Verification block absent on a `/issue-resolver` PR | check 3 fails on a PR that does include a Decision Record | ⚠ traceability: partial — "Acceptance Criteria Verification block missing" |
+
+The `Closes #{N}` failure is the only traceability outcome that **blocks** the soft-pass. All other partial outcomes are reported but do not block. This matches issue #36's contract: a PR missing `Closes #N` reports a traceability failure even if tests pass; a human-authored PR without a Decision Record reports `partial`, not `fail`.
+
+When traceability fails on `Closes #{N}`, emit a fixable issue in Step 6 with `category: traceability`, `action: fix`, suggested fix: "Add `Closes #{N}` to the PR body."
+
+## Refactor/chore exemption
+
+Some PRs aren't tied to a single tracked issue — skill quality passes, dependency bumps, doc-only updates. Forcing each one to open a tracking issue purely to satisfy the `Closes #N` gate is workflow ceremony with no information gain. To accommodate this, check 1 (`Closes #N`) is **skipped** when either of the following holds:
+
+1. The PR has any label whose name appears in `review.traceability_exempt_labels` (default: `["refactor", "chore"]`). Match is exact and case-sensitive against GitHub label names.
+2. The PR body contains a line matching `review.traceability_exempt_pattern` (default: `"^\\s*Type:\\s*(refactor|chore)\\s*$"`, case-insensitive, evaluated multiline-anchored against the body). The line may appear anywhere in the body. The default is shown in YAML double-quoted form, so `\\s` is the correct value to copy into `.gitissue.yml`.
+
+The exemption applies **only to check 1**. Checks 2-4 (commit reference, Decision Record, Acceptance Criteria Verification block) still run; their absence is reported as `partial`, never `fail`. Note that check 2 (`git log --grep="#{N}"`) is well-defined only when there is a tracked issue number; an exempt refactor/chore PR with no linked issue has no `#{N}` to grep for, so check 2 is reported as `n/a — no linked issue`, not `partial`. When an exempt PR _does_ have a linked issue (e.g., a refactor scoped under a tracking ticket) but no commit references it, the report is `○ pass — exempt; no commit references #{N} (note)`, not `fail`.
+
+Report wording:
+
+```
+traceability:        ○ pass — exempt (refactor/chore PR; no Closes #N required)
+```
+
+If checks 2-4 produce partial findings on an exempt PR, append them as in the human-authored case:
+
+```
+traceability:        ○ pass — exempt (refactor/chore PR; no Closes #N required);
+                       no commit references #{N}
+```
+
+To **disable** the exemption entirely (restore the strict issue #36 behavior), set `traceability_exempt_labels: []` and `traceability_exempt_pattern: ""` in `.gitissue.yml`.
+
+The exemption check runs before the four traceability checks; if a PR matches, log which mechanism matched (label name or pattern) so reviewers can audit the decision in the report.

--- a/skills/issue-resolver/SKILL.md
+++ b/skills/issue-resolver/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: issue-resolver
-description: "Create an atomic PR that closes a GitHub issue end-to-end via a 6-step pipeline. Use when asked to resolve issue #N, fix #N, implement #N, work on #N, take issue #N, or /issue-resolver. Don't use for analyzing an issue without implementing (use /issue-analysis), reviewing an existing PR (use /issue-pr-review), or bulk backlog processing (use /auto-pilot)."
+description: "Create an atomic PR that closes a GitHub issue end-to-end via a 6-step pipeline. Use for resolve, fix, implement, work on, or take issue #N. Don't use for analyzing an issue without implementing (use /issue-analysis), reviewing an existing PR (use /issue-pr-review), or bulk backlog processing (use /auto-pilot)."
 license: MIT
-compatibility: Requires git and GitHub CLI (gh) with authentication and push access. Self-contained — uses shared agents from shared/agents/.
+compatibility: "Requires git and GitHub CLI (gh) with authentication and push access. Self-contained — uses shared agents from shared/agents/."
 effort: max
 metadata:
-  version: 0.7.2
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 0.8.0
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # /issue-resolver N
@@ -363,55 +363,14 @@ If the changes affect documented behavior:
 
 ### Push branch
 
-Before pushing, run the pre-commit security scan against every file touched by
-commits on this branch. The implementer ran the scan per commit during Step 3,
-but a final pre-push pass catches secrets that may have slipped in during QA
-fixes (see the pre-commit security conventions reference at
-`references/docs/pre-commit-security.md` — that document is authoritative; the snippet
-below mirrors its Primary Pattern). Real secrets block the push; warnings
-prompt for confirmation in interactive mode and log-and-continue in auto mode.
+The implementer ran the security scan per commit during Step 3, but before pushing you MUST run a final pre-push pass over the whole branch diff (`git diff --name-only "origin/${base}"...HEAD`) — it catches secrets that may have slipped in during QA fixes. Run the **Primary Pattern** in `references/docs/pre-commit-security.md` (authoritative; do not improvise a weaker check); export `IDD_AUTO_MODE=1` first in auto mode. It enforces, in order:
+
+1. **Block on real secrets** — secret-bearing filenames (`.env`, `*.key`, `*.pem`, `credentials.json`, `id_rsa`, …) or real API-key patterns (OpenAI, AWS, GitHub, Slack, GitLab, Google) in any text file in the diff → print the offending file and `exit 1`. Never push.
+2. **Warn (non-blocking) on** large files (>10 MB without LFS), build artifacts in the diff (`node_modules`, `dist`, `__pycache__`, `*.pyc`, …), and being on a protected branch. Interactive: prompt `Proceed anyway? [y/N]`; auto (`IDD_AUTO_MODE=1`): log and continue.
+
+Only after the scan passes (or warnings are accepted):
 
 ```bash
-# Pre-push security scan — mirrors the Primary Pattern in the
-# pre-commit-security conventions reference. Set IDD_AUTO_MODE=1 in auto mode.
-base="$(gh pr view --json baseRefName --jq .baseRefName 2>/dev/null || echo main)"
-files="$(git diff --name-only "origin/${base}"...HEAD)"
-secrets_found=0
-warnings=()
-if printf '%s\n' "$files" | grep -E -q '(^|/)\.env($|\.)|\.key$|\.pem$|credentials\.json$|secrets\.ya?ml$|id_rsa($|\.pub$)|\.p12$|\.pfx$|\.cer$'; then
-  echo "✗ Secret-bearing file in branch diff."
-  secrets_found=1
-fi
-realkey='(sk-(proj-)?[A-Za-z0-9_-]{20,}|sk_live_[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{30,}|gho_[A-Za-z0-9]{30,}|ghs_[A-Za-z0-9]{30,}|ghu_[A-Za-z0-9]{30,}|github_pat_[A-Za-z0-9_]{40,}|xox[abprs]-[A-Za-z0-9-]{10,}|glpat-[A-Za-z0-9_-]{20,}|AIza[0-9A-Za-z_-]{30,})'
-while IFS= read -r f; do
-  [ -z "$f" ] && continue
-  [ -f "$f" ] || continue
-  file --mime "$f" 2>/dev/null | grep -q 'charset=binary' && continue
-  if grep -E -q "$realkey" "$f" 2>/dev/null; then
-    echo "✗ Real API key detected in: $f"
-    secrets_found=1
-  fi
-  size=$(stat -f%z "$f" 2>/dev/null || stat -c%s "$f" 2>/dev/null || echo 0)
-  [ "$size" -gt 10485760 ] && warnings+=("⚠ Large file (>10 MB) without LFS: $f")
-done <<< "$files"
-junk='(^|/)(node_modules|dist|build|__pycache__|\.venv)(/|$)|\.pyc$|(^|/)(\.DS_Store|thumbs\.db)$|\.swp$|\.tmp$'
-while IFS= read -r f; do
-  [ -z "$f" ] && continue
-  printf '%s\n' "$f" | grep -E -q "$junk" && warnings+=("⚠ Build artifact in diff: $f")
-done <<< "$files"
-case "$(git rev-parse --abbrev-ref HEAD)" in
-  main|master|production|release) warnings+=("⚠ On protected branch — confirm intentional") ;;
-esac
-[ "$secrets_found" = 1 ] && { echo "✗ Pre-push security scan blocked. See pre-commit-security conventions reference."; exit 1; }
-if [ "${#warnings[@]}" -gt 0 ]; then
-  printf '%s\n' "${warnings[@]}"
-  if [ "${IDD_AUTO_MODE:-0}" = "1" ]; then
-    echo "○ Warnings logged — proceeding (auto mode)."
-  else
-    printf "Proceed anyway? [y/N] "; read -r reply
-    case "$reply" in y|Y|yes|YES) echo "○ Continuing despite warnings." ;; *) echo "✗ Stopped."; exit 1 ;; esac
-  fi
-fi
 git push -u origin {branch_name}
 ```
 

--- a/skills/issue-triage/SKILL.md
+++ b/skills/issue-triage/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: issue-triage
-description: "Analyze and triage open GitHub issues for dependencies, priorities, parallelizable work, staleness, and already-fixed detection, caching results to .gitissue/triage.json. Use when asked to triage issues, prioritize issues, what should I work on next, or /issue-triage. Don't use for analyzing one specific issue (use /issue-analysis), resolving an issue (use /issue-resolver), or creating new issues (use /issue-creator)."
+description: "Triage open GitHub issues for dependencies, priorities, parallelizable work, staleness, and already-fixed detection; caches to .gitissue/triage.json. Use for triage or prioritize issues, or what to work on next. Don't use for analyzing one specific issue (use /issue-analysis), resolving an issue (use /issue-resolver), or creating new issues (use /issue-creator)."
 license: MIT
-compatibility: Requires git and GitHub CLI (gh) with authentication. Default mode (cached view) needs only local file access — no gh required.
+compatibility: "Requires git and GitHub CLI (gh) with authentication. Default mode (cached view) needs only local file access — no gh required."
 effort: medium
 metadata:
-  version: 0.5.2
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 0.5.3
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # /issue-triage

--- a/src/skills/auto-pilot/SKILL.source.md
+++ b/src/skills/auto-pilot/SKILL.source.md
@@ -1,46 +1,19 @@
 ---
 name: auto-pilot
-description: "Run a fully autonomous triage-resolve-review-merge loop over the GitHub issue backlog with zero user prompts. Use when asked to auto-pilot, autopilot, resolve everything, work through the backlog, run the loop, or keep going until done. Don't use for single-issue work (use /issue-resolver), one-shot triage (use /issue-triage), or interactive PR review (use /issue-pr-review)."
+description: "Autonomous triage-resolve-review-merge loop over the GitHub issue backlog with zero prompts. Use when asked to auto-pilot, resolve everything, work through the backlog, or keep going until done. Don't use for single-issue work (use /issue-resolver), one-shot triage (use /issue-triage), or interactive PR review (use /issue-pr-review)."
 license: MIT
 compatibility: "Requires git and GitHub CLI (gh) with auth and push access. Requires merge permission for auto-merge. Requires issue-triage, issue-resolver, issue-analysis, and issue-pr-review to be installed from the same distribution. Optional: issue-creator for normalizing unstructured issues mid-loop."
 effort: max
 metadata:
-  version: 2.3.1
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 2.3.2
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # /auto-pilot
 
 Fully autonomous development loop: triage, pick, resolve, review, fix, merge, repeat — zero user prompts.
 
-### Changes in 2.3.0 — Dependency-aware merge gating
-
-- New Phase 5 pre-merge gate honors `Depends on #N` / `Blocked by #N` markers in issue bodies. Before merging PR-A, the loop verifies that every dependency referenced from issue A is closed and its associated PR is merged. If any dependency is still open or its PR is unmerged, the auto-pilot pauses with a structured alert (mirroring the critical-issue alert shape) — the user merges the dependency, then re-runs `/auto-pilot` to resume.
-- New iteration outcome label: `blocked_by_dependency`. The PR is left open, the issue stays open, and the loop stops cleanly.
-- New config: `autopilot.respect_dependencies: true` (default on). Set to `false` to skip the gate entirely for repos that don't use the convention.
-- The `Depends on #N` convention is documented in `docs/idd-methodology.md` (Issue Dependencies). The marker is plain prose — case-insensitive, list/sentence-shape agnostic, cross-repo references ignored.
-- This is the second documented exception to the autonomy philosophy (alongside critical-issue review failures): merging a PR out of dependency order is effectively irreversible (squash-merge into history), so the loop pauses rather than guessing.
-
-### Changes in 2.2.0 — Conservative-by-default merge modes
-
-- New `autopilot.mode` setting (`conservative` | `balanced` | `aggressive`). Default is **`balanced`**: clean PRs are auto-merged; PRs with unresolved review issues get follow-up issues and stay open.
-- New `autopilot.merge_partial: false` setting. Aggressive partial-merge behavior now requires both `mode: aggressive` AND `merge_partial: true` — the previous "merge anyway with follow-up" path is no longer reachable by accident.
-- Final-report iteration outcomes now use the categorical labels `merged`, `left_open`, `partial_followup`, `failed`, `skipped`.
-- Legacy `autopilot.auto_merge` is honored when `autopilot.mode` is unset, but `mode` is authoritative when both are present. The schema is being consolidated separately in the autopilot/review config schema work — this release ships only the merge-mode behavior change.
-
-### Changes in 2.1.0 — Token optimization
-
-- Review cycles reduced from 10 to **3** — script pre-pass handles lint/format, so fewer LLM cycles needed
-- `/issue-pr-review` now runs a **script pre-pass** (lint, format, test auto-fix) before spawning LLM reviewers — zero token cost for mechanical fixes
-- Code reviewer now classifies issues as `"fix"` or `"note"` — only "fix" issues trigger fix cycles, "note" issues are reported but don't consume tokens
-- **Soft pass condition** — PR passes when zero "fix" issues remain, even with ≤ 2 medium "note" issues
-- Lint/format violations no longer consume LLM review cycles — handled entirely by tooling
-
-### Breaking changes in 2.0.0
-
-- The loop no longer pauses on failure by default — failed issues are skipped and the loop continues (`pause_on_failure` defaults to `false`)
-- `auto_merge: false` no longer halts the loop — PRs that pass review are left open and the loop moves to the next issue
-- All confirmation prompts removed — the loop runs with full autonomy from start to finish
+> Version history lives in `docs/CHANGELOG.md` and `docs/release-notes/`, not in this skill body.
 
 The auto-pilot orchestrates existing gitissue skills into a continuous loop that processes the issue backlog with absolute autonomy. Each iteration: triage the backlog, pick the top-priority issue, resolve it via the full pipeline, review the PR with up to 3 token-optimized fix-review cycles (script pre-pass for lint/format, LLM only for critical issues), and merge according to `autopilot.mode`. Clean PRs merge in `balanced` or `aggressive` mode. PRs with unresolved review issues create a follow-up issue and stay open unless `mode: aggressive` and `merge_partial: true` are both explicitly set. For critical issues, the loop stops and asks the user for a decision instead of auto-continuing. The agent makes all non-critical decisions automatically, always choosing the best available path forward.
 

--- a/src/skills/auto-pilot/SKILL.source.md
+++ b/src/skills/auto-pilot/SKILL.source.md
@@ -35,7 +35,7 @@ Inspired by the auto-adapt-mode pattern: **always proceed, never block on recove
    - Modifying repository settings or branch protection rules
    - Any action that matches the dangerous patterns list (destructive ops, production deployment, package publishing)
    - **Critical issues with unresolved review problems** — if the issue has a `critical` or `priority:critical` label and the review-fix loop exhausts its cycles without resolving all issues, stop and ask
-   - **PR blocked by an unmerged dependency** — if the originating issue has a `Depends on #N` / `Blocked by #N` marker and any referenced issue is still open (or its PR is unmerged), stop and ask. Merging out of dependency order is effectively irreversible (squash-merge lands on the default branch and rewrites history), so the loop pauses rather than guessing. Disabled by `autopilot.respect_dependencies: false`.
+   - **PR blocked by an unmerged dependency** — if the originating issue has a `Depends on #N` / `Blocked by #N` marker and any referenced issue is still open (or its PR is unmerged), stop and ask. Merging out of dependency order is effectively irreversible (squash-merge lands on the default branch and rewrites history), so the loop pauses rather than guessing. Disabled by `autopilot.respect_dependencies: false`. This is the second documented exception to the autonomy philosophy (alongside critical-issue review failures).
 
 When in doubt, the auto-pilot proceeds with the safer option rather than stopping to ask. A skipped issue can always be retried; a blocked loop wastes time.
 

--- a/src/skills/init-gitissue/SKILL.source.md
+++ b/src/skills/init-gitissue/SKILL.source.md
@@ -1,12 +1,12 @@
 ---
 name: init-gitissue
-description: "Generate a project-specific .gitissue.yml by auto-detecting language, framework, test runner, and repo size. Use when asked to init gitissue, setup gitissue, configure gitissue, first time setup, /init-gitissue, or to set up IDD on a new repo. Don't use for editing an existing .gitissue.yml (edit directly), creating GitHub issues (use /issue-creator), or general git/repo initialization like git init or npm init."
+description: "Generate a project-specific .gitissue.yml by auto-detecting language, framework, test runner, and repo size. Use to init, setup, or configure gitissue, or set up IDD on a new repo. Don't use for editing an existing .gitissue.yml (edit directly), creating GitHub issues (use /issue-creator), or general git/repo initialization like git init or npm init."
 license: MIT
-compatibility: Requires git. No GitHub CLI or authentication needed — generates a local config file only.
+compatibility: "Requires git. No GitHub CLI or authentication needed — generates a local config file only."
 effort: low
 metadata:
-  version: 0.3.3
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 0.3.4
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # /init-gitissue

--- a/src/skills/issue-analysis/SKILL.source.md
+++ b/src/skills/issue-analysis/SKILL.source.md
@@ -1,12 +1,12 @@
 ---
 name: issue-analysis
-description: "Analyze a single GitHub issue for root cause, affected files, implementation options, complexity, and risk; persists to .gitissue/analysis-N.json. Use when asked to analyze issue #N, investigate issue, impact analysis, how hard is #N, or /issue-analysis. Don't use for creating/filing issues (use /issue-creator), bulk triaging (use /issue-triage), or actually resolving the issue (use /issue-resolver)."
+description: "Analyze one GitHub issue for root cause, affected files, options, complexity, and risk; persists to .gitissue/analysis-N.json. Use for analyze issue #N, investigate, impact analysis, or how hard is #N. Don't use for creating/filing issues (use /issue-creator), bulk triaging (use /issue-triage), or actually resolving the issue (use /issue-resolver)."
 license: MIT
-compatibility: Requires git and GitHub CLI (gh) with authentication. View mode (`/issue-analysis N view`) needs only local file access — no gh required.
+compatibility: "Requires git and GitHub CLI (gh) with authentication. View mode (`/issue-analysis N view`) needs only local file access — no gh required."
 effort: high
 metadata:
-  version: 0.4.1
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 0.4.2
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # /issue-analysis N

--- a/src/skills/issue-creator/SKILL.source.md
+++ b/src/skills/issue-creator/SKILL.source.md
@@ -1,12 +1,12 @@
 ---
 name: issue-creator
-description: "Creates structured, intent-focused GitHub issues from text, screenshots, or lists. Preserves reporter context and generates acceptance criteria without guessing implementation details. Use for filing bugs/features, batch creation, or template cleanup. Don't use for resolving, triaging, or deep issue analysis."
+description: "Create structured GitHub issues from text, screenshots, or lists, with acceptance criteria and preserved reporter context. Use for filing bugs/features, batch creation, or template cleanup. Don't use for resolving, triaging, or deep issue analysis."
 license: MIT
-compatibility: Requires git and GitHub CLI (gh) with authentication. Run `gh auth status` to verify.
+compatibility: "Requires git and GitHub CLI (gh) with authentication. Run `gh auth status` to verify."
 effort: medium
 metadata:
-  version: 0.4.1
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 0.5.0
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # /issue-creator
@@ -52,6 +52,29 @@ Before any operation, verify the environment. On failure, output the exact error
 2. Confirm `gh` is installed: `which gh`
 3. Confirm authentication: `gh auth status`
 4. Confirm GitHub remote exists: `git remote -v`
+
+## Repo Sync Before Edits (mandatory)
+
+This skill can write to the repository: in Normalize mode it edits issue bodies, and when images are supplied it commits them to `.github/issue-assets/` via the GitHub contents API. Before any such write, sync with remote using the stash-first pattern (see `docs/sync-conventions.md` for the full convention and recovery procedure):
+
+```bash
+branch="$(git rev-parse --abbrev-ref HEAD)"
+dirty=0
+if [ -n "$(git status --porcelain)" ]; then
+  git stash push -u -m "pre-sync: ${branch}"
+  dirty=1
+fi
+git fetch origin
+git pull --rebase origin "$branch"
+if [ "$dirty" -eq 1 ]; then
+  git stash pop || {
+    echo "✗ Stash pop failed — recover with: git stash list && git stash show -p stash@{0}"
+    exit 1
+  }
+fi
+```
+
+If `origin` is missing or rebase conflicts occur, stop and ask the user before continuing. In a pure Create-from-text run with no image upload, this sync is a no-op safeguard and adds negligible cost.
 
 ## Configuration
 
@@ -120,19 +143,7 @@ Check these files relative to the skill's directory (the dirname of this SKILL.m
 - `references/docs/github-projects-sync.md` — GitHub Projects status sync reference
 - `references/modes.md` — Normalize and Batch mode step specs and error paths
 
-### Parallel execution — Batch mode
-
-In batch mode, the duplicate detector and template generation can run in parallel since they are independent:
-
-```
-Batch mode — Step 2 completes (items classified)
-    ├── Spawn duplicate-detector (Step 3)       ─┐
-    └── Pre-generate template content (for S5)   ─┤  parallel
-                                                  │
-    Collect both results ◄────────────────────────┘
-Step 4 (Approval) continues with merged data
-Step 5 (Create Issues) uses pre-generated templates
-```
+In batch mode, the duplicate detector (Step 3) and template pre-generation (for Step 5) run in parallel since they are independent; both results are merged before the Step 4 approval gate.
 
 ---
 

--- a/src/skills/issue-pr-review/SKILL.source.md
+++ b/src/skills/issue-pr-review/SKILL.source.md
@@ -2,11 +2,11 @@
 name: issue-pr-review
 description: "Review a PR end-to-end with CI checks, fix cycles, and optional auto-merge. Use for PR review, cleanup, or readiness checks. Don't use for creating PRs, raw issue analysis, or non-PR code review."
 license: MIT
-compatibility: Requires git and GitHub CLI (gh) with authentication. Self-contained — uses shared agents from shared/agents/.
+compatibility: "Requires git and GitHub CLI (gh) with authentication. Self-contained — uses shared agents from shared/agents/."
 effort: high
 metadata:
-  version: 1.0.0
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 2.0.0
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # /issue-pr-review [PR_NUMBER]
@@ -35,31 +35,9 @@ In auto mode, export `IDD_AUTO_MODE=1` before any shell snippet that consults it
 
 ### Bundled dependency precheck
 
-`/issue-pr-review` is distributed as a self-contained skill. It does not require
-another gitissue skill to review a PR, but it does require its bundled reviewer
-agent prompt. Before execution, verify `references/agents/code-reviewer.md` and
-`references/agents/fixer.md` are present in the installed skill directory.
-
-If either agent prompt is missing, stop immediately and print:
+`/issue-pr-review` is distributed as a self-contained skill — it does not require another gitissue skill to review a PR, but it does require its bundled agent prompts and reference files. Before execution, verify the files below are present relative to the skill's directory (the dirname of this SKILL.md). If any is missing, stop immediately and print the error, then do not continue with an inline or guessed reviewer/fixer prompt:
 
 ```text
-✗ Missing bundled dependency: {missing_agent_prompt}
-
-  To fix:  asm install https://github.com/luongnv89/idd --skill issue-pr-review
-  Or:      asm install https://github.com/luongnv89/idd
-           Select: issue-pr-review
-
-  Then restart the agent session and re-run /issue-pr-review.
-```
-
-Do not continue with an inline or guessed reviewer/fixer prompt when a bundled
-agent is missing.
-
-Additionally, verify that this skill's bundled reference files are present.
-If any are missing, stop immediately and print:
-
-```
-text
 ✗ Missing bundled dependency: {missing_file}
 
   To fix:  asm install https://github.com/luongnv89/idd --skill issue-pr-review
@@ -68,10 +46,10 @@ text
   Then restart the agent session and re-run /issue-pr-review.
 ```
 
-Check these files relative to the skill's directory (the dirname of this SKILL.md):
-
-- `references/agents/code-reviewer.md` — Review subagent prompt (already checked above)
+- `references/agents/code-reviewer.md` — Review subagent prompt
 - `references/agents/fixer.md` — Fix subagent prompt
+- `references/verification-checks.md` — AC + traceability check procedure (Step 3)
+- `references/review-loop-mechanics.md` — reviewer/fixer spawn + reuse mechanics
 - `references/report-templates.md` — Step 7 summary templates, auto-merge flow, expected inline output
 - `references/docs/pre-commit-security.md` — pre-commit security conventions reference
 - `references/docs/sync-conventions.md` — stash-first sync convention and recovery
@@ -113,10 +91,12 @@ Load `.gitissue.yml` once. Defaults:
 - `review.ci_timeout: 600` (seconds, 10 minutes)
 - `review.test_timeout: 300` (seconds)
 - `review.soft_pass: true` — pass when zero "fix" issues remain, even if "note" issues exist (≤ 2 medium allowed)
-- `review.require_acceptance_criteria_check: true` — when `false`, skip per-criterion AC verification; report acceptance_criteria as `pass` with a "verification disabled" note (never blocks soft-pass). Default `true` preserves the issue #36 contract.
-- `review.require_traceability_check: true` — when `false`, skip the four traceability checks; report traceability as `pass` with a "verification disabled" note (never blocks soft-pass). Default `true` preserves the issue #36 contract.
-- `review.traceability_exempt_labels: ["refactor", "chore"]` — PR labels that exempt a PR from the `Closes #N` hard-fail (check 1 only; the other three traceability checks still run). Set to `[]` to disable label-based exemption.
-- `review.traceability_exempt_pattern: "^\\s*Type:\\s*(refactor|chore)\\s*$"` — case-insensitive multiline regex; if the PR body contains a matching line, the PR is exempt from the `Closes #N` hard-fail (check 1 only). Set to empty string `""` to disable pattern-based exemption.
+- `review.require_acceptance_criteria_check: true` — gate for per-criterion AC verification
+- `review.require_traceability_check: true` — gate for the four traceability checks
+- `review.traceability_exempt_labels: ["refactor", "chore"]` — labels that exempt a PR from the `Closes #N` hard-fail
+- `review.traceability_exempt_pattern: "^\\s*Type:\\s*(refactor|chore)\\s*$"` — body-line regex exempting a PR from the `Closes #N` hard-fail
+
+The last four flags default to `true`/the values shown, which preserve the issue #36 contract. Their full semantics (what `false` does, exemption scope, disabling) are in `references/verification-checks.md`.
 
 ---
 
@@ -134,17 +114,7 @@ Load `.gitissue.yml` once. Defaults:
   [7/7] Report       ✓ PR is clean — ready to merge
 ```
 
-Step 2 (Pre-pass) runs once before the review loop. Steps 3-6 repeat up to `review.max_cycles` times (default: 3). Step 7 runs once at the end.
-
-### Token optimization strategy
-
-The pipeline is designed to minimize LLM token usage:
-
-1. **Script pre-pass (Step 2)** — Lint, format, and test tools run via shell scripts, not LLM agents. Auto-fixes mechanical issues for free (zero tokens). This handles the bulk of lint/format violations that previously consumed full review cycles.
-2. **Agent reuse (Steps 3-6)** — The same reviewer and fixer agents are reused across fix cycles via `SendMessage`. Only the final confirmation pass spawns a fresh agent. This cuts agent spawn cost from 2 per cycle to ~1.3 average (reuse in cycles 2-3, fresh only for confirmation).
-3. **Severity-based filtering** — The code reviewer classifies each issue with `action: "fix"` or `action: "note"`. Only "fix" issues trigger a fix cycle. "Note" issues are reported but don't consume tokens.
-4. **Soft pass condition** — The review passes when zero "fix" issues remain, even if some medium "note" issues exist. This avoids burning cycles on diminishing-return fixes.
-5. **Reduced cycles (3 max)** — With mechanical issues handled by scripts and only critical issues triggering fixes, 3 LLM cycles are sufficient.
+Step 2 (Pre-pass) runs once before the review loop. Steps 3-6 repeat up to `review.max_cycles` times (default: 3). Step 7 runs once at the end. The pipeline minimizes LLM tokens via a zero-token script pre-pass (Step 2), reviewer/fixer reuse across cycles, severity-based `fix`/`note` filtering (Step 6), and the soft-pass condition (Review Loop).
 
 ---
 
@@ -232,52 +202,20 @@ npm test          # or pytest, go test ./..., cargo test, etc.
 
 ### Commit auto-fixes
 
-If any files were modified by the auto-fix tools, run the pre-commit security
-scan before staging (see the pre-commit security conventions reference at
-`docs/pre-commit-security.md` — that document is authoritative; the snippet
-below mirrors its Primary Pattern). Real secrets block; warnings prompt for
-confirmation in interactive mode and log-and-continue in auto mode.
+If any files were modified by the auto-fix tools, you MUST run the pre-commit
+security scan before staging. The authoritative scan is the **Primary Pattern**
+in `docs/pre-commit-security.md` — run that exact pattern against the working
+tree; do not improvise a weaker check. In auto mode, export `IDD_AUTO_MODE=1`
+first so the scan logs-and-continues on warnings instead of prompting.
+
+The scan enforces, in order:
+
+1. **Block on real secrets** — secret-bearing filenames (`.env`, `*.key`, `*.pem`, `credentials.json`, `id_rsa`, …) or real API-key patterns (OpenAI, AWS, GitHub, Slack, GitLab, Google) in any staged text file → print the offending file and `exit 1`. Never commit.
+2. **Warn (non-blocking) on** large files (>10 MB without LFS), staged build artifacts (`node_modules`, `dist`, `__pycache__`, `*.pyc`, …), and being on a protected branch (`main`/`master`/`production`/`release`). In interactive mode prompt `Proceed anyway? [y/N]`; in auto mode (`IDD_AUTO_MODE=1`) log and continue.
+
+Only after the scan passes (or warnings are accepted), commit and push:
 
 ```bash
-# Pre-commit security scan — mirrors the Primary Pattern in the
-# pre-commit-security conventions reference. Set IDD_AUTO_MODE=1 in auto mode.
-files="$(git status --porcelain | awk '{print $2}')"
-secrets_found=0
-warnings=()
-if printf '%s\n' "$files" | grep -E -q '(^|/)\.env($|\.)|\.key$|\.pem$|credentials\.json$|secrets\.ya?ml$|id_rsa($|\.pub$)|\.p12$|\.pfx$|\.cer$'; then
-  echo "✗ Secret-bearing file in working tree."
-  secrets_found=1
-fi
-realkey='(sk-(proj-)?[A-Za-z0-9_-]{20,}|sk_live_[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{30,}|gho_[A-Za-z0-9]{30,}|ghs_[A-Za-z0-9]{30,}|ghu_[A-Za-z0-9]{30,}|github_pat_[A-Za-z0-9_]{40,}|xox[abprs]-[A-Za-z0-9-]{10,}|glpat-[A-Za-z0-9_-]{20,}|AIza[0-9A-Za-z_-]{30,})'
-while IFS= read -r f; do
-  [ -z "$f" ] && continue
-  [ -f "$f" ] || continue
-  file --mime "$f" 2>/dev/null | grep -q 'charset=binary' && continue
-  if grep -E -q "$realkey" "$f" 2>/dev/null; then
-    echo "✗ Real API key detected in: $f"
-    secrets_found=1
-  fi
-  size=$(stat -f%z "$f" 2>/dev/null || stat -c%s "$f" 2>/dev/null || echo 0)
-  [ "$size" -gt 10485760 ] && warnings+=("⚠ Large file (>10 MB) without LFS: $f")
-done <<< "$files"
-junk='(^|/)(node_modules|dist|build|__pycache__|\.venv)(/|$)|\.pyc$|(^|/)(\.DS_Store|thumbs\.db)$|\.swp$|\.tmp$'
-while IFS= read -r f; do
-  [ -z "$f" ] && continue
-  printf '%s\n' "$f" | grep -E -q "$junk" && warnings+=("⚠ Build artifact staged: $f")
-done <<< "$files"
-case "$(git rev-parse --abbrev-ref HEAD)" in
-  main|master|production|release) warnings+=("⚠ On protected branch — confirm intentional") ;;
-esac
-[ "$secrets_found" = 1 ] && { echo "✗ Pre-commit security scan blocked. See pre-commit-security conventions reference."; exit 1; }
-if [ "${#warnings[@]}" -gt 0 ]; then
-  printf '%s\n' "${warnings[@]}"
-  if [ "${IDD_AUTO_MODE:-0}" = "1" ]; then
-    echo "○ Warnings logged — proceeding (auto mode)."
-  else
-    printf "Proceed anyway? [y/N] "; read -r reply
-    case "$reply" in y|Y|yes|YES) echo "○ Continuing despite warnings." ;; *) echo "✗ Stopped."; exit 1 ;; esac
-  fi
-fi
 git add -A
 git commit -m "style: auto-fix lint and format issues"
 git push origin {branch_name}
@@ -299,72 +237,18 @@ If tests fail at this stage, continue to the review loop — test failures will 
 
 ## Step 3 — Analyze & Review [3/7]
 
-### Agent reuse strategy
+### Reviewer agents and cycle reuse
 
-To minimize token usage, the review loop **reuses the same reviewer agent** across fix cycles instead of spawning a fresh one each time. The reviewer already has the codebase context loaded, so subsequent reviews are cheaper.
+Read `shared/agents/code-reviewer.md` for the reviewer prompt template and `shared/agents/fixer.md` for the fix-cycle prompt. Both are spawned with `subagent_type="general-purpose"` (NOT a custom `code-reviewer`/`fixer` type). Pass the reviewer `branch_name`, `base_branch`, `pr_context` (PR title + body), and `diff_command` (`gh pr diff {N}`).
 
-- **Cycle 1:** Spawn a new reviewer agent (cold start — reads diff, files, context)
-- **Cycles 2-3:** Send the reviewer a follow-up message via `SendMessage` asking it to re-review the diff after fixes were applied. The agent retains its context and only needs to re-read the updated diff, not re-discover the entire codebase.
-- **Confirmation pass:** After the fixer reports all issues resolved, spawn a **fresh confirmation reviewer** (separate agent, no memory of prior cycles) for an unbiased final check. This is the only fresh spawn after cycle 1.
+To minimize tokens, the loop **reuses the same reviewer across cycles**: cycle 1 is a cold-start spawn; cycles 2+ re-message that agent via `SendMessage` to re-review the updated diff; after the fixer reports zero fixable issues, one **fresh** confirmation reviewer does an unbiased final check. The full mechanics (exact spawn calls, the SendMessage re-review prompt, and the token-trade rationale) live in `references/review-loop-mechanics.md`.
 
-This trades perfect independence between cycles (which rarely matters in practice — the reviewer was already correct about what the issues were) for significant token savings. The fresh confirmation pass at the end catches anything the reused reviewer might have missed.
-
-### Cycle 1 — Initial review
-
-Read `shared/agents/code-reviewer.md` for the full prompt template. Read `shared/agents/fixer.md` for the fix-cycle prompt template.
-
-Spawn a new reviewer agent (cold start):
-
-```python
-Agent(
-  description="Review PR #N",
-  prompt=<code-reviewer.md prompt with {variables} replaced>,
-  subagent_type="general-purpose"  # NOT "code-reviewer"
-)
-```
-
-Pass to the reviewer:
-- `branch_name`: PR head branch
-- `base_branch`: PR base branch
-- `pr_context`: PR title and body
-- `diff_command`: `gh pr diff {N}`
-
-### Cycles 2+ — Re-review via SendMessage
-
-Send a message to the existing reviewer agent:
-```
-The fixer applied changes. Re-review the PR diff to check if the issues were resolved and find any new issues.
-
-Run: {diff_command}
-
-Return the same JSON format as before.
-```
-
-### Confirmation pass
-
-After the fix cycle reports zero fixable issues, spawn a **fresh** confirmation reviewer (new agent, no memory of prior cycles):
-
-```python
-Agent(
-  description="Confirmation review for PR #N",
-  prompt=<code-reviewer.md prompt with {variables} replaced>,
-  subagent_type="general-purpose"  # NOT "code-reviewer"
-)
-```
-
-If it finds new fixable issues, they go back to the existing fixer. If it confirms clean, the PR passes.
+Also fetch the linked issue for acceptance-criteria verification: `gh issue view {linked_issue} --json number,title,body,labels`.
 
 ```
 [3/7] Review       ✓ correctness:pass  ac:pass  trace:pass  maint:partial  safety:pass
                      {fixable_count} fixable, {note_count} noted
 ```
-
-Also fetch linked issues for acceptance criteria verification:
-```bash
-gh issue view {linked_issue} --json number,title,body,labels
-```
-
-Parse the `## Acceptance Criteria` section into one entry per checklist item and check each criterion against the PR changes — see *Acceptance-criteria verification (per criterion)* below.
 
 ### Order within Step 3
 
@@ -388,124 +272,18 @@ Step 3 produces a single review verdict organized into **five dimensions**. The 
 
 Each dimension reports `pass`, `partial`, or `fail`. A PR can pass tests and still fail on `traceability` or `acceptance_criteria` — those dimensions are not gated by test results.
 
-### Verification gates
+### Verification gates and the AC + traceability checks
 
-Two `.gitissue.yml` flags decide whether the acceptance-criteria and traceability checks run at all:
+Two of the five dimensions — `acceptance_criteria` and `traceability` — are produced by this skill, not the reviewer subagent. Their full procedure (per-criterion AC verification, the four traceability checks, the refactor/chore exemption, and the reviewer-category → dimension mapping) lives in `references/verification-checks.md`. **Read that file and apply it now**, before aggregating the cycle report.
 
-| Flag | Default | When `true` (default) | When `false` |
-|------|---------|----------------------|--------------|
-| `review.require_acceptance_criteria_check` | `true` | Run per-criterion verification described below; any `fail` blocks soft-pass. | Skip the check entirely. Report `○ acceptance_criteria: pass` with the explicit note `verification disabled (review.require_acceptance_criteria_check: false)`. Never blocks soft-pass; emit no fixable issues for this dimension. |
-| `review.require_traceability_check` | `true` | Run the four traceability checks below; missing `Closes #N` blocks soft-pass. | Skip the check entirely. Report `○ traceability: pass` with the explicit note `verification disabled (review.require_traceability_check: false)`. Never blocks soft-pass; emit no fixable issues for this dimension. |
+The gating rules that the rest of this skill depends on — keep these in mind here and enforce them in the Review Loop below:
 
-Both default to `true`, which preserves the issue #36 contract verbatim. Setting either flag to `false` is an explicit opt-out — the corresponding hard-block conditions in *Loop controls* below no longer apply for that dimension.
+- `review.require_acceptance_criteria_check` (default `true`) gates the AC check; `review.require_traceability_check` (default `true`) gates traceability. When either is `false`, that dimension reports `pass — verification disabled` and never blocks soft-pass.
+- **Any `acceptance_criteria: fail`** (a criterion the PR does not satisfy) → fixable issue in Step 6, `category: acceptance_criteria`. **Hard-blocks** soft-pass.
+- **`Closes #{N}` absent** (traceability check 1, unless the PR is refactor/chore-exempt) → fixable issue in Step 6, `category: traceability`, suggested fix "Add `Closes #{N}` to the PR body." **Hard-blocks** soft-pass.
+- All other traceability outcomes (missing commit ref, missing Decision Record on a human-authored PR, etc.) report `partial` and do **not** block.
 
-A separate, narrower opt-out exists for refactor/chore PRs (see *Refactor/chore exemption* below). It relaxes only check 1 (`Closes #N`) for the matching PR; the other three traceability checks still run.
-
-### Acceptance-criteria verification (per criterion)
-
-> Run only when `review.require_acceptance_criteria_check` is `true`. When `false`, skip this entire subsection and emit `○ acceptance_criteria: pass — verification disabled (review.require_acceptance_criteria_check: false)`.
-
-Fetch the linked issue and parse its `## Acceptance Criteria` section into individual checklist items. For each criterion, evaluate against the PR diff and produce one of three statuses:
-
-| Status | When |
-|--------|------|
-| `pass` | The PR demonstrably satisfies the criterion. Evidence is required: a file path with line range, a test name, or a one-line description of how the change fulfills the criterion. |
-| `fail` | The PR does not satisfy the criterion. Evidence is required: what's missing or what contradicts the criterion. |
-| `unverified` | The criterion cannot be verified from the diff alone (e.g., needs production validation, manual user testing, or behavior outside the change set). Explanation is required. |
-
-Output a structured block:
-
-```
-○ Acceptance Criteria
-  | # | Criterion | Status | Evidence |
-  |---|-----------|--------|----------|
-  | 1 | "{criterion text}" | pass | tests/foo.test.ts: case 'rejects empty' |
-  | 2 | "{criterion text}" | fail | exclusion list still hard-codes /login |
-  | 3 | "{criterion text}" | unverified | needs manual mobile-device test |
-```
-
-If the issue has no acceptance criteria:
-
-```
-○ Acceptance Criteria — none defined; manual review recommended
-```
-
-**Pass/partial/fail rule for the dimension:**
-- All criteria `pass` → ✓ acceptance_criteria: pass
-- Any criterion `fail` → ✗ acceptance_criteria: fail (blocks soft-pass; treat as fixable)
-- No fails, but at least one `unverified` → ⚠ acceptance_criteria: partial (does not block soft-pass; surfaced in report)
-- No criteria defined → ○ acceptance_criteria: pass (with the "manual review recommended" note)
-
-Each `fail` criterion becomes a fixable issue in Step 6 with `category: acceptance_criteria`, `action: fix`, evidence as the description, and the criterion text as the suggested fix target.
-
-### Traceability checks
-
-> Run only when `review.require_traceability_check` is `true`. When `false`, skip this entire subsection and emit `○ traceability: pass — verification disabled (review.require_traceability_check: false)`.
-
-Per the dual-write rule (see *Analysis Artifacts and Durable Memory* in `docs/idd-methodology.md`), the durable analysis signal must survive the squash-merge into git history. Run the following four checks against the PR body and the commits in the PR:
-
-1. **Issue link** — PR body contains `Closes #{N}`, `Fixes #{N}`, or `Resolves #{N}` for the linked issue. Detected with the same regex used by GitHub itself: `(?i)(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#\d+`. See *Refactor/chore exemption* below — the `Closes #N` requirement is relaxed for refactor/chore PRs (the other three checks still run).
-2. **Commit references issue** — at least one commit between base and head references the issue number:
-   ```bash
-   git log "{base_branch}..{head_branch}" --grep="#{N}" --oneline
-   ```
-   The reference may live in the subject or body. A reference inside a `Co-authored-by:` trailer does not count.
-3. **Durable analysis fields in PR body** — the PR body contains a `## Decision Record` section with the five stable labels (`Root cause`, `Options considered`, `Options rejected`, `Selected option`, `Residual risk`) and a `## Acceptance Criteria Verification` section (table or the explicit `No acceptance criteria defined` note). The labels are the contract — match them as exact strings, do not rewrite.
-4. **Squash-commit-body assumption** — under squash-merge (the project default per `docs/idd-methodology.md`), GitHub copies the PR body verbatim into the commit message. Treat passing check 3 as evidence the squash commit will carry the durable summary; no separate check is needed pre-merge. Note this assumption explicitly in the report so reviewers know what is and is not verified.
-
-**Pass/partial/fail rule for the dimension:**
-
-| Outcome | Conditions | Status |
-|---------|-----------|--------|
-| All four checks pass | Closes #N + commit ref + Decision Record + AC Verification block all present | ✓ traceability: pass |
-| `Closes #{N}` absent on a refactor/chore-exempt PR | check 1 skipped via the *Refactor/chore exemption* below; checks 2-4 still run | ○ traceability: pass — exempt (refactor/chore PR; no Closes #N required), with any check 2-4 partial findings appended |
-| `Closes #{N}` absent | check 1 fails (regardless of other checks) | ✗ traceability: fail (blocking — see below) |
-| Decision Record absent on a human-authored PR | check 3 partially fails: PR was not produced by `/issue-resolver` and has no Decision Record | ⚠ traceability: partial — "PR not produced by `/issue-resolver`; Decision Record absent" |
-| Commit reference absent | check 2 fails but check 1 passes (PR body has Closes #N but no commit references the issue) | ⚠ traceability: partial — "no commit references #{N}" |
-| Acceptance Criteria Verification block absent on a `/issue-resolver` PR | check 3 fails on a PR that does include a Decision Record | ⚠ traceability: partial — "Acceptance Criteria Verification block missing" |
-
-The `Closes #{N}` failure is the only traceability outcome that **blocks** the soft-pass. All other partial outcomes are reported but do not block. This matches issue #36's contract: a PR missing `Closes #N` reports a traceability failure even if tests pass; a human-authored PR without a Decision Record reports `partial`, not `fail`.
-
-When traceability fails on `Closes #{N}`, emit a fixable issue in Step 6 with `category: traceability`, `action: fix`, suggested fix: "Add `Closes #{N}` to the PR body."
-
-### Refactor/chore exemption
-
-Some PRs aren't tied to a single tracked issue — skill quality passes, dependency bumps, doc-only updates. Forcing each one to open a tracking issue purely to satisfy the `Closes #N` gate is workflow ceremony with no information gain. To accommodate this, check 1 (`Closes #N`) is **skipped** when either of the following holds:
-
-1. The PR has any label whose name appears in `review.traceability_exempt_labels` (default: `["refactor", "chore"]`). Match is exact and case-sensitive against GitHub label names.
-2. The PR body contains a line matching `review.traceability_exempt_pattern` (default: `"^\\s*Type:\\s*(refactor|chore)\\s*$"`, case-insensitive, evaluated multiline-anchored against the body). The line may appear anywhere in the body. The default is shown in YAML double-quoted form, so `\\s` is the correct value to copy into `.gitissue.yml`.
-
-The exemption applies **only to check 1**. Checks 2-4 (commit reference, Decision Record, Acceptance Criteria Verification block) still run; their absence is reported as `partial`, never `fail`. Note that check 2 (`git log --grep="#{N}"`) is well-defined only when there is a tracked issue number; an exempt refactor/chore PR with no linked issue has no `#{N}` to grep for, so check 2 is reported as `n/a — no linked issue`, not `partial`. When an exempt PR _does_ have a linked issue (e.g., a refactor scoped under a tracking ticket) but no commit references it, the report is `○ pass — exempt; no commit references #{N} (note)`, not `fail`.
-
-Report wording:
-
-```
-traceability:        ○ pass — exempt (refactor/chore PR; no Closes #N required)
-```
-
-If checks 2-4 produce partial findings on an exempt PR, append them as in the human-authored case:
-
-```
-traceability:        ○ pass — exempt (refactor/chore PR; no Closes #N required);
-                       no commit references #{N}
-```
-
-To **disable** the exemption entirely (restore the strict issue #36 behavior), set `traceability_exempt_labels: []` and `traceability_exempt_pattern: ""` in `.gitissue.yml`.
-
-The exemption check runs before the four traceability checks; if a PR matches, log which mechanism matched (label name or pattern) so reviewers can audit the decision in the report.
-
-### Reviewer call-out for the other three dimensions
-
-Pass the reviewer the issue body alongside the diff (the existing `pr_context` field is fine). The reviewer's JSON output already partitions findings by category — at the end of Step 3, this skill aggregates:
-
-- `correctness` findings → `correctness` dimension
-- `code_quality` + `test_coverage` findings → `maintainability` dimension
-- `security` + `edge_cases` findings → `safety` dimension
-
-Each dimension's status is computed from its findings:
-- Any `action: fix` finding in the dimension → ✗ `fail`
-- Only `action: note` findings → ⚠ `partial`
-- No findings → ✓ `pass`
+These two hard-blocks are the issue #36 contract: a PR can pass tests and still be blocked on `acceptance_criteria: fail` or a missing `Closes #N`.
 
 ---
 
@@ -612,31 +390,7 @@ Exit the loop — PR passes the soft-pass condition.
 
 ### If fixable issues found
 
-Delegate fixes to the fixer subagent (see `shared/agents/fixer.md`) instead of applying code changes in the main skill context. Reuse the same fixer agent across cycles when possible.
-
-Spawn or re-message the fixer with:
-- `branch_name`: PR head branch
-- `base_branch`: PR base branch
-- `issue_context`: linked issue details and acceptance criteria, if any
-- `pr_context`: PR number, title, body, and URL
-- `findings_json`: all blocking findings from reviewer, acceptance-criteria checks, traceability checks, tests, and CI
-- `test_output`: trimmed relevant failure output from Steps 4-5
-- `commit_message`: `fix({scope}): address review feedback` (append `(#{linked_issue})` only if a linked issue exists)
-- `security_convention`: `references/docs/pre-commit-security.md` — the bundled pre-commit security scan the fixer MUST run before committing
-
-```python
-Agent(
-  description="Fix PR #N review issues",
-  prompt=<fixer.md prompt with {variables} replaced>,
-  subagent_type="general-purpose"  # NOT "fixer"
-)
-```
-
-The fixer subagent reads affected files, applies targeted changes, stages specific files, runs relevant verification, and — before committing — runs the mandatory pre-commit security scan from `references/docs/pre-commit-security.md` against the staged set (real secrets block the commit). It then commits any changes. The main agent only collects the fixer's JSON result and pushes if changes were committed.
-
-If the fixer cannot resolve all blocking findings, keep the remaining items for the next loop/report.
-
-After the fixer returns with one or more commits, push: `git push origin {branch_name}`
+Delegate fixes to the fixer subagent (`shared/agents/fixer.md`) — never apply code changes in the main skill context — and reuse the same fixer across cycles when possible. The fixer reads affected files, applies targeted changes, runs the mandatory pre-commit security scan from `references/docs/pre-commit-security.md` against the staged set (real secrets block the commit), then commits. The main agent collects the fixer's JSON result and pushes any commits (`git push origin {branch_name}`); unresolved blocking findings carry to the next cycle. The exact spawn variables and `Agent(...)` call are in `references/review-loop-mechanics.md`.
 
 ```
 [6/7] Fix          ✓ fixed {N} issues (noted: {note_count} — not fixed)
@@ -678,16 +432,7 @@ Print a structured step-by-step summary showing the review pipeline results. Use
 
 In interactive mode: never auto-merge — just report status.
 
----
-
-## Review-Only Mode
-
-When invoked with `--review-only`:
-
-1. Run Steps 1-5 once (PR info, pre-pass, review, test, CI check)
-2. Skip Step 6 (no fixes)
-3. Report findings in Step 7
-4. Never loop, never fix, never merge
+**Review-only mode (`--review-only`):** run Steps 1-5 once, skip Step 6, report in Step 7 — never loop, fix, or merge.
 
 ---
 
@@ -721,12 +466,13 @@ A clean review prints the 7-step tracker and a summary — see the *Expected Inl
 - **CI still running** — waits up to `review.ci_timeout`, then prints the current state and stops without merging.
 - **Critical issue unresolvable after 3 cycles** — stops, prints remaining issues, does not merge, asks the user to take over.
 - **Merge conflict with base** — prints the exact rebase command and stops.
-- **Review-only mode (`--review-only`)** — never fixes or merges, always reports.
 
 ## Additional Resources
 
 - **`shared/agents/code-reviewer.md`** — Review subagent prompt
 - **`shared/agents/fixer.md`** — Fix subagent prompt
+- **`references/verification-checks.md`** — AC + traceability check procedure (Step 3)
+- **`references/review-loop-mechanics.md`** — reviewer/fixer spawn + reuse mechanics
 - **`references/report-templates.md`** — Step 7 summary templates, auto-merge flow, expected inline output
 - **`references/error-messages.md`** — Error catalog
 - **`docs/naming-conventions.md`** — Naming conventions

--- a/src/skills/issue-pr-review/references/review-loop-mechanics.md
+++ b/src/skills/issue-pr-review/references/review-loop-mechanics.md
@@ -1,0 +1,82 @@
+# Review Loop Mechanics — Agent Reuse
+
+Exact spawn calls and the token-trade rationale for the reviewer/fixer agents used in Step 3 and the Review Loop of `/issue-pr-review`. SKILL.md keeps the summary (cold start → SendMessage re-review → fresh confirmation); this file holds the detail.
+
+## Why reuse the reviewer
+
+To minimize token usage, the review loop **reuses the same reviewer agent** across fix cycles instead of spawning a fresh one each time. The reviewer already has the codebase context loaded, so subsequent reviews are cheaper.
+
+- **Cycle 1:** Spawn a new reviewer agent (cold start — reads diff, files, context).
+- **Cycles 2-3:** Send the reviewer a follow-up message via `SendMessage` asking it to re-review the diff after fixes were applied. The agent retains its context and only needs to re-read the updated diff, not re-discover the entire codebase.
+- **Confirmation pass:** After the fixer reports all issues resolved, spawn a **fresh confirmation reviewer** (separate agent, no memory of prior cycles) for an unbiased final check. This is the only fresh spawn after cycle 1.
+
+This trades perfect independence between cycles (which rarely matters in practice — the reviewer was already correct about what the issues were) for significant token savings. The fresh confirmation pass at the end catches anything the reused reviewer might have missed.
+
+## Cycle 1 — Initial review
+
+Read `shared/agents/code-reviewer.md` for the full prompt template. Read `shared/agents/fixer.md` for the fix-cycle prompt template.
+
+Spawn a new reviewer agent (cold start):
+
+```python
+Agent(
+  description="Review PR #N",
+  prompt=<code-reviewer.md prompt with {variables} replaced>,
+  subagent_type="general-purpose"  # NOT "code-reviewer"
+)
+```
+
+Pass to the reviewer:
+- `branch_name`: PR head branch
+- `base_branch`: PR base branch
+- `pr_context`: PR title and body
+- `diff_command`: `gh pr diff {N}`
+
+## Cycles 2+ — Re-review via SendMessage
+
+Send a message to the existing reviewer agent:
+
+```
+The fixer applied changes. Re-review the PR diff to check if the issues were resolved and find any new issues.
+
+Run: {diff_command}
+
+Return the same JSON format as before.
+```
+
+## Confirmation pass
+
+After the fix cycle reports zero fixable issues, spawn a **fresh** confirmation reviewer (new agent, no memory of prior cycles):
+
+```python
+Agent(
+  description="Confirmation review for PR #N",
+  prompt=<code-reviewer.md prompt with {variables} replaced>,
+  subagent_type="general-purpose"  # NOT "code-reviewer"
+)
+```
+
+If it finds new fixable issues, they go back to the existing fixer. If it confirms clean, the PR passes.
+
+## Fixer spawn (Step 6)
+
+Delegate fixes to the fixer subagent instead of applying code changes in the main skill context. Reuse the same fixer agent across cycles when possible. Spawn or re-message the fixer with:
+
+- `branch_name`: PR head branch
+- `base_branch`: PR base branch
+- `issue_context`: linked issue details and acceptance criteria, if any
+- `pr_context`: PR number, title, body, and URL
+- `findings_json`: all blocking findings from reviewer, acceptance-criteria checks, traceability checks, tests, and CI
+- `test_output`: trimmed relevant failure output from Steps 4-5
+- `commit_message`: `fix({scope}): address review feedback` (append `(#{linked_issue})` only if a linked issue exists)
+- `security_convention`: `references/docs/pre-commit-security.md` — the bundled pre-commit security scan the fixer MUST run before committing
+
+```python
+Agent(
+  description="Fix PR #N review issues",
+  prompt=<fixer.md prompt with {variables} replaced>,
+  subagent_type="general-purpose"  # NOT "fixer"
+)
+```
+
+The fixer subagent reads affected files, applies targeted changes, stages specific files, runs relevant verification, and — before committing — runs the mandatory pre-commit security scan from `references/docs/pre-commit-security.md` against the staged set (real secrets block the commit). It then commits any changes. The main agent only collects the fixer's JSON result and pushes if changes were committed. If the fixer cannot resolve all blocking findings, keep the remaining items for the next loop/report. After the fixer returns with one or more commits, push: `git push origin {branch_name}`.

--- a/src/skills/issue-pr-review/references/verification-checks.md
+++ b/src/skills/issue-pr-review/references/verification-checks.md
@@ -1,0 +1,115 @@
+# Verification Checks — Acceptance Criteria & Traceability
+
+Full specification for the two verification dimensions that Step 3 of `/issue-pr-review` adds on top of the reviewer subagent's findings: **acceptance-criteria verification** (per criterion) and **traceability**. SKILL.md keeps the pass/fail and hard-block rules; this file holds the detailed procedure for each check, plus the refactor/chore exemption.
+
+Apply this file during Step 3, after collecting the reviewer subagent's findings and before aggregating the five user-facing dimensions for the cycle report.
+
+## Verification gates
+
+Two `.gitissue.yml` flags decide whether the acceptance-criteria and traceability checks run at all:
+
+| Flag | Default | When `true` (default) | When `false` |
+|------|---------|----------------------|--------------|
+| `review.require_acceptance_criteria_check` | `true` | Run per-criterion verification described below; any `fail` blocks soft-pass. | Skip the check entirely. Report `○ acceptance_criteria: pass` with the explicit note `verification disabled (review.require_acceptance_criteria_check: false)`. Never blocks soft-pass; emit no fixable issues for this dimension. |
+| `review.require_traceability_check` | `true` | Run the four traceability checks below; missing `Closes #N` blocks soft-pass. | Skip the check entirely. Report `○ traceability: pass` with the explicit note `verification disabled (review.require_traceability_check: false)`. Never blocks soft-pass; emit no fixable issues for this dimension. |
+
+Both default to `true`, which preserves the issue #36 contract verbatim. Setting either flag to `false` is an explicit opt-out — the corresponding hard-block conditions in *Loop controls* (see SKILL.md Review Loop) no longer apply for that dimension.
+
+A separate, narrower opt-out exists for refactor/chore PRs (see *Refactor/chore exemption* below). It relaxes only check 1 (`Closes #N`) for the matching PR; the other three traceability checks still run.
+
+## Reviewer-category → dimension mapping
+
+The five user-facing dimensions and the fixed mapping from reviewer categories live in SKILL.md (*Dimensional review output*). The reviewer's JSON output partitions findings by its own categories; this skill aggregates them: `correctness` → `correctness`; `code_quality` + `test_coverage` → `maintainability`; `security` + `edge_cases` → `safety`. The remaining two dimensions (`acceptance_criteria`, `traceability`) are produced by the checks below. Each dimension's status: any `action: fix` finding → ✗ `fail`; only `action: note` findings → ⚠ `partial`; no findings → ✓ `pass`.
+
+## Acceptance-criteria verification (per criterion)
+
+> Run only when `review.require_acceptance_criteria_check` is `true`. When `false`, skip this entire subsection and emit `○ acceptance_criteria: pass — verification disabled (review.require_acceptance_criteria_check: false)`.
+
+Fetch the linked issue and parse its `## Acceptance Criteria` section into individual checklist items. For each criterion, evaluate against the PR diff and produce one of three statuses:
+
+| Status | When |
+|--------|------|
+| `pass` | The PR demonstrably satisfies the criterion. Evidence is required: a file path with line range, a test name, or a one-line description of how the change fulfills the criterion. |
+| `fail` | The PR does not satisfy the criterion. Evidence is required: what's missing or what contradicts the criterion. |
+| `unverified` | The criterion cannot be verified from the diff alone (e.g., needs production validation, manual user testing, or behavior outside the change set). Explanation is required. |
+
+Output a structured block:
+
+```
+○ Acceptance Criteria
+  | # | Criterion | Status | Evidence |
+  |---|-----------|--------|----------|
+  | 1 | "{criterion text}" | pass | tests/foo.test.ts: case 'rejects empty' |
+  | 2 | "{criterion text}" | fail | exclusion list still hard-codes /login |
+  | 3 | "{criterion text}" | unverified | needs manual mobile-device test |
+```
+
+If the issue has no acceptance criteria:
+
+```
+○ Acceptance Criteria — none defined; manual review recommended
+```
+
+**Pass/partial/fail rule for the dimension:**
+- All criteria `pass` → ✓ acceptance_criteria: pass
+- Any criterion `fail` → ✗ acceptance_criteria: fail (blocks soft-pass; treat as fixable)
+- No fails, but at least one `unverified` → ⚠ acceptance_criteria: partial (does not block soft-pass; surfaced in report)
+- No criteria defined → ○ acceptance_criteria: pass (with the "manual review recommended" note)
+
+Each `fail` criterion becomes a fixable issue in Step 6 with `category: acceptance_criteria`, `action: fix`, evidence as the description, and the criterion text as the suggested fix target.
+
+## Traceability checks
+
+> Run only when `review.require_traceability_check` is `true`. When `false`, skip this entire subsection and emit `○ traceability: pass — verification disabled (review.require_traceability_check: false)`.
+
+Per the dual-write rule (see *Analysis Artifacts and Durable Memory* in `docs/idd-methodology.md`), the durable analysis signal must survive the squash-merge into git history. Run the following four checks against the PR body and the commits in the PR:
+
+1. **Issue link** — PR body contains `Closes #{N}`, `Fixes #{N}`, or `Resolves #{N}` for the linked issue. Detected with the same regex used by GitHub itself: `(?i)(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#\d+`. See *Refactor/chore exemption* below — the `Closes #N` requirement is relaxed for refactor/chore PRs (the other three checks still run).
+2. **Commit references issue** — at least one commit between base and head references the issue number:
+   ```bash
+   git log "{base_branch}..{head_branch}" --grep="#{N}" --oneline
+   ```
+   The reference may live in the subject or body. A reference inside a `Co-authored-by:` trailer does not count.
+3. **Durable analysis fields in PR body** — the PR body contains a `## Decision Record` section with the five stable labels (`Root cause`, `Options considered`, `Options rejected`, `Selected option`, `Residual risk`) and a `## Acceptance Criteria Verification` section (table or the explicit `No acceptance criteria defined` note). The labels are the contract — match them as exact strings, do not rewrite.
+4. **Squash-commit-body assumption** — under squash-merge (the project default per `docs/idd-methodology.md`), GitHub copies the PR body verbatim into the commit message. Treat passing check 3 as evidence the squash commit will carry the durable summary; no separate check is needed pre-merge. Note this assumption explicitly in the report so reviewers know what is and is not verified.
+
+**Pass/partial/fail rule for the dimension:**
+
+| Outcome | Conditions | Status |
+|---------|-----------|--------|
+| All four checks pass | Closes #N + commit ref + Decision Record + AC Verification block all present | ✓ traceability: pass |
+| `Closes #{N}` absent on a refactor/chore-exempt PR | check 1 skipped via the *Refactor/chore exemption* below; checks 2-4 still run | ○ traceability: pass — exempt (refactor/chore PR; no Closes #N required), with any check 2-4 partial findings appended |
+| `Closes #{N}` absent | check 1 fails (regardless of other checks) | ✗ traceability: fail (blocking — see below) |
+| Decision Record absent on a human-authored PR | check 3 partially fails: PR was not produced by `/issue-resolver` and has no Decision Record | ⚠ traceability: partial — "PR not produced by `/issue-resolver`; Decision Record absent" |
+| Commit reference absent | check 2 fails but check 1 passes (PR body has Closes #N but no commit references the issue) | ⚠ traceability: partial — "no commit references #{N}" |
+| Acceptance Criteria Verification block absent on a `/issue-resolver` PR | check 3 fails on a PR that does include a Decision Record | ⚠ traceability: partial — "Acceptance Criteria Verification block missing" |
+
+The `Closes #{N}` failure is the only traceability outcome that **blocks** the soft-pass. All other partial outcomes are reported but do not block. This matches issue #36's contract: a PR missing `Closes #N` reports a traceability failure even if tests pass; a human-authored PR without a Decision Record reports `partial`, not `fail`.
+
+When traceability fails on `Closes #{N}`, emit a fixable issue in Step 6 with `category: traceability`, `action: fix`, suggested fix: "Add `Closes #{N}` to the PR body."
+
+## Refactor/chore exemption
+
+Some PRs aren't tied to a single tracked issue — skill quality passes, dependency bumps, doc-only updates. Forcing each one to open a tracking issue purely to satisfy the `Closes #N` gate is workflow ceremony with no information gain. To accommodate this, check 1 (`Closes #N`) is **skipped** when either of the following holds:
+
+1. The PR has any label whose name appears in `review.traceability_exempt_labels` (default: `["refactor", "chore"]`). Match is exact and case-sensitive against GitHub label names.
+2. The PR body contains a line matching `review.traceability_exempt_pattern` (default: `"^\\s*Type:\\s*(refactor|chore)\\s*$"`, case-insensitive, evaluated multiline-anchored against the body). The line may appear anywhere in the body. The default is shown in YAML double-quoted form, so `\\s` is the correct value to copy into `.gitissue.yml`.
+
+The exemption applies **only to check 1**. Checks 2-4 (commit reference, Decision Record, Acceptance Criteria Verification block) still run; their absence is reported as `partial`, never `fail`. Note that check 2 (`git log --grep="#{N}"`) is well-defined only when there is a tracked issue number; an exempt refactor/chore PR with no linked issue has no `#{N}` to grep for, so check 2 is reported as `n/a — no linked issue`, not `partial`. When an exempt PR _does_ have a linked issue (e.g., a refactor scoped under a tracking ticket) but no commit references it, the report is `○ pass — exempt; no commit references #{N} (note)`, not `fail`.
+
+Report wording:
+
+```
+traceability:        ○ pass — exempt (refactor/chore PR; no Closes #N required)
+```
+
+If checks 2-4 produce partial findings on an exempt PR, append them as in the human-authored case:
+
+```
+traceability:        ○ pass — exempt (refactor/chore PR; no Closes #N required);
+                       no commit references #{N}
+```
+
+To **disable** the exemption entirely (restore the strict issue #36 behavior), set `traceability_exempt_labels: []` and `traceability_exempt_pattern: ""` in `.gitissue.yml`.
+
+The exemption check runs before the four traceability checks; if a PR matches, log which mechanism matched (label name or pattern) so reviewers can audit the decision in the report.

--- a/src/skills/issue-resolver/SKILL.source.md
+++ b/src/skills/issue-resolver/SKILL.source.md
@@ -1,12 +1,12 @@
 ---
 name: issue-resolver
-description: "Create an atomic PR that closes a GitHub issue end-to-end via a 6-step pipeline. Use when asked to resolve issue #N, fix #N, implement #N, work on #N, take issue #N, or /issue-resolver. Don't use for analyzing an issue without implementing (use /issue-analysis), reviewing an existing PR (use /issue-pr-review), or bulk backlog processing (use /auto-pilot)."
+description: "Create an atomic PR that closes a GitHub issue end-to-end via a 6-step pipeline. Use for resolve, fix, implement, work on, or take issue #N. Don't use for analyzing an issue without implementing (use /issue-analysis), reviewing an existing PR (use /issue-pr-review), or bulk backlog processing (use /auto-pilot)."
 license: MIT
-compatibility: Requires git and GitHub CLI (gh) with authentication and push access. Self-contained — uses shared agents from shared/agents/.
+compatibility: "Requires git and GitHub CLI (gh) with authentication and push access. Self-contained — uses shared agents from shared/agents/."
 effort: max
 metadata:
-  version: 0.7.2
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 0.8.0
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # /issue-resolver N
@@ -363,55 +363,14 @@ If the changes affect documented behavior:
 
 ### Push branch
 
-Before pushing, run the pre-commit security scan against every file touched by
-commits on this branch. The implementer ran the scan per commit during Step 3,
-but a final pre-push pass catches secrets that may have slipped in during QA
-fixes (see the pre-commit security conventions reference at
-`docs/pre-commit-security.md` — that document is authoritative; the snippet
-below mirrors its Primary Pattern). Real secrets block the push; warnings
-prompt for confirmation in interactive mode and log-and-continue in auto mode.
+The implementer ran the security scan per commit during Step 3, but before pushing you MUST run a final pre-push pass over the whole branch diff (`git diff --name-only "origin/${base}"...HEAD`) — it catches secrets that may have slipped in during QA fixes. Run the **Primary Pattern** in `docs/pre-commit-security.md` (authoritative; do not improvise a weaker check); export `IDD_AUTO_MODE=1` first in auto mode. It enforces, in order:
+
+1. **Block on real secrets** — secret-bearing filenames (`.env`, `*.key`, `*.pem`, `credentials.json`, `id_rsa`, …) or real API-key patterns (OpenAI, AWS, GitHub, Slack, GitLab, Google) in any text file in the diff → print the offending file and `exit 1`. Never push.
+2. **Warn (non-blocking) on** large files (>10 MB without LFS), build artifacts in the diff (`node_modules`, `dist`, `__pycache__`, `*.pyc`, …), and being on a protected branch. Interactive: prompt `Proceed anyway? [y/N]`; auto (`IDD_AUTO_MODE=1`): log and continue.
+
+Only after the scan passes (or warnings are accepted):
 
 ```bash
-# Pre-push security scan — mirrors the Primary Pattern in the
-# pre-commit-security conventions reference. Set IDD_AUTO_MODE=1 in auto mode.
-base="$(gh pr view --json baseRefName --jq .baseRefName 2>/dev/null || echo main)"
-files="$(git diff --name-only "origin/${base}"...HEAD)"
-secrets_found=0
-warnings=()
-if printf '%s\n' "$files" | grep -E -q '(^|/)\.env($|\.)|\.key$|\.pem$|credentials\.json$|secrets\.ya?ml$|id_rsa($|\.pub$)|\.p12$|\.pfx$|\.cer$'; then
-  echo "✗ Secret-bearing file in branch diff."
-  secrets_found=1
-fi
-realkey='(sk-(proj-)?[A-Za-z0-9_-]{20,}|sk_live_[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{30,}|gho_[A-Za-z0-9]{30,}|ghs_[A-Za-z0-9]{30,}|ghu_[A-Za-z0-9]{30,}|github_pat_[A-Za-z0-9_]{40,}|xox[abprs]-[A-Za-z0-9-]{10,}|glpat-[A-Za-z0-9_-]{20,}|AIza[0-9A-Za-z_-]{30,})'
-while IFS= read -r f; do
-  [ -z "$f" ] && continue
-  [ -f "$f" ] || continue
-  file --mime "$f" 2>/dev/null | grep -q 'charset=binary' && continue
-  if grep -E -q "$realkey" "$f" 2>/dev/null; then
-    echo "✗ Real API key detected in: $f"
-    secrets_found=1
-  fi
-  size=$(stat -f%z "$f" 2>/dev/null || stat -c%s "$f" 2>/dev/null || echo 0)
-  [ "$size" -gt 10485760 ] && warnings+=("⚠ Large file (>10 MB) without LFS: $f")
-done <<< "$files"
-junk='(^|/)(node_modules|dist|build|__pycache__|\.venv)(/|$)|\.pyc$|(^|/)(\.DS_Store|thumbs\.db)$|\.swp$|\.tmp$'
-while IFS= read -r f; do
-  [ -z "$f" ] && continue
-  printf '%s\n' "$f" | grep -E -q "$junk" && warnings+=("⚠ Build artifact in diff: $f")
-done <<< "$files"
-case "$(git rev-parse --abbrev-ref HEAD)" in
-  main|master|production|release) warnings+=("⚠ On protected branch — confirm intentional") ;;
-esac
-[ "$secrets_found" = 1 ] && { echo "✗ Pre-push security scan blocked. See pre-commit-security conventions reference."; exit 1; }
-if [ "${#warnings[@]}" -gt 0 ]; then
-  printf '%s\n' "${warnings[@]}"
-  if [ "${IDD_AUTO_MODE:-0}" = "1" ]; then
-    echo "○ Warnings logged — proceeding (auto mode)."
-  else
-    printf "Proceed anyway? [y/N] "; read -r reply
-    case "$reply" in y|Y|yes|YES) echo "○ Continuing despite warnings." ;; *) echo "✗ Stopped."; exit 1 ;; esac
-  fi
-fi
 git push -u origin {branch_name}
 ```
 

--- a/src/skills/issue-triage/SKILL.source.md
+++ b/src/skills/issue-triage/SKILL.source.md
@@ -1,12 +1,12 @@
 ---
 name: issue-triage
-description: "Analyze and triage open GitHub issues for dependencies, priorities, parallelizable work, staleness, and already-fixed detection, caching results to .gitissue/triage.json. Use when asked to triage issues, prioritize issues, what should I work on next, or /issue-triage. Don't use for analyzing one specific issue (use /issue-analysis), resolving an issue (use /issue-resolver), or creating new issues (use /issue-creator)."
+description: "Triage open GitHub issues for dependencies, priorities, parallelizable work, staleness, and already-fixed detection; caches to .gitissue/triage.json. Use for triage or prioritize issues, or what to work on next. Don't use for analyzing one specific issue (use /issue-analysis), resolving an issue (use /issue-resolver), or creating new issues (use /issue-creator)."
 license: MIT
-compatibility: Requires git and GitHub CLI (gh) with authentication. Default mode (cached view) needs only local file access — no gh required.
+compatibility: "Requires git and GitHub CLI (gh) with authentication. Default mode (cached view) needs only local file access — no gh required."
 effort: medium
 metadata:
-  version: 0.5.2
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 0.5.3
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # /issue-triage

--- a/tests/test-issue-pr-review-traceability.sh
+++ b/tests/test-issue-pr-review-traceability.sh
@@ -27,6 +27,16 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SKILL="$REPO_ROOT/src/skills/issue-pr-review/SKILL.source.md"
+# The detailed AC + traceability spec language (per-criterion statuses, the
+# Decision Record labels, the `traceability: partial` verdict, the
+# `git log --grep` commit check) was extracted from SKILL.source.md into
+# references/verification-checks.md for progressive disclosure (≤500-line
+# skill-creator standard). SKILL.source.md still instructs the agent to read
+# and apply that file at Step 3 ("Read that file and apply it now"), so the
+# runtime-reachable spec surface is SKILL.source.md *plus* verification-checks.md.
+# Assertions that target the extracted language grep this combined corpus.
+VERIFICATION_CHECKS="$REPO_ROOT/src/skills/issue-pr-review/references/verification-checks.md"
+SKILL_SPEC=("$SKILL" "$VERIFICATION_CHECKS")
 TEMPLATES="$REPO_ROOT/src/skills/issue-pr-review/references/report-templates.md"
 RESOLVER_TEMPLATES="$REPO_ROOT/src/skills/issue-resolver/references/report-templates.md"
 METHODOLOGY="$REPO_ROOT/docs/idd-methodology.md"
@@ -49,7 +59,7 @@ echo "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄�
 # ───────────────────────────────────────────────────────────
 # T0: Files exist
 # ───────────────────────────────────────────────────────────
-for f in "$SKILL" "$TEMPLATES" "$RESOLVER_TEMPLATES" "$METHODOLOGY"; do
+for f in "$SKILL" "$VERIFICATION_CHECKS" "$TEMPLATES" "$RESOLVER_TEMPLATES" "$METHODOLOGY"; do
   if [ -f "$f" ]; then
     pass "T0: $(basename "$f") exists"
   else
@@ -132,13 +142,13 @@ else
   fail "T3.AC2: SKILL.md does not address human-authored PRs"
 fi
 
-if grep -qiE 'traceability:.*partial' "$SKILL"; then
+if grep -qiE 'traceability:.*partial' "${SKILL_SPEC[@]}"; then
   pass "T3.AC2: SKILL.md uses 'traceability: partial' for the soft case"
 else
   fail "T3.AC2: SKILL.md never declares 'traceability: partial'"
 fi
 
-if grep -qiE 'Decision Record absent' "$SKILL"; then
+if grep -qiE 'Decision Record absent' "${SKILL_SPEC[@]}"; then
   pass "T3.AC2: SKILL.md notes Decision Record may be absent"
 else
   fail "T3.AC2: SKILL.md does not note Decision Record absent case"
@@ -168,7 +178,7 @@ fi
 # All five Decision Record stable labels must be enumerated, since they
 # are the string-matched contract.
 for label in "Root cause" "Options considered" "Options rejected" "Selected option" "Residual risk"; do
-  if grep -qF "$label" "$SKILL"; then
+  if grep -qF "$label" "${SKILL_SPEC[@]}"; then
     pass "T4.AC3: SKILL.md enumerates Decision Record label '$label'"
   else
     fail "T4.AC3: SKILL.md missing Decision Record label '$label'"
@@ -229,14 +239,14 @@ fi
 # All three statuses must be documented in /issue-pr-review too,
 # alongside the requirement that evidence accompanies pass/fail.
 for status in pass fail unverified; do
-  if grep -qE "\\\`$status\\\`" "$SKILL" || grep -qiE "(^|[^a-z_])$status([^a-z_]|$)" "$SKILL"; then
+  if grep -qE "\\\`$status\\\`" "${SKILL_SPEC[@]}" || grep -qiE "(^|[^a-z_])$status([^a-z_]|$)" "${SKILL_SPEC[@]}"; then
     pass "T6: SKILL.md documents AC status '$status'"
   else
     fail "T6: SKILL.md missing AC status '$status'"
   fi
 done
 
-if grep -qiE 'evidence' "$SKILL"; then
+if grep -qiE 'evidence' "${SKILL_SPEC[@]}"; then
   pass "T6: SKILL.md requires evidence on AC verifications"
 else
   fail "T6: SKILL.md does not require evidence on AC verifications"
@@ -256,7 +266,7 @@ else
   fail "T7: SKILL.md missing 'PR body contains Closes #N' check"
 fi
 
-if grep -qE 'git log.*--grep' "$SKILL"; then
+if grep -qE 'git log.*--grep' "${SKILL_SPEC[@]}"; then
   pass "T7: SKILL.md documents commit-references-issue check via git log --grep"
 else
   fail "T7: SKILL.md missing commit-references-issue check"


### PR DESCRIPTION
Type: chore

Retrofits every skill under `src/skills/` to the skill-creator frontmatter and body standards (Subpath B1 — mechanical conformance, no behavioral redesign), then rebuilds the committed `skills/` tree. Source of truth is `SKILL.source.md`; `dist/` is gitignored and rebuilt in CI, so only `src/skills/` + `skills/` change here.

## Frontmatter (all 7 skills)
- `metadata.creator` → `metadata.author` — the audit's required normalization
- Quoted all `compatibility:` values containing `:`, backticks, parens, or em-dashes (YAML safety)
- Trimmed 6 over-long descriptions, **keeping every negative-trigger clause verbatim**. `issue-creator` (248) and `issue-pr-review` (195) now meet the ≤250 target; the other 5 stay 312–364 because their cross-skill negatives alone run 140–171 chars — per the standard, an intact negative clause beats the soft 250 target.

## Body / structure (4 skills were ≥500 lines)
| Skill | Before | After | Change |
|-------|--------|-------|--------|
| `issue-pr-review` | 733 | 479 | Extract AC/traceability specs → `references/verification-checks.md` and agent-reuse + fixer-spawn → `references/review-loop-mechanics.md`; replace duplicated inline security-scan bash with a pointer to canonical `pre-commit-security.md` |
| `issue-resolver` | 525 | 484 | Same security-scan extraction |
| `auto-pilot` | 503 | 476 | Move in-body changelog to release notes (config keys still documented in `config-schema.md`) |
| `issue-creator` | 483→506→494 | 494 | Add mandatory **Repo Sync Before Edits** section (it commits images to `.github/issue-assets/`), trim a redundant diagram back under 500 |

Version bumps reflect the largest change per skill (e.g. `issue-pr-review` 1.0.0→2.0.0; `issue-creator` 0.4.1→0.5.0).

## Security control: delegated, not weakened
The extracted scan points to `docs/pre-commit-security.md`, whose Primary Pattern is parameterized over a `$files` variable — so both scopes (working tree for pr-review, branch diff for resolver) are honest. This matches the doc's own "link here rather than copy-paste" guidance.

## Verification
- `quick_validate.py` clean on all 7
- Every built `SKILL.md` <500 across `skills/`, `dist/skills/`, `dist/plugin/`
- No runtime doc dropped from any bundle (closure preserved)
- Test suites all green: pre-commit-security lint 9/0, build 30/0, dependency-closure 22/0, flattened-self-contained 7/0, flattened-coexistence 5/0, autopilot-modes 35/0