### PR TITLE
fix(nav): repair broken landing-page nav links and deploy changelog (#118)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,7 +1,7 @@
 name: Deploy landing page to GitHub Pages
 
-# Publishes landing.html, docs.html (plus the brand assets they reference) to
-# GitHub Pages on every push to main. The site is assembled into a _site/
+# Publishes landing.html, docs.html, changelog.html (plus the brand assets they
+# reference) to GitHub Pages on every push to main. The site is assembled into a _site/
 # directory so the repository source tree is never exposed — only the public
 # pages and the specific assets they load are deployed.
 
@@ -11,6 +11,7 @@ on:
     paths:
       - landing.html
       - docs.html
+      - changelog.html
       - sitemap.xml
       - robots.txt
       - llms.txt
@@ -42,9 +43,11 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p _site/assets/logo _site/assets/screenshots _site/assets/og
-          # Landing page becomes the site index; docs.html is the dedicated docs page.
+          # Landing page becomes the site index; docs.html and changelog.html
+          # are dedicated pages linked from the nav.
           cp landing.html _site/index.html
           cp docs.html _site/docs.html
+          cp changelog.html _site/changelog.html
           # Crawl and AI-discovery files for search engines and LLM tools.
           cp sitemap.xml _site/sitemap.xml
           cp robots.txt _site/robots.txt

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ dist/skills/
 dist/agents/
 dist/plugin/
 dist/test-plugin/
+
+# gstack browser/session artifacts
+.gstack/

--- a/changelog.html
+++ b/changelog.html
@@ -228,19 +228,19 @@
   <!-- ───────────────────────── NAV ───────────────────────── -->
   <header class="nav">
     <div class="wrap nav-inner">
-      <a class="brand" href="landing.html" aria-label="issuedev home">
+      <a class="brand" href="./" aria-label="issuedev home">
         <svg width="26" height="26" viewBox="0 0 120 120" aria-hidden="true">
           <path fill-rule="evenodd" fill="#00FF41" d="M60 12 L108 60 L60 108 L12 60 Z M48 46 L80 60 L48 74 Z"/>
         </svg>
         <span><span class="b-issue">issue</span><span class="b-dev">dev</span></span>
       </a>
       <nav class="nav-links">
-        <a href="landing.html">Home</a>
-        <a href="landing.html#how">How it works</a>
-        <a href="landing.html#commands">Commands</a>
+        <a href="./">Home</a>
+        <a href="./#how">How it works</a>
+        <a href="./#commands">Commands</a>
         <a href="docs.html">Docs</a>
         <a href="changelog.html" class="active">Changelog</a>
-        <a href="landing.html#install">Install</a>
+        <a href="./#install">Install</a>
         <a class="nav-cta" href="https://github.com/luongnv89/idd">GitHub ↗</a>
       </nav>
     </div>
@@ -285,7 +285,7 @@
   <!-- ───────────────────────── FOOTER ───────────────────────── -->
   <footer class="site">
     <div class="wrap foot-inner">
-      <a class="brand" href="landing.html" style="font-size:18px;">
+      <a class="brand" href="./" style="font-size:18px;">
         <svg width="22" height="22" viewBox="0 0 120 120" aria-hidden="true">
           <path fill-rule="evenodd" fill="#00FF41" d="M60 12 L108 60 L60 108 L12 60 Z M48 46 L80 60 L48 74 Z"/>
         </svg>
@@ -293,7 +293,7 @@
       </a>
       <div class="foot-links">
         <a href="https://github.com/luongnv89/idd">GitHub</a>
-        <a href="landing.html#commands">Commands</a>
+        <a href="./#commands">Commands</a>
         <a href="docs.html">Docs</a>
         <a href="changelog.html">Changelog</a>
         <a href="https://github.com/luongnv89/idd/blob/main/LICENSE">License</a>

--- a/docs.html
+++ b/docs.html
@@ -155,7 +155,7 @@
   </style>
 </head>
 <body>
-<header><div class="wrap nav nav-inner"><a class="brand" href="landing.html"><svg width="26" height="26" viewBox="0 0 120 120"><path fill-rule="evenodd" fill="#00FF41" d="M60 12 L108 60 L60 108 L12 60 Z M48 46 L80 60 L48 74 Z"/></svg><span><b>issue</b><b>dev</b></span></a><nav class="nav-links"><a href="landing.html">Home</a><a href="landing.html#how">How it works</a><a href="landing.html#commands">Commands</a><a href="docs.html" class="active">Docs</a><a href="changelog.html">Changelog</a><a href="landing.html#install">Install</a><a class="cta" href="https://github.com/luongnv89/idd">GitHub ↗</a></nav></div></header>
+<header><div class="wrap nav nav-inner"><a class="brand" href="./"><svg width="26" height="26" viewBox="0 0 120 120"><path fill-rule="evenodd" fill="#00FF41" d="M60 12 L108 60 L60 108 L12 60 Z M48 46 L80 60 L48 74 Z"/></svg><span><b>issue</b><b>dev</b></span></a><nav class="nav-links"><a href="./">Home</a><a href="./#how">How it works</a><a href="./#commands">Commands</a><a href="docs.html" class="active">Docs</a><a href="changelog.html">Changelog</a><a href="./#install">Install</a><a class="cta" href="https://github.com/luongnv89/idd">GitHub ↗</a></nav></div></header>
 <main>
   <div class="wrap hero"><div class="eyebrow">◆ Documentation</div><h1>Skills reference and <span>input options.</span></h1><p class="lead">Every issuedev / gitissue command in one place: what it does, accepted inputs, execution modes, and requirements.</p></div>
   <div class="wrap grid">
@@ -176,7 +176,7 @@
 </main>
 <footer class="site">
   <div class="wrap foot-inner">
-    <a class="brand" href="landing.html" style="font-size:18px;">
+    <a class="brand" href="./" style="font-size:18px;">
       <svg width="22" height="22" viewBox="0 0 120 120" aria-hidden="true">
         <path fill-rule="evenodd" fill="#00FF41" d="M60 12 L108 60 L60 108 L12 60 Z M48 46 L80 60 L48 74 Z"/>
       </svg>
@@ -184,7 +184,7 @@
     </a>
     <div class="foot-links">
       <a href="https://github.com/luongnv89/idd">GitHub</a>
-      <a href="landing.html#commands">Commands</a>
+      <a href="./#commands">Commands</a>
       <a href="docs.html">Docs</a>
       <a href="changelog.html">Changelog</a>
       <a href="https://github.com/luongnv89/idd/blob/main/LICENSE">License</a>

--- a/landing.html
+++ b/landing.html
@@ -457,19 +457,19 @@
   <!-- ───────────────────────── NAV ───────────────────────── -->
   <header class="nav">
     <div class="wrap nav-inner">
-      <a class="brand" href="landing.html" aria-label="issuedev home">
+      <a class="brand" href="./" aria-label="issuedev home">
         <svg width="26" height="26" viewBox="0 0 120 120" aria-hidden="true">
           <path fill-rule="evenodd" fill="#00FF41" d="M60 12 L108 60 L60 108 L12 60 Z M48 46 L80 60 L48 74 Z"/>
         </svg>
         <span><span class="b-issue">issue</span><span class="b-dev">dev</span></span>
       </a>
       <nav class="nav-links">
-        <a href="landing.html" class="active">Home</a>
-        <a href="landing.html#how">How it works</a>
-        <a href="#commands">Commands</a>
+        <a href="./" class="active">Home</a>
+        <a href="./#how">How it works</a>
+        <a href="./#commands">Commands</a>
         <a href="docs.html">Docs</a>
         <a href="changelog.html">Changelog</a>
-        <a href="#install">Install</a>
+        <a href="./#install">Install</a>
         <a class="nav-cta" href="https://github.com/luongnv89/idd">GitHub ↗</a>
       </nav>
     </div>
@@ -486,7 +486,7 @@
           so any developer or AI agent can pick up an issue and ship a tested PR. Zero config. Works with the tools you already use.
         </p>
         <div class="hero-cta">
-          <a class="btn btn-primary" href="#install">▶ Get Started</a>
+          <a class="btn btn-primary" href="./#install">▶ Get Started</a>
           <a class="btn btn-ghost" href="docs.html">Read the Docs</a>
           <a class="btn btn-ghost" href="https://github.com/luongnv89/idd">View on GitHub</a>
         </div>
@@ -820,7 +820,7 @@
     <h2>Stop translating issues by hand.<br/>Let your agents <span class="green">execute them.</span></h2>
     <p>Turn vague reports into agent-ready work orders — and turn your git history back into the knowledge base it was meant to be.</p>
     <div class="hero-cta">
-      <a class="btn btn-primary" href="#install">▶ Get Started Free</a>
+      <a class="btn btn-primary" href="./#install">▶ Get Started Free</a>
       <a class="btn btn-ghost" href="https://github.com/luongnv89/idd">Star on GitHub ★</a>
     </div>
     <div class="risk"><span class="ok">✓</span> MIT licensed &nbsp;·&nbsp; <span class="ok">✓</span> Zero config &nbsp;·&nbsp; <span class="ok">✓</span> No vendor lock-in</div>
@@ -829,7 +829,7 @@
   <!-- ───────────────────────── FOOTER ───────────────────────── -->
   <footer class="site">
     <div class="wrap foot-inner">
-      <a class="brand" href="landing.html" style="font-size:18px;">
+      <a class="brand" href="./" style="font-size:18px;">
         <svg width="22" height="22" viewBox="0 0 120 120" aria-hidden="true">
           <path fill-rule="evenodd" fill="#00FF41" d="M60 12 L108 60 L60 108 L12 60 Z M48 46 L80 60 L48 74 Z"/>
         </svg>
@@ -837,7 +837,7 @@
       </a>
       <div class="foot-links">
         <a href="https://github.com/luongnv89/idd">GitHub</a>
-        <a href="#commands">Commands</a>
+        <a href="./#commands">Commands</a>
         <a href="docs.html">Docs</a>
         <a href="changelog.html">Changelog</a>
         <a href="https://github.com/luongnv89/idd/blob/main/LICENSE">License</a>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -12,4 +12,10 @@
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
+  <url>
+    <loc>https://luongnv.com/idd/changelog.html</loc>
+    <lastmod>2026-06-12</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
Closes #118

## Summary

Navigation links on the live landing page (https://luongnv.com/idd/) were broken. The "Home" link, the brand logo, and the "Changelog" link returned 404 on every page; landing-section links from the docs and changelog pages pointed at a missing file or the wrong page's anchor.

## Approach

**Root cause:** the GitHub Pages workflow (`.github/workflows/pages.yml`) renames `landing.html` → `index.html` at deploy and only copied `landing.html` + `docs.html` into the published `_site/`. As a result, on the live site:

| Link | Target in source | Live result |
|------|------------------|-------------|
| Home / brand logo (all pages) | `href="landing.html"` | **404** — only `index.html` is deployed |
| Changelog (all pages) | `href="changelog.html"` | **404** — `changelog.html` was never deployed |
| Commands/How/Install from docs & changelog | `landing.html#commands`, bare `#commands` | **404** or wrong-page anchor |

Confirmed against the live site before fixing: `curl` returned `404` for `/idd/landing.html` and `/idd/changelog.html`, `200` for `/idd/` and `/idd/docs.html`.

**Fix (two coupled parts):**
1. Normalized **every** nav, footer, and brand link across `landing.html`, `docs.html`, and `changelog.html` to `./` (home/brand) and `./#anchor` (landing sections). `./` resolves to the canonical `/idd/` from all three deployed pages. This also delivers the "unify the nav" intent of #114/#115, which had unified the markup but to filenames that don't survive the deploy rename.
2. Deployed `changelog.html` — added it to the workflow's trigger `paths` and the assemble step's `cp` list, and added it to `sitemap.xml`. (Per maintainer decision, the changelog page is kept and deployed rather than retired.)

## Decision Record

- **Why `./` and not `index.html` or `landing.html`?** The deploy intentionally serves the landing page as the site index at `/idd/` (no `index.html` suffix in the canonical tag or sitemap). `./` is the only form that resolves to canonical `/idd/` from every page; `index.html` would create a divergent second URL, and `landing.html` is exactly what 404s. Local `file://` viewing is not a goal — the deploy deliberately renames the file, so source filenames already differ from live URLs.
- **Why deploy `changelog.html`?** It is a complete, working page (fetches GitHub releases at runtime); it was simply never copied into `_site/`. Maintainer chose to ship it rather than remove the links.

## Changes

| File | Change |
|------|--------|
| `landing.html` | Nav + footer + brand + 2 hero/CTA links → `./` / `./#anchor` |
| `docs.html` | Nav + footer + brand links → `./` / `./#anchor` |
| `changelog.html` | Nav + footer + brand links → `./` / `./#anchor` (incl. a bare `#commands` that pointed at a non-existent anchor) |
| `.github/workflows/pages.yml` | Deploy `changelog.html` (trigger path + `cp` into `_site/`) |
| `sitemap.xml` | Add `changelog.html` URL entry |
| `.gitignore` | Ignore `.gstack/` tooling artifacts |

## Test Results

No runtime test suite (skills-only + static HTML project). Verified by **replicating the Pages assemble step locally** (`cp landing.html _site/index.html`, etc., including all copied assets) and serving `_site/` over HTTP under an `/idd/` path:

- Clicked every nav/footer link on all three pages → all resolve to **200** URLs (`/idd/`, `/idd/#how`, `/idd/#commands`, `/idd/#install`, `/idd/docs.html`, `/idd/changelog.html`).
- "Home" clicked from `docs.html` lands on `/idd/` and the hero renders.
- `#commands` / `#how` / `#install` anchor targets exist on the index page (links scroll to real sections).
- `changelog.html` renders; **zero local-asset 404s** across all three pages.

> **Note:** This verifies the assembled artifact the workflow deploys. The live `/idd/` site is repaired only **after this PR merges** — all changed files are in the workflow's `on.push.paths` trigger, so merging to `main` fires the Pages deploy automatically. Live confirmation is a post-merge step.

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| All nav bar links on `/idd/` reviewed | ✅ | Audited nav + footer + brand across all 3 deployed pages |
| Each nav link opens the intended section/page/destination | ✅ (local replica) | All links resolve to 200; anchors hit real `id=` targets; cross-page links land and render. Live confirmation post-merge. |
| Broken/incorrect/non-responsive links fixed | ✅ | `landing.html`→`./`, `changelog.html` now deployed, wrong-page bare anchor corrected; live 404s (`landing.html`, `changelog.html`) eliminated by the `./`-normalization + deploy |

Out of scope (noted, not addressed): `changelog.html` lacks an `og:image` and `llms.txt` doesn't list the changelog — both pre-existing and unrelated to broken nav links.
