### PR TITLE
feat(issue-resolver): offer interactive worktree resolution (#123)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+- `feat(issue-resolver)` Interactive runs now offer to resolve the issue in an isolated git **worktree** instead of the current working tree. On accept, the resolver creates the branch + worktree in one `git worktree add -b` off a freshly fetched base (replacing the in-place stash-first sync and branch creation), copies the repo's gitignored local config (`.env*` and similar), and runs the project's detected install/bootstrap so the workspace is ready to run without manual reconfiguration. Declining keeps today's in-place behavior unchanged, and auto-pilot / `IDD_AUTO_MODE=1` never shows the prompt. Worktree creation failures fall back to the in-place path. Skill bumped 0.8.0 → 0.9.0. (#123)
+
 ### Changed
 - `feat(issue-creator)` Model-suggestion cache moved from per-repo `.gitissue/model-data.json` to a **skill-level** dated cache (`model-data-<date>.json` in the installed skill folder), so one cache serves every repo on the machine — no more re-seeding per project. The filename carries the last-update date for at-a-glance staleness, and `--refresh-model-data` forces a refresh on demand regardless of the staleness threshold. A legacy per-repo `.gitissue/model-data.json` is ignored and may be deleted. (#124)
 

--- a/skills/issue-resolver/SKILL.md
+++ b/skills/issue-resolver/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Requires git and GitHub CLI (gh) with authentication and push access. Self-contained — uses shared agents from shared/agents/."
 effort: max
 metadata:
-  version: 0.8.0
+  version: 0.9.0
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -32,6 +32,8 @@ Before any operation, verify the environment. On failure, output the exact error
 4. Confirm GitHub remote exists: `git remote -v`
 
 ## Repo Sync Before Edits (mandatory)
+
+This applies to the **in-place path** (auto mode, or interactive when the user declines the worktree offer in Step 0e). On the **worktree path** the sync is unnecessary — `git worktree add` branches from a freshly fetched `origin/<base>`, so the new workspace already starts current (see Step 0e and `references/pipeline-steps.md`).
 
 Before making file modifications, sync with remote using the stash-first pattern (see `references/docs/sync-conventions.md` for the full convention and recovery procedure):
 
@@ -223,7 +225,60 @@ If `issue.auto_normalize` is true and the issue is not already normalized (no `<
 
 If normalization fails, warn and continue with original body.
 
-### 0e — Create branch
+### 0e — Workspace (interactive only)
+
+Decide *where* the resolution work happens. The branch name is the same in both
+cases: `{type}/{N}-{short-description}` (see `references/docs/naming-conventions.md`).
+
+**Auto mode (`--auto` / `IDD_AUTO_MODE=1`): skip this offer entirely.** Go
+straight to *0f — Create branch* (in-place). The worktree prompt never appears
+in auto mode (acceptance criterion 4).
+
+**Interactive mode:** offer to run the resolution in a dedicated git *worktree*
+— an isolated checkout in a separate directory — so branch creation,
+implementation, and testing never touch the user's current working tree. State
+plainly what will be set up and the workspace/branch naming the user can expect:
+
+```
+◆ Workspace for issue #N
+┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+
+  This resolution can run in an isolated git worktree instead of your
+  current working tree.
+
+    Branch:    {type}/{N}-{short-description}
+    Worktree:  ../{repo}-worktrees/{type}-{N}-{short-description}
+    Setup:     copies your gitignored local config (.env*, and similar),
+               then runs this project's detected install/bootstrap so the
+               workspace is ready to run without manual reconfiguration.
+
+  Accepting keeps your current working tree untouched. Declining uses the
+  current working tree with the existing sync and branch behavior.
+
+  Resolve in a new worktree? [Y/n]
+```
+
+- **Accept (default):** create the worktree and prepare it, then continue the
+  pipeline from inside it. This **replaces** *0f — Create branch* and the
+  mandatory Repo Sync (the worktree branches from a freshly fetched
+  `origin/<base>`, so it starts current). Full procedure — creation commands,
+  generic setup-artifact propagation, and cleanup guidance — is in
+  `references/pipeline-steps.md` (*Step 0e — Workspace*).
+- **Decline:** proceed in the current working tree exactly as today — run the
+  mandatory Repo Sync, then *0f — Create branch*. No behavior change.
+
+If worktree creation fails, warn and fall back to the in-place path (see
+`references/error-messages.md` → *Worktree creation failed*). If setup fails
+after the worktree was created, first remove that partial worktree (and delete
+only a branch created by this step), then fall back to the in-place path (see
+`references/error-messages.md` → *Worktree setup failed*). Never leave the user
+without a working resolution.
+
+### 0f — Create branch
+
+This is the **in-place path** — used in auto mode, and in interactive mode when
+the user declined the worktree offer. (On the accepted-worktree path the branch
+was already created by `git worktree add -b` in 0e; skip this sub-step.)
 
 Create working branch: `{type}/{N}-{short-description}` (see `references/docs/naming-conventions.md`).
 
@@ -233,8 +288,11 @@ Create working branch: `{type}/{N}-{short-description}` (see `references/docs/na
 
 After preflight:
 ```
-[0/5] Preflight    ✓ issue #N open, branch: {branch_name}
+[0/5] Preflight    ✓ issue #N open, branch: {branch_name}{workspace_note}
 ```
+
+where `{workspace_note}` is ` (worktree)` when the resolution is running in a
+worktree, and empty otherwise.
 
 ---
 

--- a/skills/issue-resolver/references/error-messages.md
+++ b/skills/issue-resolver/references/error-messages.md
@@ -82,15 +82,18 @@ All errors follow the rich error format: what went wrong + fix command + docs li
 
 ### Branch already exists
 ```
-⚠ Branch issue-N/{description} already exists
+⚠ Branch {branch} already exists
+
+  You were creating a worktree for issue #{N}.
 
   Options:
-    continue  — resume from existing branch
-    fresh     — delete and start fresh
+    continue  — attach a new worktree to the existing branch
+              (git worktree add "{wt_dir}" "{branch}")
+    fresh     — delete the branch, then retry git worktree add -b
 
   Choose: [continue/fresh]
 ```
-**Trigger:** `git checkout -b {branch_name}` fails because the branch already exists.
+**Trigger:** `git worktree add -b {branch} {wt_dir}` fails because the branch already exists (Step 0e). On `continue`, set `created_branch_in_step_0e=0` and run `git worktree add "$wt_dir" "$branch"`. On `fresh`, delete the branch, keep `created_branch_in_step_0e=1`, and retry creation. The in-place *0f — Create branch* flow uses the same `continue`/`fresh` wording but runs `git checkout {branch}` or `git branch -D` + `git checkout -b` instead of worktree commands.
 
 ### Worktree creation failed
 ```

--- a/skills/issue-resolver/references/error-messages.md
+++ b/skills/issue-resolver/references/error-messages.md
@@ -80,7 +80,7 @@ All errors follow the rich error format: what went wrong + fix command + docs li
 
 ## Branch
 
-### Branch already exists
+### Branch already exists (worktree path — Step 0e)
 ```
 ⚠ Branch {branch} already exists
 
@@ -93,7 +93,19 @@ All errors follow the rich error format: what went wrong + fix command + docs li
 
   Choose: [continue/fresh]
 ```
-**Trigger:** `git worktree add -b {branch} {wt_dir}` fails because the branch already exists (Step 0e). On `continue`, set `created_branch_in_step_0e=0` and run `git worktree add "$wt_dir" "$branch"`. On `fresh`, delete the branch, keep `created_branch_in_step_0e=1`, and retry creation. The in-place *0f — Create branch* flow uses the same `continue`/`fresh` wording but runs `git checkout {branch}` or `git branch -D` + `git checkout -b` instead of worktree commands.
+**Trigger:** `git worktree add -b {branch} {wt_dir}` fails because the branch already exists (Step 0e). On `continue`, set `created_branch_in_step_0e=0` and run `git worktree add "$wt_dir" "$branch"`. On `fresh`, delete the branch, keep `created_branch_in_step_0e=1`, and retry creation.
+
+### Branch already exists (in-place path — Step 0f)
+```
+⚠ Branch {branch} already exists
+
+  Options:
+    continue  — check out the existing branch in this working tree
+    fresh     — delete the branch and create it again from {base_branch}
+
+  Choose: [continue/fresh]
+```
+**Trigger:** `git checkout -b {branch}` fails because the branch already exists (Step 0f, in-place path). On `continue`, run `git checkout {branch}`. On `fresh`, run `git branch -D {branch}` then `git checkout -b {branch}`.
 
 ### Worktree creation failed
 ```

--- a/skills/issue-resolver/references/error-messages.md
+++ b/skills/issue-resolver/references/error-messages.md
@@ -92,6 +92,26 @@ All errors follow the rich error format: what went wrong + fix command + docs li
 ```
 **Trigger:** `git checkout -b {branch_name}` fails because the branch already exists.
 
+### Worktree creation failed
+```
+⚠ Could not create the worktree at {wt_dir}
+
+  Falling back to resolving in the current working tree.
+  To clean up stale worktrees:  git worktree prune
+```
+**Trigger:** `git worktree add` fails for a reason other than an existing branch (path already occupied, locked worktree, disk error). Non-fatal — the resolver continues on the in-place path (Repo Sync + branch creation). Interactive only; the worktree offer never runs in auto mode.
+
+### Worktree setup failed
+```
+⚠ Worktree setup failed at {wt_dir}
+
+  Cleaning up the partial worktree, then falling back to resolving in the
+  current working tree.
+  Recover manually:  git worktree list && git worktree remove {wt_dir}
+                    git worktree prune
+```
+**Trigger:** local setup preparation fails after the worktree was created (copy error, dependency install failure, bootstrap failure). The resolver removes the partial worktree, deletes only a branch created by this Step 0e, then continues on the in-place path. If cleanup fails, stop and ask the user to run the recovery commands.
+
 ## Verify
 
 ### Tests failed

--- a/skills/issue-resolver/references/pipeline-steps.md
+++ b/skills/issue-resolver/references/pipeline-steps.md
@@ -54,7 +54,7 @@ git worktree add -b "$branch" "$wt_dir" "origin/${base}"
 Keep `repo_root` and `wt_dir` available for the setup step below (both are
 absolute, so the copy works regardless of the current directory).
 
-**If the branch already exists** (`git worktree add -b` fails): in interactive mode ask `continue` (set `created_branch_in_step_0e=0`, then add a worktree for the existing branch with `git worktree add "$wt_dir" "$branch"`) or `fresh` (delete the branch, keep `created_branch_in_step_0e=1`, then retry). See `references/error-messages.md` → *Branch already exists*.
+**If the branch already exists** (`git worktree add -b` fails): in interactive mode ask `continue` (set `created_branch_in_step_0e=0`, then add a worktree for the existing branch with `git worktree add "$wt_dir" "$branch"`) or `fresh` (delete the branch, keep `created_branch_in_step_0e=1`, then retry). See `references/error-messages.md` → *Branch already exists (worktree path — Step 0e)*.
 
 **If worktree creation fails for any other reason** (e.g. path exists, disk, locked worktree): warn, print the message from `references/error-messages.md` → *Worktree creation failed*, and **fall back to the in-place path** (Repo Sync + *0f — Create branch*). Never abort the resolution just because the worktree could not be made.
 

--- a/skills/issue-resolver/references/pipeline-steps.md
+++ b/skills/issue-resolver/references/pipeline-steps.md
@@ -2,6 +2,116 @@
 
 Detailed procedures for each subagent delegation in the resolve pipeline. SKILL.md keeps the contract short; this file holds the full input/output spec and inline fallback instructions.
 
+## Step 0e — Workspace (interactive only)
+
+Full procedure for the worktree offer described in SKILL.md *Step 0e — Workspace*. **Interactive mode only** — in auto mode (`--auto` / `IDD_AUTO_MODE=1`) this entire step is skipped and the pipeline uses the in-place path (Repo Sync + *0f — Create branch*), byte-for-byte as before. The worktree prompt never appears in auto mode (acceptance criterion 4).
+
+### Why a worktree
+
+`git worktree` checks out a branch into a *separate directory* that shares the same `.git` object store. The user's current working tree — including any uncommitted changes — is never modified. Branch creation, implementation, and the QA test runs all happen in the isolated directory.
+
+### The offer
+
+Present the prompt from SKILL.md (*Step 0e — Workspace*). It must state, before the user answers:
+
+- the **branch** name (`{type}/{N}-{short-description}`),
+- the **worktree path** (the naming convention below), and
+- what **setup** will be copied/run (gitignored local config + the project's detected install/bootstrap).
+
+Default is **accept** (`[Y/n]`). This satisfies acceptance criterion 5 (the proposal states what is copied and the workspace/branch naming).
+
+### Naming convention
+
+- **Branch:** `{type}/{N}-{short-description}` — identical to the in-place path (`references/docs/naming-conventions.md`). Unchanged so traceability and the `feat/`, `fix/`, … prefixes stay consistent.
+- **Worktree directory:** a *sibling* of the repo root, derived from the branch with `/` → `-` so it is a single path segment:
+
+  ```
+  ../{repo}-worktrees/{type}-{N}-{short-description}
+  ```
+
+  Example: repo `idd`, branch `feat/123-resolver-worktree-prompt` → `../idd-worktrees/feat-123-resolver-worktree-prompt`.
+
+  A sibling directory (outside the repo) keeps the worktree out of the repo's own status and ignore rules. If you instead place it *inside* the repo, the path **must** already be covered by `.gitignore` — otherwise the worktree's own files surface as untracked changes in the parent. Prefer the sibling location.
+
+### Create the worktree
+
+`git worktree add -b` creates the branch **and** the workspace in one command, off a freshly fetched base — so this replaces both the mandatory Repo Sync and *0f — Create branch* on the accepted path. No `git pull --rebase` / stash dance is needed (the new branch starts at `origin/<base>` directly).
+
+```bash
+repo_root="$(git rev-parse --show-toplevel)"        # absolute path to the repo
+base="$(git rev-parse --abbrev-ref HEAD)"           # base branch to fork from
+repo="$(basename "$repo_root")"
+branch="{type}/{N}-{short-description}"
+# Absolute worktree path (sibling of the repo) — independent of the current
+# directory, so later steps that `cd` into it stay correct.
+wt_dir="$(dirname "$repo_root")/${repo}-worktrees/$(printf '%s' "$branch" | tr '/' '-')"
+
+git fetch origin
+created_branch_in_step_0e=1
+git worktree add -b "$branch" "$wt_dir" "origin/${base}"
+```
+
+Keep `repo_root` and `wt_dir` available for the setup step below (both are
+absolute, so the copy works regardless of the current directory).
+
+**If the branch already exists** (`git worktree add -b` fails): in interactive mode ask `continue` (set `created_branch_in_step_0e=0`, then add a worktree for the existing branch with `git worktree add "$wt_dir" "$branch"`) or `fresh` (delete the branch, keep `created_branch_in_step_0e=1`, then retry). See `references/error-messages.md` → *Branch already exists*.
+
+**If worktree creation fails for any other reason** (e.g. path exists, disk, locked worktree): warn, print the message from `references/error-messages.md` → *Worktree creation failed*, and **fall back to the in-place path** (Repo Sync + *0f — Create branch*). Never abort the resolution just because the worktree could not be made.
+
+After creation, **change into the worktree** so every subsequent step (research, implement, QA, deliver) operates there:
+
+```bash
+cd "$wt_dir"
+```
+
+### Prepare the workspace (generic — discovered, not hardcoded)
+
+The goal: the worktree can build and run immediately, without the user reconfiguring it. A fresh worktree shares git history but **not** gitignored files (local config) or installed dependencies. Reconstruct them **by detecting what this repo uses** — do not assume any specific stack:
+
+1. **Copy gitignored local config** from the original working tree into the worktree. These are the files git does not track but the app needs at runtime — typically environment files. Copy what exists; skip silently what does not:
+
+   ```bash
+   # Absolute paths from the creation block — works from any directory, so this
+   # does not depend on a prior `cd` or on shell state carrying across steps.
+   for f in .env .env.local .env.development .env.test; do
+     [ -f "$repo_root/$f" ] && cp "$repo_root/$f" "$wt_dir/$f"
+   done
+   ```
+
+   If the repo keeps other gitignored local config (service-account JSON, local certs, a `config.local.*`), copy those too. Use the repo's `.gitignore` as the guide for what is local-only. **Never copy secrets anywhere outside the worktree, and never commit them** — the pre-commit security scan (`references/docs/pre-commit-security.md`) still blocks secret-bearing files on push.
+
+2. **Install dependencies** using the project's **detected** package manager — the same detection the researcher/implementer rely on. Examples (pick the one matching the repo, do not run all): `npm ci` / `pnpm install` / `yarn` (Node), `pip install -r requirements.txt` or `uv sync` inside the project venv (Python), `bundle install` (Ruby), `go mod download` (Go), `cargo fetch` (Rust). If the repo has no dependency manifest, skip this step.
+
+3. **Run project bootstrap** if the repo defines one — e.g. a `Makefile` `setup`/`bootstrap` target, a `scripts/setup.sh`, a documented "getting started" command, or generated files (`prisma generate`, etc.). Skip if none exists.
+
+Report what was prepared, e.g. `✓ Worktree ready — copied .env, ran npm ci`. Keep it factual: list only what actually ran.
+
+**If setup fails after the worktree was created** (copy error, dependency install failure, bootstrap failure): warn, print the message from `references/error-messages.md` → *Worktree setup failed*, then clean up the partial workspace before falling back to the in-place path. This avoids stranding the resolver on a branch that is already checked out in the failed worktree.
+
+```bash
+cd "$repo_root"
+git worktree remove "$wt_dir" --force 2>/dev/null || git worktree prune
+# Delete the branch only if this Step 0e created it with `git worktree add -b`.
+# If the user chose to continue an existing branch, keep the branch and let 0f's
+# existing branch flow handle it.
+if [ "${created_branch_in_step_0e:-0}" = "1" ]; then
+  git branch -D "$branch" 2>/dev/null || true
+fi
+```
+
+After cleanup, run the mandatory Repo Sync and *0f — Create branch* in the original working tree. If cleanup itself fails, stop and tell the user how to recover with `git worktree list`, `git worktree remove {wt_dir}`, and `git worktree prune` rather than attempting to use two checked-out copies of the same branch.
+
+### Cleanup (after delivery, interactive only)
+
+The worktree is intentionally left in place after the PR is created so the user can inspect it. Tell them how to remove it when done:
+
+```
+○ Worktree left at {wt_dir} for inspection.
+  Remove with:  git worktree remove {wt_dir}
+```
+
+Do not auto-remove it — the user may still want the local artifacts.
+
 ## Step 1 — Research (codebase-researcher subagent)
 
 ### Delegation payload

--- a/skills/issue-resolver/references/pipeline-steps.md
+++ b/skills/issue-resolver/references/pipeline-steps.md
@@ -90,7 +90,23 @@ Report what was prepared, e.g. `✓ Worktree ready — copied .env, ran npm ci`.
 
 ```bash
 cd "$repo_root"
-git worktree remove "$wt_dir" --force 2>/dev/null || git worktree prune
+cleanup_ok=1
+git worktree remove "$wt_dir" --force 2>/dev/null || cleanup_ok=0
+if [ "$cleanup_ok" -eq 1 ] && git worktree list --porcelain | grep -q "worktree $wt_dir$"; then
+  cleanup_ok=0
+fi
+if [ "$cleanup_ok" -eq 0 ]; then
+  git worktree prune 2>/dev/null || true
+  if git worktree list --porcelain | grep -q "worktree $wt_dir$"; then
+    cleanup_ok=0
+  else
+    cleanup_ok=1
+  fi
+fi
+if [ "$cleanup_ok" -eq 0 ]; then
+  # Do not fall back in-place while the branch is still checked out in the failed worktree.
+  stop with *Worktree setup failed* recovery commands and exit the resolution attempt.
+fi
 # Delete the branch only if this Step 0e created it with `git worktree add -b`.
 # If the user chose to continue an existing branch, keep the branch and let 0f's
 # existing branch flow handle it.
@@ -99,7 +115,7 @@ if [ "${created_branch_in_step_0e:-0}" = "1" ]; then
 fi
 ```
 
-After cleanup, run the mandatory Repo Sync and *0f — Create branch* in the original working tree. If cleanup itself fails, stop and tell the user how to recover with `git worktree list`, `git worktree remove {wt_dir}`, and `git worktree prune` rather than attempting to use two checked-out copies of the same branch.
+After **verified** cleanup (`cleanup_ok=1`), run the mandatory Repo Sync and *0f — Create branch* in the original working tree. If cleanup cannot remove the worktree entry, **stop** — print `references/error-messages.md` → *Worktree setup failed* and do not attempt the in-place path while the same branch may still be checked out in `{wt_dir}`.
 
 ### Cleanup (after delivery, interactive only)
 

--- a/src/skills/issue-resolver/SKILL.source.md
+++ b/src/skills/issue-resolver/SKILL.source.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Requires git and GitHub CLI (gh) with authentication and push access. Self-contained — uses shared agents from shared/agents/."
 effort: max
 metadata:
-  version: 0.8.0
+  version: 0.9.0
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -32,6 +32,8 @@ Before any operation, verify the environment. On failure, output the exact error
 4. Confirm GitHub remote exists: `git remote -v`
 
 ## Repo Sync Before Edits (mandatory)
+
+This applies to the **in-place path** (auto mode, or interactive when the user declines the worktree offer in Step 0e). On the **worktree path** the sync is unnecessary — `git worktree add` branches from a freshly fetched `origin/<base>`, so the new workspace already starts current (see Step 0e and `references/pipeline-steps.md`).
 
 Before making file modifications, sync with remote using the stash-first pattern (see `docs/sync-conventions.md` for the full convention and recovery procedure):
 
@@ -223,7 +225,60 @@ If `issue.auto_normalize` is true and the issue is not already normalized (no `<
 
 If normalization fails, warn and continue with original body.
 
-### 0e — Create branch
+### 0e — Workspace (interactive only)
+
+Decide *where* the resolution work happens. The branch name is the same in both
+cases: `{type}/{N}-{short-description}` (see `docs/naming-conventions.md`).
+
+**Auto mode (`--auto` / `IDD_AUTO_MODE=1`): skip this offer entirely.** Go
+straight to *0f — Create branch* (in-place). The worktree prompt never appears
+in auto mode (acceptance criterion 4).
+
+**Interactive mode:** offer to run the resolution in a dedicated git *worktree*
+— an isolated checkout in a separate directory — so branch creation,
+implementation, and testing never touch the user's current working tree. State
+plainly what will be set up and the workspace/branch naming the user can expect:
+
+```
+◆ Workspace for issue #N
+┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+
+  This resolution can run in an isolated git worktree instead of your
+  current working tree.
+
+    Branch:    {type}/{N}-{short-description}
+    Worktree:  ../{repo}-worktrees/{type}-{N}-{short-description}
+    Setup:     copies your gitignored local config (.env*, and similar),
+               then runs this project's detected install/bootstrap so the
+               workspace is ready to run without manual reconfiguration.
+
+  Accepting keeps your current working tree untouched. Declining uses the
+  current working tree with the existing sync and branch behavior.
+
+  Resolve in a new worktree? [Y/n]
+```
+
+- **Accept (default):** create the worktree and prepare it, then continue the
+  pipeline from inside it. This **replaces** *0f — Create branch* and the
+  mandatory Repo Sync (the worktree branches from a freshly fetched
+  `origin/<base>`, so it starts current). Full procedure — creation commands,
+  generic setup-artifact propagation, and cleanup guidance — is in
+  `references/pipeline-steps.md` (*Step 0e — Workspace*).
+- **Decline:** proceed in the current working tree exactly as today — run the
+  mandatory Repo Sync, then *0f — Create branch*. No behavior change.
+
+If worktree creation fails, warn and fall back to the in-place path (see
+`references/error-messages.md` → *Worktree creation failed*). If setup fails
+after the worktree was created, first remove that partial worktree (and delete
+only a branch created by this step), then fall back to the in-place path (see
+`references/error-messages.md` → *Worktree setup failed*). Never leave the user
+without a working resolution.
+
+### 0f — Create branch
+
+This is the **in-place path** — used in auto mode, and in interactive mode when
+the user declined the worktree offer. (On the accepted-worktree path the branch
+was already created by `git worktree add -b` in 0e; skip this sub-step.)
 
 Create working branch: `{type}/{N}-{short-description}` (see `docs/naming-conventions.md`).
 
@@ -233,8 +288,11 @@ Create working branch: `{type}/{N}-{short-description}` (see `docs/naming-conven
 
 After preflight:
 ```
-[0/5] Preflight    ✓ issue #N open, branch: {branch_name}
+[0/5] Preflight    ✓ issue #N open, branch: {branch_name}{workspace_note}
 ```
+
+where `{workspace_note}` is ` (worktree)` when the resolution is running in a
+worktree, and empty otherwise.
 
 ---
 

--- a/src/skills/issue-resolver/references/error-messages.md
+++ b/src/skills/issue-resolver/references/error-messages.md
@@ -82,15 +82,18 @@ All errors follow the rich error format: what went wrong + fix command + docs li
 
 ### Branch already exists
 ```
-⚠ Branch issue-N/{description} already exists
+⚠ Branch {branch} already exists
+
+  You were creating a worktree for issue #{N}.
 
   Options:
-    continue  — resume from existing branch
-    fresh     — delete and start fresh
+    continue  — attach a new worktree to the existing branch
+              (git worktree add "{wt_dir}" "{branch}")
+    fresh     — delete the branch, then retry git worktree add -b
 
   Choose: [continue/fresh]
 ```
-**Trigger:** `git checkout -b {branch_name}` fails because the branch already exists.
+**Trigger:** `git worktree add -b {branch} {wt_dir}` fails because the branch already exists (Step 0e). On `continue`, set `created_branch_in_step_0e=0` and run `git worktree add "$wt_dir" "$branch"`. On `fresh`, delete the branch, keep `created_branch_in_step_0e=1`, and retry creation. The in-place *0f — Create branch* flow uses the same `continue`/`fresh` wording but runs `git checkout {branch}` or `git branch -D` + `git checkout -b` instead of worktree commands.
 
 ### Worktree creation failed
 ```

--- a/src/skills/issue-resolver/references/error-messages.md
+++ b/src/skills/issue-resolver/references/error-messages.md
@@ -80,7 +80,7 @@ All errors follow the rich error format: what went wrong + fix command + docs li
 
 ## Branch
 
-### Branch already exists
+### Branch already exists (worktree path — Step 0e)
 ```
 ⚠ Branch {branch} already exists
 
@@ -93,7 +93,19 @@ All errors follow the rich error format: what went wrong + fix command + docs li
 
   Choose: [continue/fresh]
 ```
-**Trigger:** `git worktree add -b {branch} {wt_dir}` fails because the branch already exists (Step 0e). On `continue`, set `created_branch_in_step_0e=0` and run `git worktree add "$wt_dir" "$branch"`. On `fresh`, delete the branch, keep `created_branch_in_step_0e=1`, and retry creation. The in-place *0f — Create branch* flow uses the same `continue`/`fresh` wording but runs `git checkout {branch}` or `git branch -D` + `git checkout -b` instead of worktree commands.
+**Trigger:** `git worktree add -b {branch} {wt_dir}` fails because the branch already exists (Step 0e). On `continue`, set `created_branch_in_step_0e=0` and run `git worktree add "$wt_dir" "$branch"`. On `fresh`, delete the branch, keep `created_branch_in_step_0e=1`, and retry creation.
+
+### Branch already exists (in-place path — Step 0f)
+```
+⚠ Branch {branch} already exists
+
+  Options:
+    continue  — check out the existing branch in this working tree
+    fresh     — delete the branch and create it again from {base_branch}
+
+  Choose: [continue/fresh]
+```
+**Trigger:** `git checkout -b {branch}` fails because the branch already exists (Step 0f, in-place path). On `continue`, run `git checkout {branch}`. On `fresh`, run `git branch -D {branch}` then `git checkout -b {branch}`.
 
 ### Worktree creation failed
 ```

--- a/src/skills/issue-resolver/references/error-messages.md
+++ b/src/skills/issue-resolver/references/error-messages.md
@@ -92,6 +92,26 @@ All errors follow the rich error format: what went wrong + fix command + docs li
 ```
 **Trigger:** `git checkout -b {branch_name}` fails because the branch already exists.
 
+### Worktree creation failed
+```
+⚠ Could not create the worktree at {wt_dir}
+
+  Falling back to resolving in the current working tree.
+  To clean up stale worktrees:  git worktree prune
+```
+**Trigger:** `git worktree add` fails for a reason other than an existing branch (path already occupied, locked worktree, disk error). Non-fatal — the resolver continues on the in-place path (Repo Sync + branch creation). Interactive only; the worktree offer never runs in auto mode.
+
+### Worktree setup failed
+```
+⚠ Worktree setup failed at {wt_dir}
+
+  Cleaning up the partial worktree, then falling back to resolving in the
+  current working tree.
+  Recover manually:  git worktree list && git worktree remove {wt_dir}
+                    git worktree prune
+```
+**Trigger:** local setup preparation fails after the worktree was created (copy error, dependency install failure, bootstrap failure). The resolver removes the partial worktree, deletes only a branch created by this Step 0e, then continues on the in-place path. If cleanup fails, stop and ask the user to run the recovery commands.
+
 ## Verify
 
 ### Tests failed

--- a/src/skills/issue-resolver/references/pipeline-steps.md
+++ b/src/skills/issue-resolver/references/pipeline-steps.md
@@ -54,7 +54,7 @@ git worktree add -b "$branch" "$wt_dir" "origin/${base}"
 Keep `repo_root` and `wt_dir` available for the setup step below (both are
 absolute, so the copy works regardless of the current directory).
 
-**If the branch already exists** (`git worktree add -b` fails): in interactive mode ask `continue` (set `created_branch_in_step_0e=0`, then add a worktree for the existing branch with `git worktree add "$wt_dir" "$branch"`) or `fresh` (delete the branch, keep `created_branch_in_step_0e=1`, then retry). See `references/error-messages.md` → *Branch already exists*.
+**If the branch already exists** (`git worktree add -b` fails): in interactive mode ask `continue` (set `created_branch_in_step_0e=0`, then add a worktree for the existing branch with `git worktree add "$wt_dir" "$branch"`) or `fresh` (delete the branch, keep `created_branch_in_step_0e=1`, then retry). See `references/error-messages.md` → *Branch already exists (worktree path — Step 0e)*.
 
 **If worktree creation fails for any other reason** (e.g. path exists, disk, locked worktree): warn, print the message from `references/error-messages.md` → *Worktree creation failed*, and **fall back to the in-place path** (Repo Sync + *0f — Create branch*). Never abort the resolution just because the worktree could not be made.
 

--- a/src/skills/issue-resolver/references/pipeline-steps.md
+++ b/src/skills/issue-resolver/references/pipeline-steps.md
@@ -2,6 +2,116 @@
 
 Detailed procedures for each subagent delegation in the resolve pipeline. SKILL.md keeps the contract short; this file holds the full input/output spec and inline fallback instructions.
 
+## Step 0e — Workspace (interactive only)
+
+Full procedure for the worktree offer described in SKILL.md *Step 0e — Workspace*. **Interactive mode only** — in auto mode (`--auto` / `IDD_AUTO_MODE=1`) this entire step is skipped and the pipeline uses the in-place path (Repo Sync + *0f — Create branch*), byte-for-byte as before. The worktree prompt never appears in auto mode (acceptance criterion 4).
+
+### Why a worktree
+
+`git worktree` checks out a branch into a *separate directory* that shares the same `.git` object store. The user's current working tree — including any uncommitted changes — is never modified. Branch creation, implementation, and the QA test runs all happen in the isolated directory.
+
+### The offer
+
+Present the prompt from SKILL.md (*Step 0e — Workspace*). It must state, before the user answers:
+
+- the **branch** name (`{type}/{N}-{short-description}`),
+- the **worktree path** (the naming convention below), and
+- what **setup** will be copied/run (gitignored local config + the project's detected install/bootstrap).
+
+Default is **accept** (`[Y/n]`). This satisfies acceptance criterion 5 (the proposal states what is copied and the workspace/branch naming).
+
+### Naming convention
+
+- **Branch:** `{type}/{N}-{short-description}` — identical to the in-place path (`docs/naming-conventions.md`). Unchanged so traceability and the `feat/`, `fix/`, … prefixes stay consistent.
+- **Worktree directory:** a *sibling* of the repo root, derived from the branch with `/` → `-` so it is a single path segment:
+
+  ```
+  ../{repo}-worktrees/{type}-{N}-{short-description}
+  ```
+
+  Example: repo `idd`, branch `feat/123-resolver-worktree-prompt` → `../idd-worktrees/feat-123-resolver-worktree-prompt`.
+
+  A sibling directory (outside the repo) keeps the worktree out of the repo's own status and ignore rules. If you instead place it *inside* the repo, the path **must** already be covered by `.gitignore` — otherwise the worktree's own files surface as untracked changes in the parent. Prefer the sibling location.
+
+### Create the worktree
+
+`git worktree add -b` creates the branch **and** the workspace in one command, off a freshly fetched base — so this replaces both the mandatory Repo Sync and *0f — Create branch* on the accepted path. No `git pull --rebase` / stash dance is needed (the new branch starts at `origin/<base>` directly).
+
+```bash
+repo_root="$(git rev-parse --show-toplevel)"        # absolute path to the repo
+base="$(git rev-parse --abbrev-ref HEAD)"           # base branch to fork from
+repo="$(basename "$repo_root")"
+branch="{type}/{N}-{short-description}"
+# Absolute worktree path (sibling of the repo) — independent of the current
+# directory, so later steps that `cd` into it stay correct.
+wt_dir="$(dirname "$repo_root")/${repo}-worktrees/$(printf '%s' "$branch" | tr '/' '-')"
+
+git fetch origin
+created_branch_in_step_0e=1
+git worktree add -b "$branch" "$wt_dir" "origin/${base}"
+```
+
+Keep `repo_root` and `wt_dir` available for the setup step below (both are
+absolute, so the copy works regardless of the current directory).
+
+**If the branch already exists** (`git worktree add -b` fails): in interactive mode ask `continue` (set `created_branch_in_step_0e=0`, then add a worktree for the existing branch with `git worktree add "$wt_dir" "$branch"`) or `fresh` (delete the branch, keep `created_branch_in_step_0e=1`, then retry). See `references/error-messages.md` → *Branch already exists*.
+
+**If worktree creation fails for any other reason** (e.g. path exists, disk, locked worktree): warn, print the message from `references/error-messages.md` → *Worktree creation failed*, and **fall back to the in-place path** (Repo Sync + *0f — Create branch*). Never abort the resolution just because the worktree could not be made.
+
+After creation, **change into the worktree** so every subsequent step (research, implement, QA, deliver) operates there:
+
+```bash
+cd "$wt_dir"
+```
+
+### Prepare the workspace (generic — discovered, not hardcoded)
+
+The goal: the worktree can build and run immediately, without the user reconfiguring it. A fresh worktree shares git history but **not** gitignored files (local config) or installed dependencies. Reconstruct them **by detecting what this repo uses** — do not assume any specific stack:
+
+1. **Copy gitignored local config** from the original working tree into the worktree. These are the files git does not track but the app needs at runtime — typically environment files. Copy what exists; skip silently what does not:
+
+   ```bash
+   # Absolute paths from the creation block — works from any directory, so this
+   # does not depend on a prior `cd` or on shell state carrying across steps.
+   for f in .env .env.local .env.development .env.test; do
+     [ -f "$repo_root/$f" ] && cp "$repo_root/$f" "$wt_dir/$f"
+   done
+   ```
+
+   If the repo keeps other gitignored local config (service-account JSON, local certs, a `config.local.*`), copy those too. Use the repo's `.gitignore` as the guide for what is local-only. **Never copy secrets anywhere outside the worktree, and never commit them** — the pre-commit security scan (`docs/pre-commit-security.md`) still blocks secret-bearing files on push.
+
+2. **Install dependencies** using the project's **detected** package manager — the same detection the researcher/implementer rely on. Examples (pick the one matching the repo, do not run all): `npm ci` / `pnpm install` / `yarn` (Node), `pip install -r requirements.txt` or `uv sync` inside the project venv (Python), `bundle install` (Ruby), `go mod download` (Go), `cargo fetch` (Rust). If the repo has no dependency manifest, skip this step.
+
+3. **Run project bootstrap** if the repo defines one — e.g. a `Makefile` `setup`/`bootstrap` target, a `scripts/setup.sh`, a documented "getting started" command, or generated files (`prisma generate`, etc.). Skip if none exists.
+
+Report what was prepared, e.g. `✓ Worktree ready — copied .env, ran npm ci`. Keep it factual: list only what actually ran.
+
+**If setup fails after the worktree was created** (copy error, dependency install failure, bootstrap failure): warn, print the message from `references/error-messages.md` → *Worktree setup failed*, then clean up the partial workspace before falling back to the in-place path. This avoids stranding the resolver on a branch that is already checked out in the failed worktree.
+
+```bash
+cd "$repo_root"
+git worktree remove "$wt_dir" --force 2>/dev/null || git worktree prune
+# Delete the branch only if this Step 0e created it with `git worktree add -b`.
+# If the user chose to continue an existing branch, keep the branch and let 0f's
+# existing branch flow handle it.
+if [ "${created_branch_in_step_0e:-0}" = "1" ]; then
+  git branch -D "$branch" 2>/dev/null || true
+fi
+```
+
+After cleanup, run the mandatory Repo Sync and *0f — Create branch* in the original working tree. If cleanup itself fails, stop and tell the user how to recover with `git worktree list`, `git worktree remove {wt_dir}`, and `git worktree prune` rather than attempting to use two checked-out copies of the same branch.
+
+### Cleanup (after delivery, interactive only)
+
+The worktree is intentionally left in place after the PR is created so the user can inspect it. Tell them how to remove it when done:
+
+```
+○ Worktree left at {wt_dir} for inspection.
+  Remove with:  git worktree remove {wt_dir}
+```
+
+Do not auto-remove it — the user may still want the local artifacts.
+
 ## Step 1 — Research (codebase-researcher subagent)
 
 ### Delegation payload

--- a/src/skills/issue-resolver/references/pipeline-steps.md
+++ b/src/skills/issue-resolver/references/pipeline-steps.md
@@ -90,7 +90,23 @@ Report what was prepared, e.g. `✓ Worktree ready — copied .env, ran npm ci`.
 
 ```bash
 cd "$repo_root"
-git worktree remove "$wt_dir" --force 2>/dev/null || git worktree prune
+cleanup_ok=1
+git worktree remove "$wt_dir" --force 2>/dev/null || cleanup_ok=0
+if [ "$cleanup_ok" -eq 1 ] && git worktree list --porcelain | grep -q "worktree $wt_dir$"; then
+  cleanup_ok=0
+fi
+if [ "$cleanup_ok" -eq 0 ]; then
+  git worktree prune 2>/dev/null || true
+  if git worktree list --porcelain | grep -q "worktree $wt_dir$"; then
+    cleanup_ok=0
+  else
+    cleanup_ok=1
+  fi
+fi
+if [ "$cleanup_ok" -eq 0 ]; then
+  # Do not fall back in-place while the branch is still checked out in the failed worktree.
+  stop with *Worktree setup failed* recovery commands and exit the resolution attempt.
+fi
 # Delete the branch only if this Step 0e created it with `git worktree add -b`.
 # If the user chose to continue an existing branch, keep the branch and let 0f's
 # existing branch flow handle it.
@@ -99,7 +115,7 @@ if [ "${created_branch_in_step_0e:-0}" = "1" ]; then
 fi
 ```
 
-After cleanup, run the mandatory Repo Sync and *0f — Create branch* in the original working tree. If cleanup itself fails, stop and tell the user how to recover with `git worktree list`, `git worktree remove {wt_dir}`, and `git worktree prune` rather than attempting to use two checked-out copies of the same branch.
+After **verified** cleanup (`cleanup_ok=1`), run the mandatory Repo Sync and *0f — Create branch* in the original working tree. If cleanup cannot remove the worktree entry, **stop** — print `references/error-messages.md` → *Worktree setup failed* and do not attempt the in-place path while the same branch may still be checked out in `{wt_dir}`.
 
 ### Cleanup (after delivery, interactive only)
 

--- a/tests/test-issue-resolver-worktree.sh
+++ b/tests/test-issue-resolver-worktree.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# test-issue-resolver-worktree.sh — Validate interactive worktree resolver contract
+#
+# This script verifies issue #123 acceptance criteria:
+#   AC #1: interactive /issue-resolver offers a new git worktree or current tree.
+#   AC #2: accepted worktree path creates/prepares a worktree with local setup.
+#   AC #3: declined path keeps current in-place behavior.
+#   AC #4: auto-pilot / IDD_AUTO_MODE=1 never shows the worktree prompt.
+#   AC #5: prompt states copied/setup artifacts and branch/workspace naming.
+#
+# Usage: bash tests/test-issue-resolver-worktree.sh
+# Returns: exit 0 if all checks pass, exit 1 on failure.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0
+FAIL=0
+
+pass() { echo "  ✓ $1"; PASS=$((PASS + 1)); }
+fail() { echo "  ✗ $1"; FAIL=$((FAIL + 1)); }
+
+contains() {
+  local file="$1"
+  local pattern="$2"
+  grep -qE "$pattern" "$file"
+}
+
+check_contains() {
+  local file="$1"
+  local pattern="$2"
+  local label="$3"
+  if contains "$file" "$pattern"; then
+    pass "$label"
+  else
+    fail "$label"
+    echo "      missing pattern: $pattern"
+    echo "      in file: $file"
+  fi
+}
+
+echo "◆ Issue Resolver Worktree Contract Tests (issue #123)"
+echo "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄"
+
+SRC_SKILL="$REPO_ROOT/src/skills/issue-resolver/SKILL.source.md"
+SRC_STEPS="$REPO_ROOT/src/skills/issue-resolver/references/pipeline-steps.md"
+SRC_ERRORS="$REPO_ROOT/src/skills/issue-resolver/references/error-messages.md"
+ROOT_SKILL="$REPO_ROOT/skills/issue-resolver/SKILL.md"
+ROOT_STEPS="$REPO_ROOT/skills/issue-resolver/references/pipeline-steps.md"
+ROOT_ERRORS="$REPO_ROOT/skills/issue-resolver/references/error-messages.md"
+
+for file in "$SRC_SKILL" "$SRC_STEPS" "$SRC_ERRORS" "$ROOT_SKILL" "$ROOT_STEPS" "$ROOT_ERRORS"; do
+  if [ -f "$file" ]; then
+    pass "exists: ${file#$REPO_ROOT/}"
+  else
+    fail "missing: ${file#$REPO_ROOT/}"
+  fi
+done
+
+# ───────────────────────────────────────────────────────────
+# T1: Interactive prompt exists and gives the expected choice.
+# ───────────────────────────────────────────────────────────
+check_contains "$SRC_SKILL" '### 0e .*Workspace \(interactive only\)' \
+  "T1.1: source skill defines interactive-only workspace step"
+check_contains "$SRC_SKILL" 'Resolve in a new worktree\? \[Y/n\]' \
+  "T1.2: prompt offers worktree with current-tree decline option"
+check_contains "$SRC_SKILL" 'Accepting keeps your current working tree untouched' \
+  "T1.3: prompt explains acceptance isolates current working tree"
+
+# ───────────────────────────────────────────────────────────
+# T2: Auto mode skips the prompt entirely.
+# ───────────────────────────────────────────────────────────
+check_contains "$SRC_SKILL" 'Auto mode .*IDD_AUTO_MODE=1.*skip this offer entirely|Auto mode .*--auto.*skip this offer entirely' \
+  "T2.1: source skill says auto mode skips offer"
+check_contains "$SRC_STEPS" 'Interactive mode only.*auto mode .*skipped|Interactive mode only.*IDD_AUTO_MODE=1.*skipped' \
+  "T2.2: pipeline details say worktree step is skipped in auto mode"
+check_contains "$SRC_STEPS" 'worktree prompt never appears in auto mode' \
+  "T2.3: no-prompt auto-mode contract is explicit"
+
+# ───────────────────────────────────────────────────────────
+# T3: Worktree branch/path naming and setup are stated before acceptance.
+# ───────────────────────────────────────────────────────────
+check_contains "$SRC_SKILL" 'Branch:[[:space:]]+\{type\}/\{N\}-\{short-description\}' \
+  "T3.1: prompt states branch naming"
+check_contains "$SRC_SKILL" 'Worktree:[[:space:]]+\.\./\{repo\}-worktrees/\{type\}-\{N\}-\{short-description\}' \
+  "T3.2: prompt states worktree naming"
+check_contains "$SRC_SKILL" 'copies your gitignored local config \(\.env\*, and similar\)' \
+  "T3.3: prompt states local config/env copy"
+check_contains "$SRC_SKILL" 'detected install/bootstrap' \
+  "T3.4: prompt states detected install/bootstrap setup"
+
+# ───────────────────────────────────────────────────────────
+# T4: Accepted path creates/prepares the worktree generically.
+# ───────────────────────────────────────────────────────────
+check_contains "$SRC_STEPS" 'git worktree add -b "\$branch" "\$wt_dir" "origin/\$\{base\}"' \
+  "T4.1: accepted path creates branch and worktree from fetched base"
+check_contains "$SRC_STEPS" 'cd "\$wt_dir"' \
+  "T4.2: subsequent resolver steps run inside worktree"
+check_contains "$SRC_STEPS" 'for f in \.env \.env\.local \.env\.development \.env\.test' \
+  "T4.3: setup copies common env files when present"
+check_contains "$SRC_STEPS" 'gitignored local config|\.gitignore.*local-only' \
+  "T4.4: setup uses gitignored local config as the guide"
+check_contains "$SRC_STEPS" 'detected package manager|npm ci|pnpm install|pip install|uv sync|bundle install|go mod download|cargo fetch' \
+  "T4.5: setup uses detected dependency manager"
+check_contains "$SRC_STEPS" 'Makefile.*setup|scripts/setup\.sh|bootstrap' \
+  "T4.6: setup runs detected project bootstrap when present"
+
+# ───────────────────────────────────────────────────────────
+# T5: Decline/failure paths keep current behavior.
+# ───────────────────────────────────────────────────────────
+check_contains "$SRC_SKILL" 'Declining uses the[[:space:]]+current working tree with the existing sync and branch behavior|Decline.*current working tree exactly as today|declined the worktree offer' \
+  "T5.1: decline path keeps current working-tree behavior"
+check_contains "$SRC_SKILL" 'mandatory Repo Sync.*0f|Repo Sync.*Create branch' \
+  "T5.2: decline path retains stash-first sync plus branch creation"
+check_contains "$SRC_ERRORS" 'Worktree creation failed' \
+  "T5.3: worktree creation fallback error is documented"
+check_contains "$SRC_ERRORS" 'Worktree setup failed' \
+  "T5.4: worktree setup fallback error is documented"
+check_contains "$SRC_STEPS" 'git worktree remove "\$wt_dir" --force' \
+  "T5.5: setup failure cleans up partial worktree before fallback"
+check_contains "$SRC_STEPS" 'created_branch_in_step_0e' \
+  "T5.6: setup failure only deletes branches created by Step 0e"
+check_contains "$SRC_ERRORS" 'Falling back to resolving in the current working tree|falling back to resolving in the[[:space:]]+current working tree' \
+  "T5.7: worktree failures fall back in-place"
+
+# ───────────────────────────────────────────────────────────
+# T6: Root install surface mirrors the contract.
+# ───────────────────────────────────────────────────────────
+for file in "$ROOT_SKILL" "$ROOT_STEPS" "$ROOT_ERRORS"; do
+  rel="${file#$REPO_ROOT/}"
+  check_contains "$file" 'worktree|Worktree' "T6: generated $rel contains worktree contract text"
+done
+
+# ───────────────────────────────────────────────────────────
+# Summary
+# ───────────────────────────────────────────────────────────
+echo ""
+echo "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄"
+echo "  Result: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
Closes #123

## Summary

Adds an interactive-only `/issue-resolver` workspace choice so users can resolve issues in an isolated git worktree, while preserving the existing in-place flow for declines and all auto-pilot runs.

## Approach

Selected option 2 — spec update plus static regression test. The resolver prompt now documents the worktree branch/path/setup contract, the pipeline reference defines creation, setup, cleanup, and fallback behavior, generated `skills/` output is refreshed, and a shell regression test guards the contract.

## Decision Record

- **Root cause:** `/issue-resolver` only documented an in-place sync/branch workflow, so interactive users had no explicit safe-isolation option for branch creation, implementation, and tests.
- **Options considered:** Option 1 — spec-only resolver worktree prompt; Option 2 — spec update plus static regression test; Option 3 — configurable worktree policy.
- **Options rejected:** Option 1 — lacked regression coverage for the no-prompt auto-mode contract; Option 3 — added configuration surface beyond the issue scope.
- **Selected option:** Option 2 — spec update plus static regression test.
- **Residual risk:** Live behavior depends on agents following the skill instructions; static tests verify the durable contract but do not execute an interactive agent session.

Analyzed at: `feat/123-resolver-worktree-prompt @ 23c2972` (2026-06-20)

## Changes

| File | Change |
|------|--------|
| `src/skills/issue-resolver/SKILL.source.md` | Adds Step 0e interactive workspace offer, auto-mode skip, in-place decline path, and worktree preflight output note. |
| `src/skills/issue-resolver/references/pipeline-steps.md` | Documents worktree naming, `git worktree add -b`, local config copy, detected dependency/bootstrap setup, cleanup, and fallback rules. |
| `src/skills/issue-resolver/references/error-messages.md` | Adds worktree creation/setup fallback warning messages. |
| `skills/issue-resolver/**` | Regenerated root install surface for the issue-resolver skill. |
| `tests/test-issue-resolver-worktree.sh` | Adds static regression coverage for all issue #123 acceptance criteria. |
| `docs/CHANGELOG.md` | Notes the new issue-resolver worktree behavior. |

## Test Results

- Unit/static tests: all `tests/*.sh` passed
- Integration tests: skipped — no separate integration framework
- E2e tests: skipped — no e2e framework
- Build: passed (`./scripts/build.sh`, build script and determinism tests)
- QA cycles: 3

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| In interactive mode, `/issue-resolver` prompts the user to resolve the issue in a new git worktree or continue in the current working tree | pass | `src/skills/issue-resolver/SKILL.source.md` Step 0e; `tests/test-issue-resolver-worktree.sh` T1 |
| When the user accepts the worktree option, the resolver creates a worktree and ensures required local setup artifacts (including `.env` and project bootstrap steps) are available so work can proceed without manual reconfiguration | pass | `src/skills/issue-resolver/references/pipeline-steps.md` creation/setup sections; test T4 |
| When the user declines the worktree option, resolution proceeds in the current working tree with no change to existing interactive behavior | pass | `src/skills/issue-resolver/SKILL.source.md` decline path; test T5.1/T5.2 |
| Auto-pilot and `IDD_AUTO_MODE=1` runs do not show the worktree prompt and follow current auto-mode behavior | pass | `src/skills/issue-resolver/SKILL.source.md` auto-mode skip; `src/skills/issue-resolver/references/pipeline-steps.md`; test T2 |
| The worktree proposal clearly states what will be copied or set up and what branch/workspace naming the user can expect | pass | Prompt block in `src/skills/issue-resolver/SKILL.source.md`; test T3 |
