### PR TITLE
chore(issue-creator): enable model_suggestion by default

### DIFF
--- a/.gitissue.yml
+++ b/.gitissue.yml
@@ -129,7 +129,7 @@ analysis:
 model_suggestion:
   # Suggest a cost-effective model + thinking level per issue, from CursorBench
   # data cached in .gitissue/model-data.json. When false, silently skipped.
-  enabled: false
+  enabled: true
 
   # Source URL refreshed into the cache on opt-in
   data_url: "https://cursor.com/cursorbench"

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -386,10 +386,10 @@ model_suggestion:
   # Suggest a cost-effective model + thinking level per issue, from CursorBench
   # data cached in .gitissue/model-data.json
   # Type: boolean
-  # Default: false
+  # Default: true
   # When false, all model-suggestion behavior is silently skipped and the issue
   # body / preview are unchanged from the pre-feature behavior
-  enabled: false
+  enabled: true
 
   # Source URL refreshed into the cache on opt-in
   # Type: string
@@ -553,6 +553,6 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `projects.status_map.todo` | `"Todo"` | Status for new issues |
 | `projects.status_map.in_progress` | `"In Progress"` | Status when work starts |
 | `projects.status_map.done` | `"Done"` | Status when PR is created |
-| `model_suggestion.enabled` | `false` | Suggest a model + thinking level per issue |
+| `model_suggestion.enabled` | `true` | Suggest a model + thinking level per issue |
 | `model_suggestion.data_url` | `"https://cursor.com/cursorbench"` | CursorBench source refreshed into the cache |
 | `model_suggestion.cache_ttl_days` | `7` | Days before cached model data is stale |

--- a/skills/auto-pilot/references/docs/config-schema.md
+++ b/skills/auto-pilot/references/docs/config-schema.md
@@ -387,10 +387,10 @@ model_suggestion:
   # Suggest a cost-effective model + thinking level per issue, from CursorBench
   # data cached in .gitissue/model-data.json
   # Type: boolean
-  # Default: false
+  # Default: true
   # When false, all model-suggestion behavior is silently skipped and the issue
   # body / preview are unchanged from the pre-feature behavior
-  enabled: false
+  enabled: true
 
   # Source URL refreshed into the cache on opt-in
   # Type: string
@@ -554,6 +554,6 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `projects.status_map.todo` | `"Todo"` | Status for new issues |
 | `projects.status_map.in_progress` | `"In Progress"` | Status when work starts |
 | `projects.status_map.done` | `"Done"` | Status when PR is created |
-| `model_suggestion.enabled` | `false` | Suggest a model + thinking level per issue |
+| `model_suggestion.enabled` | `true` | Suggest a model + thinking level per issue |
 | `model_suggestion.data_url` | `"https://cursor.com/cursorbench"` | CursorBench source refreshed into the cache |
 | `model_suggestion.cache_ttl_days` | `7` | Days before cached model data is stale |

--- a/skills/init-gitissue/references/docs/config-schema.md
+++ b/skills/init-gitissue/references/docs/config-schema.md
@@ -387,10 +387,10 @@ model_suggestion:
   # Suggest a cost-effective model + thinking level per issue, from CursorBench
   # data cached in .gitissue/model-data.json
   # Type: boolean
-  # Default: false
+  # Default: true
   # When false, all model-suggestion behavior is silently skipped and the issue
   # body / preview are unchanged from the pre-feature behavior
-  enabled: false
+  enabled: true
 
   # Source URL refreshed into the cache on opt-in
   # Type: string
@@ -554,6 +554,6 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `projects.status_map.todo` | `"Todo"` | Status for new issues |
 | `projects.status_map.in_progress` | `"In Progress"` | Status when work starts |
 | `projects.status_map.done` | `"Done"` | Status when PR is created |
-| `model_suggestion.enabled` | `false` | Suggest a model + thinking level per issue |
+| `model_suggestion.enabled` | `true` | Suggest a model + thinking level per issue |
 | `model_suggestion.data_url` | `"https://cursor.com/cursorbench"` | CursorBench source refreshed into the cache |
 | `model_suggestion.cache_ttl_days` | `7` | Days before cached model data is stale |

--- a/skills/init-gitissue/templates/gitissue-template.yml
+++ b/skills/init-gitissue/templates/gitissue-template.yml
@@ -125,7 +125,7 @@ analysis:
 model_suggestion:
   # Suggest a cost-effective model + thinking level per issue, from CursorBench
   # data cached in .gitissue/model-data.json. When false, silently skipped.
-  enabled: false
+  enabled: true
 
   # Source URL refreshed into the cache on opt-in
   data_url: "https://cursor.com/cursorbench"

--- a/skills/issue-analysis/references/docs/config-schema.md
+++ b/skills/issue-analysis/references/docs/config-schema.md
@@ -387,10 +387,10 @@ model_suggestion:
   # Suggest a cost-effective model + thinking level per issue, from CursorBench
   # data cached in .gitissue/model-data.json
   # Type: boolean
-  # Default: false
+  # Default: true
   # When false, all model-suggestion behavior is silently skipped and the issue
   # body / preview are unchanged from the pre-feature behavior
-  enabled: false
+  enabled: true
 
   # Source URL refreshed into the cache on opt-in
   # Type: string
@@ -554,6 +554,6 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `projects.status_map.todo` | `"Todo"` | Status for new issues |
 | `projects.status_map.in_progress` | `"In Progress"` | Status when work starts |
 | `projects.status_map.done` | `"Done"` | Status when PR is created |
-| `model_suggestion.enabled` | `false` | Suggest a model + thinking level per issue |
+| `model_suggestion.enabled` | `true` | Suggest a model + thinking level per issue |
 | `model_suggestion.data_url` | `"https://cursor.com/cursorbench"` | CursorBench source refreshed into the cache |
 | `model_suggestion.cache_ttl_days` | `7` | Days before cached model data is stale |

--- a/skills/issue-creator/SKILL.md
+++ b/skills/issue-creator/SKILL.md
@@ -86,13 +86,13 @@ Load `.gitissue.yml` from the repo root once at skill start. If the file does no
 ○ First run — using default config. Run /init-gitissue to customize.
 ```
 
-Defaults: `issue.auto_normalize: true`, `issue.template: "default"`, `issue.labels_auto_suggest: true`, `issue.normalize_comment: true`, `model_suggestion.enabled: false`
+Defaults: `issue.auto_normalize: true`, `issue.template: "default"`, `issue.labels_auto_suggest: true`, `issue.normalize_comment: true`, `model_suggestion.enabled: true`
 
 If the config file exists but contains invalid values, output the validation error from `references/error-messages.md` and stop.
 
 Do not re-read the config at each step.
 
-If `model_suggestion.enabled` is `true`, run the model-data cache lifecycle (check / seed / staleness-refresh) once now, before Step 1 — see `references/model-suggestion.md`. When `false` (default), skip all model-suggestion steps silently.
+If `model_suggestion.enabled` is `true` (the default), run the model-data cache lifecycle (check / seed / staleness-refresh) once now, before Step 1 — see `references/model-suggestion.md`. When `false`, skip all model-suggestion steps silently.
 
 ## Subagent Architecture
 
@@ -348,7 +348,7 @@ Read the appropriate template from `templates/` (bug.md, feature.md, or improvem
 3. **Reporter Context** — user's original text, verbatim, in a blockquote
 4. **Screenshots** — embedded images (only if images were provided and uploaded successfully)
 5. **Acceptance Criteria** — 3-5 testable criteria derived from the problem description, with confidence levels
-6. **Metadata** — suggested priority, estimated effort (XS/S/M/L/XL), suggested labels, and an advisory **Suggested model:** line keyed off the effort band — see `references/model-suggestion.md`. When `model_suggestion.enabled` is false (the default), remove the `**Suggested model:**` line from the Metadata section entirely, matching pre-feature behaviour.
+6. **Metadata** — suggested priority, estimated effort (XS/S/M/L/XL), suggested labels, and an advisory **Suggested model:** line keyed off the effort band — see `references/model-suggestion.md`. When `model_suggestion.enabled` is false, remove the `**Suggested model:**` line from the Metadata section entirely, matching pre-feature behaviour.
 
 **Note:** Per the Output Contract above, the issue body MUST NOT include predicted affected files, generated technical notes, root cause, or implementation hints. Acceptance criteria express *what done looks like*, not *how to implement it*.
 

--- a/skills/issue-creator/references/docs/config-schema.md
+++ b/skills/issue-creator/references/docs/config-schema.md
@@ -387,10 +387,10 @@ model_suggestion:
   # Suggest a cost-effective model + thinking level per issue, from CursorBench
   # data cached in .gitissue/model-data.json
   # Type: boolean
-  # Default: false
+  # Default: true
   # When false, all model-suggestion behavior is silently skipped and the issue
   # body / preview are unchanged from the pre-feature behavior
-  enabled: false
+  enabled: true
 
   # Source URL refreshed into the cache on opt-in
   # Type: string
@@ -554,6 +554,6 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `projects.status_map.todo` | `"Todo"` | Status for new issues |
 | `projects.status_map.in_progress` | `"In Progress"` | Status when work starts |
 | `projects.status_map.done` | `"Done"` | Status when PR is created |
-| `model_suggestion.enabled` | `false` | Suggest a model + thinking level per issue |
+| `model_suggestion.enabled` | `true` | Suggest a model + thinking level per issue |
 | `model_suggestion.data_url` | `"https://cursor.com/cursorbench"` | CursorBench source refreshed into the cache |
 | `model_suggestion.cache_ttl_days` | `7` | Days before cached model data is stale |

--- a/skills/issue-creator/references/model-suggestion.md
+++ b/skills/issue-creator/references/model-suggestion.md
@@ -1,9 +1,9 @@
 # Model Suggestion — Reference
 
 How `/issue-creator` suggests a cost-effective model + thinking level for each
-issue, and how it manages the local CursorBench data cache. This procedure is
-**optional** and runs only when `model_suggestion.enabled` is `true` in
-`.gitissue.yml` (default: `false`). When disabled, every step here is skipped
+issue, and how it manages the local CursorBench data cache. This procedure
+runs when `model_suggestion.enabled` is `true` in `.gitissue.yml`
+(default: `true`). When disabled, every step here is skipped
 silently — issue creation behaves exactly as before.
 
 The suggestion is **advisory metadata**, like priority and effort. It never
@@ -165,7 +165,7 @@ changes from the pre-feature behaviour.
 # Suggest a cost-effective model + thinking level per issue (CursorBench data)
 model_suggestion:
   # Master switch. When false, all model-suggestion behaviour is skipped.
-  enabled: false
+  enabled: true
   # Source URL refreshed into .gitissue/model-data.json
   data_url: "https://cursor.com/cursorbench"
   # Days before the cache is considered stale

--- a/skills/issue-resolver/references/docs/config-schema.md
+++ b/skills/issue-resolver/references/docs/config-schema.md
@@ -387,10 +387,10 @@ model_suggestion:
   # Suggest a cost-effective model + thinking level per issue, from CursorBench
   # data cached in .gitissue/model-data.json
   # Type: boolean
-  # Default: false
+  # Default: true
   # When false, all model-suggestion behavior is silently skipped and the issue
   # body / preview are unchanged from the pre-feature behavior
-  enabled: false
+  enabled: true
 
   # Source URL refreshed into the cache on opt-in
   # Type: string
@@ -554,6 +554,6 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `projects.status_map.todo` | `"Todo"` | Status for new issues |
 | `projects.status_map.in_progress` | `"In Progress"` | Status when work starts |
 | `projects.status_map.done` | `"Done"` | Status when PR is created |
-| `model_suggestion.enabled` | `false` | Suggest a model + thinking level per issue |
+| `model_suggestion.enabled` | `true` | Suggest a model + thinking level per issue |
 | `model_suggestion.data_url` | `"https://cursor.com/cursorbench"` | CursorBench source refreshed into the cache |
 | `model_suggestion.cache_ttl_days` | `7` | Days before cached model data is stale |

--- a/skills/issue-triage/references/docs/config-schema.md
+++ b/skills/issue-triage/references/docs/config-schema.md
@@ -387,10 +387,10 @@ model_suggestion:
   # Suggest a cost-effective model + thinking level per issue, from CursorBench
   # data cached in .gitissue/model-data.json
   # Type: boolean
-  # Default: false
+  # Default: true
   # When false, all model-suggestion behavior is silently skipped and the issue
   # body / preview are unchanged from the pre-feature behavior
-  enabled: false
+  enabled: true
 
   # Source URL refreshed into the cache on opt-in
   # Type: string
@@ -554,6 +554,6 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `projects.status_map.todo` | `"Todo"` | Status for new issues |
 | `projects.status_map.in_progress` | `"In Progress"` | Status when work starts |
 | `projects.status_map.done` | `"Done"` | Status when PR is created |
-| `model_suggestion.enabled` | `false` | Suggest a model + thinking level per issue |
+| `model_suggestion.enabled` | `true` | Suggest a model + thinking level per issue |
 | `model_suggestion.data_url` | `"https://cursor.com/cursorbench"` | CursorBench source refreshed into the cache |
 | `model_suggestion.cache_ttl_days` | `7` | Days before cached model data is stale |

--- a/src/skills/init-gitissue/templates/gitissue-template.yml
+++ b/src/skills/init-gitissue/templates/gitissue-template.yml
@@ -125,7 +125,7 @@ analysis:
 model_suggestion:
   # Suggest a cost-effective model + thinking level per issue, from CursorBench
   # data cached in .gitissue/model-data.json. When false, silently skipped.
-  enabled: false
+  enabled: true
 
   # Source URL refreshed into the cache on opt-in
   data_url: "https://cursor.com/cursorbench"

--- a/src/skills/issue-creator/SKILL.source.md
+++ b/src/skills/issue-creator/SKILL.source.md
@@ -86,13 +86,13 @@ Load `.gitissue.yml` from the repo root once at skill start. If the file does no
 ○ First run — using default config. Run /init-gitissue to customize.
 ```
 
-Defaults: `issue.auto_normalize: true`, `issue.template: "default"`, `issue.labels_auto_suggest: true`, `issue.normalize_comment: true`, `model_suggestion.enabled: false`
+Defaults: `issue.auto_normalize: true`, `issue.template: "default"`, `issue.labels_auto_suggest: true`, `issue.normalize_comment: true`, `model_suggestion.enabled: true`
 
 If the config file exists but contains invalid values, output the validation error from `references/error-messages.md` and stop.
 
 Do not re-read the config at each step.
 
-If `model_suggestion.enabled` is `true`, run the model-data cache lifecycle (check / seed / staleness-refresh) once now, before Step 1 — see `references/model-suggestion.md`. When `false` (default), skip all model-suggestion steps silently.
+If `model_suggestion.enabled` is `true` (the default), run the model-data cache lifecycle (check / seed / staleness-refresh) once now, before Step 1 — see `references/model-suggestion.md`. When `false`, skip all model-suggestion steps silently.
 
 ## Subagent Architecture
 
@@ -348,7 +348,7 @@ Read the appropriate template from `templates/` (bug.md, feature.md, or improvem
 3. **Reporter Context** — user's original text, verbatim, in a blockquote
 4. **Screenshots** — embedded images (only if images were provided and uploaded successfully)
 5. **Acceptance Criteria** — 3-5 testable criteria derived from the problem description, with confidence levels
-6. **Metadata** — suggested priority, estimated effort (XS/S/M/L/XL), suggested labels, and an advisory **Suggested model:** line keyed off the effort band — see `references/model-suggestion.md`. When `model_suggestion.enabled` is false (the default), remove the `**Suggested model:**` line from the Metadata section entirely, matching pre-feature behaviour.
+6. **Metadata** — suggested priority, estimated effort (XS/S/M/L/XL), suggested labels, and an advisory **Suggested model:** line keyed off the effort band — see `references/model-suggestion.md`. When `model_suggestion.enabled` is false, remove the `**Suggested model:**` line from the Metadata section entirely, matching pre-feature behaviour.
 
 **Note:** Per the Output Contract above, the issue body MUST NOT include predicted affected files, generated technical notes, root cause, or implementation hints. Acceptance criteria express *what done looks like*, not *how to implement it*.
 

--- a/src/skills/issue-creator/references/model-suggestion.md
+++ b/src/skills/issue-creator/references/model-suggestion.md
@@ -1,9 +1,9 @@
 # Model Suggestion — Reference
 
 How `/issue-creator` suggests a cost-effective model + thinking level for each
-issue, and how it manages the local CursorBench data cache. This procedure is
-**optional** and runs only when `model_suggestion.enabled` is `true` in
-`.gitissue.yml` (default: `false`). When disabled, every step here is skipped
+issue, and how it manages the local CursorBench data cache. This procedure
+runs when `model_suggestion.enabled` is `true` in `.gitissue.yml`
+(default: `true`). When disabled, every step here is skipped
 silently — issue creation behaves exactly as before.
 
 The suggestion is **advisory metadata**, like priority and effort. It never
@@ -165,7 +165,7 @@ changes from the pre-feature behaviour.
 # Suggest a cost-effective model + thinking level per issue (CursorBench data)
 model_suggestion:
   # Master switch. When false, all model-suggestion behaviour is skipped.
-  enabled: false
+  enabled: true
   # Source URL refreshed into .gitissue/model-data.json
   data_url: "https://cursor.com/cursorbench"
   # Days before the cache is considered stale

--- a/tests/test-model-suggestion-117.sh
+++ b/tests/test-model-suggestion-117.sh
@@ -163,8 +163,8 @@ else
   fail "T5.AC7.2: Config Section Map missing model_suggestion"
 fi
 # Defaults table
-if grep -qE '\| \`model_suggestion\.enabled\` \| \`false\`' "$SCHEMA"; then
-  pass "T5.AC7.3: defaults table lists model_suggestion.enabled = false"
+if grep -qE '\| \`model_suggestion\.enabled\` \| \`true\`' "$SCHEMA"; then
+  pass "T5.AC7.3: defaults table lists model_suggestion.enabled = true"
 else
   fail "T5.AC7.3: defaults table missing model_suggestion.enabled"
 fi
@@ -199,11 +199,11 @@ else
   fail "T6.3: error catalog missing model-data failure entries"
 fi
 
-# Default-off: feature must be opt-in (projects-style toggle)
-if grep -qE '^\s*enabled:\s*false' "$INIT_TEMPLATE"; then
-  pass "T6.4: model_suggestion defaults to disabled (opt-in)"
+# Default-on: feature is enabled by default (opt-out toggle)
+if grep -qE '^\s*enabled:\s*true' "$INIT_TEMPLATE"; then
+  pass "T6.4: model_suggestion defaults to enabled (opt-out)"
 else
-  fail "T6.4: model_suggestion not default-disabled"
+  fail "T6.4: model_suggestion not default-enabled"
 fi
 
 # ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Flips `model_suggestion.enabled` from `false` (opt-in) to `true` (opt-out). Per-issue model suggestions — the advisory **Suggested model:** line and the `⚡ Model:` preview, keyed off the effort band from CursorBench data — now render by default.

The feature was fully built but disabled by default; this makes it active out of the box. It remains non-blocking: any fetch/cache/parse failure degrades to a warning, and auto-pilot (`IDD_AUTO_MODE=1`) never prompts.

## Changes

**Default flip (source of truth):**
- `src/skills/issue-creator/SKILL.source.md` — defaults line + two prose statements that called `false` "the default"
- `src/skills/issue-creator/references/model-suggestion.md` — header prose + example config block
- `src/skills/init-gitissue/templates/gitissue-template.yml` — what `/init-gitissue` scaffolds
- `docs/config-schema.md` — inline `# Default:`, example value, and defaults table

**This repo:** `.gitissue.yml` set to `enabled: true` so it dogfoods the feature.

**Tests:** `tests/test-model-suggestion-117.sh` T5.AC7.3 and T6.4 reversed from default-off/opt-in to default-on/opt-out. All 33 tests pass.

**Rebuilt:** `./scripts/build.sh` regenerated the committed `skills/` tree (config-schema.md propagated into all 6 skill mirrors).

**Unchanged (correct):** `error-messages.md` tips that say "set `model_suggestion.enabled: false` to disable" — still accurate as disable instructions.

## Test plan

- [x] `bash tests/test-model-suggestion-117.sh` — 33 passed, 0 failed
- [x] Build is deterministic; seed propagates into built templates