### PR TITLE
feat(shared): add auto-detecting UI/UX reviewer agent

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -119,6 +119,20 @@ resolve:
   # Maximum: 10
   qa_max_cycles: 5
 
+  # UI/UX review settings (Step 4 — QA)
+  # Code-level UI review is auto-detected per issue and always runs when UI
+  # work is present; it needs no flag and runs in any environment (including
+  # headless servers with no display). Only the optional browser (screenshot)
+  # review is gated here.
+  ui_review:
+    # Browser (screenshot) review mode
+    # Type: string enum
+    # Values: "false" (never) | "ask" (prompt interactive, skip in auto) | "true" (always attempt)
+    # Default: "ask"
+    # Note: when enabled it still skips (fail-soft to code-only) if no app is
+    #       running/reachable or capture is unsafe — it never blocks code review.
+    browser_review: "ask"
+
 # PR review settings (used by /issue-pr-review and /auto-pilot)
 review:
   # Max review-fix cycles before stopping
@@ -218,6 +232,20 @@ review:
   # Set to "" to disable pattern-based exemption. Setting both this and
   # traceability_exempt_labels to empty restores strict issue #36 behavior.
   traceability_exempt_pattern: "^\\s*Type:\\s*(refactor|chore)\\s*$"
+
+  # UI/UX review settings (Step 3 — Review)
+  # Code-level UI review is auto-detected per PR and always runs when UI work is
+  # present; it needs no flag and runs in any environment (including headless
+  # servers with no display). Only the optional browser (screenshot) review is
+  # gated here.
+  ui_review:
+    # Browser (screenshot) review mode
+    # Type: string enum
+    # Values: "false" (never) | "ask" (prompt interactive, skip in auto) | "true" (always attempt)
+    # Default: "ask"
+    # Note: when enabled it still skips (fail-soft to code-only) if no app is
+    #       running/reachable or capture is unsafe — it never blocks code review.
+    browser_review: "ask"
 
 # Auto-pilot settings (used by /auto-pilot)
 autopilot:
@@ -526,6 +554,7 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `resolve.test_timeout` | `300` | 5 minute test timeout |
 | `resolve.pr_auto_link` | `true` | Auto-close issue on merge |
 | `resolve.max_commits` | `10` | Max commits warning |
+| `resolve.ui_review.browser_review` | `"ask"` | Browser (screenshot) UI review mode; code UI review is auto-detected and always runs |
 | `review.max_cycles` | `3` | Max review-fix cycles |
 | `review.auto_merge` | `false` | Auto-merge PR when clean |
 | `review.confidence_threshold` | `80` | Min confidence level for issues |
@@ -539,6 +568,7 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `review.require_traceability_check` | `true` | Run the four traceability checks; missing `Closes #N` blocks soft-pass |
 | `review.traceability_exempt_labels` | `["refactor", "chore"]` | PR labels that exempt a PR from the `Closes #N` hard-fail (check 1 only; other three checks still run) |
 | `review.traceability_exempt_pattern` | `"^\\s*Type:\\s*(refactor\|chore)\\s*$"` | Regex (multiline, case-insensitive) matched against PR body for exemption from check 1 |
+| `review.ui_review.browser_review` | `"ask"` | Browser (screenshot) UI review mode; code UI review is auto-detected and always runs |
 | `autopilot.mode` | `balanced` | Merge mode: `balanced` (auto-merge clean PRs), `conservative` (never merge), `aggressive` (merge clean + partial w/ `merge_partial: true`) |
 | `autopilot.merge_partial` | `false` | Allow merging PRs with unresolved review issues. Only honored when `mode: aggressive` |
 | `autopilot.max_iterations` | `10` | Max issues to process |

--- a/skills/auto-pilot/references/docs/config-schema.md
+++ b/skills/auto-pilot/references/docs/config-schema.md
@@ -120,6 +120,20 @@ resolve:
   # Maximum: 10
   qa_max_cycles: 5
 
+  # UI/UX review settings (Step 4 — QA)
+  # Code-level UI review is auto-detected per issue and always runs when UI
+  # work is present; it needs no flag and runs in any environment (including
+  # headless servers with no display). Only the optional browser (screenshot)
+  # review is gated here.
+  ui_review:
+    # Browser (screenshot) review mode
+    # Type: string enum
+    # Values: "false" (never) | "ask" (prompt interactive, skip in auto) | "true" (always attempt)
+    # Default: "ask"
+    # Note: when enabled it still skips (fail-soft to code-only) if no app is
+    #       running/reachable or capture is unsafe — it never blocks code review.
+    browser_review: "ask"
+
 # PR review settings (used by /issue-pr-review and /auto-pilot)
 review:
   # Max review-fix cycles before stopping
@@ -219,6 +233,20 @@ review:
   # Set to "" to disable pattern-based exemption. Setting both this and
   # traceability_exempt_labels to empty restores strict issue #36 behavior.
   traceability_exempt_pattern: "^\\s*Type:\\s*(refactor|chore)\\s*$"
+
+  # UI/UX review settings (Step 3 — Review)
+  # Code-level UI review is auto-detected per PR and always runs when UI work is
+  # present; it needs no flag and runs in any environment (including headless
+  # servers with no display). Only the optional browser (screenshot) review is
+  # gated here.
+  ui_review:
+    # Browser (screenshot) review mode
+    # Type: string enum
+    # Values: "false" (never) | "ask" (prompt interactive, skip in auto) | "true" (always attempt)
+    # Default: "ask"
+    # Note: when enabled it still skips (fail-soft to code-only) if no app is
+    #       running/reachable or capture is unsafe — it never blocks code review.
+    browser_review: "ask"
 
 # Auto-pilot settings (used by /auto-pilot)
 autopilot:
@@ -527,6 +555,7 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `resolve.test_timeout` | `300` | 5 minute test timeout |
 | `resolve.pr_auto_link` | `true` | Auto-close issue on merge |
 | `resolve.max_commits` | `10` | Max commits warning |
+| `resolve.ui_review.browser_review` | `"ask"` | Browser (screenshot) UI review mode; code UI review is auto-detected and always runs |
 | `review.max_cycles` | `3` | Max review-fix cycles |
 | `review.auto_merge` | `false` | Auto-merge PR when clean |
 | `review.confidence_threshold` | `80` | Min confidence level for issues |
@@ -540,6 +569,7 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `review.require_traceability_check` | `true` | Run the four traceability checks; missing `Closes #N` blocks soft-pass |
 | `review.traceability_exempt_labels` | `["refactor", "chore"]` | PR labels that exempt a PR from the `Closes #N` hard-fail (check 1 only; other three checks still run) |
 | `review.traceability_exempt_pattern` | `"^\\s*Type:\\s*(refactor\|chore)\\s*$"` | Regex (multiline, case-insensitive) matched against PR body for exemption from check 1 |
+| `review.ui_review.browser_review` | `"ask"` | Browser (screenshot) UI review mode; code UI review is auto-detected and always runs |
 | `autopilot.mode` | `balanced` | Merge mode: `balanced` (auto-merge clean PRs), `conservative` (never merge), `aggressive` (merge clean + partial w/ `merge_partial: true`) |
 | `autopilot.merge_partial` | `false` | Allow merging PRs with unresolved review issues. Only honored when `mode: aggressive` |
 | `autopilot.max_iterations` | `10` | Max issues to process |

--- a/skills/init-gitissue/references/docs/config-schema.md
+++ b/skills/init-gitissue/references/docs/config-schema.md
@@ -120,6 +120,20 @@ resolve:
   # Maximum: 10
   qa_max_cycles: 5
 
+  # UI/UX review settings (Step 4 — QA)
+  # Code-level UI review is auto-detected per issue and always runs when UI
+  # work is present; it needs no flag and runs in any environment (including
+  # headless servers with no display). Only the optional browser (screenshot)
+  # review is gated here.
+  ui_review:
+    # Browser (screenshot) review mode
+    # Type: string enum
+    # Values: "false" (never) | "ask" (prompt interactive, skip in auto) | "true" (always attempt)
+    # Default: "ask"
+    # Note: when enabled it still skips (fail-soft to code-only) if no app is
+    #       running/reachable or capture is unsafe — it never blocks code review.
+    browser_review: "ask"
+
 # PR review settings (used by /issue-pr-review and /auto-pilot)
 review:
   # Max review-fix cycles before stopping
@@ -219,6 +233,20 @@ review:
   # Set to "" to disable pattern-based exemption. Setting both this and
   # traceability_exempt_labels to empty restores strict issue #36 behavior.
   traceability_exempt_pattern: "^\\s*Type:\\s*(refactor|chore)\\s*$"
+
+  # UI/UX review settings (Step 3 — Review)
+  # Code-level UI review is auto-detected per PR and always runs when UI work is
+  # present; it needs no flag and runs in any environment (including headless
+  # servers with no display). Only the optional browser (screenshot) review is
+  # gated here.
+  ui_review:
+    # Browser (screenshot) review mode
+    # Type: string enum
+    # Values: "false" (never) | "ask" (prompt interactive, skip in auto) | "true" (always attempt)
+    # Default: "ask"
+    # Note: when enabled it still skips (fail-soft to code-only) if no app is
+    #       running/reachable or capture is unsafe — it never blocks code review.
+    browser_review: "ask"
 
 # Auto-pilot settings (used by /auto-pilot)
 autopilot:
@@ -527,6 +555,7 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `resolve.test_timeout` | `300` | 5 minute test timeout |
 | `resolve.pr_auto_link` | `true` | Auto-close issue on merge |
 | `resolve.max_commits` | `10` | Max commits warning |
+| `resolve.ui_review.browser_review` | `"ask"` | Browser (screenshot) UI review mode; code UI review is auto-detected and always runs |
 | `review.max_cycles` | `3` | Max review-fix cycles |
 | `review.auto_merge` | `false` | Auto-merge PR when clean |
 | `review.confidence_threshold` | `80` | Min confidence level for issues |
@@ -540,6 +569,7 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `review.require_traceability_check` | `true` | Run the four traceability checks; missing `Closes #N` blocks soft-pass |
 | `review.traceability_exempt_labels` | `["refactor", "chore"]` | PR labels that exempt a PR from the `Closes #N` hard-fail (check 1 only; other three checks still run) |
 | `review.traceability_exempt_pattern` | `"^\\s*Type:\\s*(refactor\|chore)\\s*$"` | Regex (multiline, case-insensitive) matched against PR body for exemption from check 1 |
+| `review.ui_review.browser_review` | `"ask"` | Browser (screenshot) UI review mode; code UI review is auto-detected and always runs |
 | `autopilot.mode` | `balanced` | Merge mode: `balanced` (auto-merge clean PRs), `conservative` (never merge), `aggressive` (merge clean + partial w/ `merge_partial: true`) |
 | `autopilot.merge_partial` | `false` | Allow merging PRs with unresolved review issues. Only honored when `mode: aggressive` |
 | `autopilot.max_iterations` | `10` | Max issues to process |

--- a/skills/issue-analysis/references/docs/config-schema.md
+++ b/skills/issue-analysis/references/docs/config-schema.md
@@ -120,6 +120,20 @@ resolve:
   # Maximum: 10
   qa_max_cycles: 5
 
+  # UI/UX review settings (Step 4 — QA)
+  # Code-level UI review is auto-detected per issue and always runs when UI
+  # work is present; it needs no flag and runs in any environment (including
+  # headless servers with no display). Only the optional browser (screenshot)
+  # review is gated here.
+  ui_review:
+    # Browser (screenshot) review mode
+    # Type: string enum
+    # Values: "false" (never) | "ask" (prompt interactive, skip in auto) | "true" (always attempt)
+    # Default: "ask"
+    # Note: when enabled it still skips (fail-soft to code-only) if no app is
+    #       running/reachable or capture is unsafe — it never blocks code review.
+    browser_review: "ask"
+
 # PR review settings (used by /issue-pr-review and /auto-pilot)
 review:
   # Max review-fix cycles before stopping
@@ -219,6 +233,20 @@ review:
   # Set to "" to disable pattern-based exemption. Setting both this and
   # traceability_exempt_labels to empty restores strict issue #36 behavior.
   traceability_exempt_pattern: "^\\s*Type:\\s*(refactor|chore)\\s*$"
+
+  # UI/UX review settings (Step 3 — Review)
+  # Code-level UI review is auto-detected per PR and always runs when UI work is
+  # present; it needs no flag and runs in any environment (including headless
+  # servers with no display). Only the optional browser (screenshot) review is
+  # gated here.
+  ui_review:
+    # Browser (screenshot) review mode
+    # Type: string enum
+    # Values: "false" (never) | "ask" (prompt interactive, skip in auto) | "true" (always attempt)
+    # Default: "ask"
+    # Note: when enabled it still skips (fail-soft to code-only) if no app is
+    #       running/reachable or capture is unsafe — it never blocks code review.
+    browser_review: "ask"
 
 # Auto-pilot settings (used by /auto-pilot)
 autopilot:
@@ -527,6 +555,7 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `resolve.test_timeout` | `300` | 5 minute test timeout |
 | `resolve.pr_auto_link` | `true` | Auto-close issue on merge |
 | `resolve.max_commits` | `10` | Max commits warning |
+| `resolve.ui_review.browser_review` | `"ask"` | Browser (screenshot) UI review mode; code UI review is auto-detected and always runs |
 | `review.max_cycles` | `3` | Max review-fix cycles |
 | `review.auto_merge` | `false` | Auto-merge PR when clean |
 | `review.confidence_threshold` | `80` | Min confidence level for issues |
@@ -540,6 +569,7 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `review.require_traceability_check` | `true` | Run the four traceability checks; missing `Closes #N` blocks soft-pass |
 | `review.traceability_exempt_labels` | `["refactor", "chore"]` | PR labels that exempt a PR from the `Closes #N` hard-fail (check 1 only; other three checks still run) |
 | `review.traceability_exempt_pattern` | `"^\\s*Type:\\s*(refactor\|chore)\\s*$"` | Regex (multiline, case-insensitive) matched against PR body for exemption from check 1 |
+| `review.ui_review.browser_review` | `"ask"` | Browser (screenshot) UI review mode; code UI review is auto-detected and always runs |
 | `autopilot.mode` | `balanced` | Merge mode: `balanced` (auto-merge clean PRs), `conservative` (never merge), `aggressive` (merge clean + partial w/ `merge_partial: true`) |
 | `autopilot.merge_partial` | `false` | Allow merging PRs with unresolved review issues. Only honored when `mode: aggressive` |
 | `autopilot.max_iterations` | `10` | Max issues to process |

--- a/skills/issue-creator/references/docs/config-schema.md
+++ b/skills/issue-creator/references/docs/config-schema.md
@@ -120,6 +120,20 @@ resolve:
   # Maximum: 10
   qa_max_cycles: 5
 
+  # UI/UX review settings (Step 4 — QA)
+  # Code-level UI review is auto-detected per issue and always runs when UI
+  # work is present; it needs no flag and runs in any environment (including
+  # headless servers with no display). Only the optional browser (screenshot)
+  # review is gated here.
+  ui_review:
+    # Browser (screenshot) review mode
+    # Type: string enum
+    # Values: "false" (never) | "ask" (prompt interactive, skip in auto) | "true" (always attempt)
+    # Default: "ask"
+    # Note: when enabled it still skips (fail-soft to code-only) if no app is
+    #       running/reachable or capture is unsafe — it never blocks code review.
+    browser_review: "ask"
+
 # PR review settings (used by /issue-pr-review and /auto-pilot)
 review:
   # Max review-fix cycles before stopping
@@ -219,6 +233,20 @@ review:
   # Set to "" to disable pattern-based exemption. Setting both this and
   # traceability_exempt_labels to empty restores strict issue #36 behavior.
   traceability_exempt_pattern: "^\\s*Type:\\s*(refactor|chore)\\s*$"
+
+  # UI/UX review settings (Step 3 — Review)
+  # Code-level UI review is auto-detected per PR and always runs when UI work is
+  # present; it needs no flag and runs in any environment (including headless
+  # servers with no display). Only the optional browser (screenshot) review is
+  # gated here.
+  ui_review:
+    # Browser (screenshot) review mode
+    # Type: string enum
+    # Values: "false" (never) | "ask" (prompt interactive, skip in auto) | "true" (always attempt)
+    # Default: "ask"
+    # Note: when enabled it still skips (fail-soft to code-only) if no app is
+    #       running/reachable or capture is unsafe — it never blocks code review.
+    browser_review: "ask"
 
 # Auto-pilot settings (used by /auto-pilot)
 autopilot:
@@ -527,6 +555,7 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `resolve.test_timeout` | `300` | 5 minute test timeout |
 | `resolve.pr_auto_link` | `true` | Auto-close issue on merge |
 | `resolve.max_commits` | `10` | Max commits warning |
+| `resolve.ui_review.browser_review` | `"ask"` | Browser (screenshot) UI review mode; code UI review is auto-detected and always runs |
 | `review.max_cycles` | `3` | Max review-fix cycles |
 | `review.auto_merge` | `false` | Auto-merge PR when clean |
 | `review.confidence_threshold` | `80` | Min confidence level for issues |
@@ -540,6 +569,7 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `review.require_traceability_check` | `true` | Run the four traceability checks; missing `Closes #N` blocks soft-pass |
 | `review.traceability_exempt_labels` | `["refactor", "chore"]` | PR labels that exempt a PR from the `Closes #N` hard-fail (check 1 only; other three checks still run) |
 | `review.traceability_exempt_pattern` | `"^\\s*Type:\\s*(refactor\|chore)\\s*$"` | Regex (multiline, case-insensitive) matched against PR body for exemption from check 1 |
+| `review.ui_review.browser_review` | `"ask"` | Browser (screenshot) UI review mode; code UI review is auto-detected and always runs |
 | `autopilot.mode` | `balanced` | Merge mode: `balanced` (auto-merge clean PRs), `conservative` (never merge), `aggressive` (merge clean + partial w/ `merge_partial: true`) |
 | `autopilot.merge_partial` | `false` | Allow merging PRs with unresolved review issues. Only honored when `mode: aggressive` |
 | `autopilot.max_iterations` | `10` | Max issues to process |

--- a/skills/issue-pr-review/SKILL.md
+++ b/skills/issue-pr-review/SKILL.md
@@ -302,7 +302,7 @@ Agent(
 )
 ```
 
-Pass `{branch_name}`, `{base_branch}`, `{pr_context}`, and `{diff_command}` (`gh pr diff {N}`). Merge UI reviewer findings into the code reviewer findings — both use the same `action: "fix" | "note"` semantics, so they flow into Step 6 unchanged.
+Pass `{branch_name}`, `{base_branch}`, `{pr_context}` (PR title + body), `{issue_context}` (the linked issue title/body + acceptance criteria, or empty if none), and `{diff_command}` (`gh pr diff {N}`). Merge UI reviewer findings into the code reviewer findings — both use the same `action: "fix" | "note"` semantics, so they flow into Step 6 unchanged.
 
 For cycle reuse, cycles 2+ re-message the existing UI reviewer via `SendMessage`:
 ```

--- a/skills/issue-pr-review/SKILL.md
+++ b/skills/issue-pr-review/SKILL.md
@@ -32,6 +32,7 @@ In auto mode, export `IDD_AUTO_MODE=1` before any shell snippet that consults it
 2. Confirm `gh` is installed and authenticated: `gh auth status`
 3. Confirm the bundled reviewer agent exists at `references/agents/code-reviewer.md`
 4. Confirm the bundled fixer agent exists at `references/agents/fixer.md`
+5. Confirm the bundled UI reviewer agent exists at `references/agents/ui-reviewer.md`
 
 ### Bundled dependency precheck
 
@@ -48,6 +49,7 @@ In auto mode, export `IDD_AUTO_MODE=1` before any shell snippet that consults it
 
 - `references/agents/code-reviewer.md` — Review subagent prompt
 - `references/agents/fixer.md` — Fix subagent prompt
+- `references/agents/ui-reviewer.md` — UI/UX review subagent prompt (auto-detected; see Step 3)
 - `references/verification-checks.md` — AC + traceability check procedure (Step 3)
 - `references/review-loop-mechanics.md` — reviewer/fixer spawn + reuse mechanics
 - `references/report-templates.md` — Step 7 summary templates, auto-merge flow, expected inline output
@@ -95,8 +97,11 @@ Load `.gitissue.yml` once. Defaults:
 - `review.require_traceability_check: true` — gate for the four traceability checks
 - `review.traceability_exempt_labels: ["refactor", "chore"]` — labels that exempt a PR from the `Closes #N` hard-fail
 - `review.traceability_exempt_pattern: "^\\s*Type:\\s*(refactor|chore)\\s*$"` — body-line regex exempting a PR from the `Closes #N` hard-fail
+- `review.ui_review.browser_review: "ask"` — browser (screenshot) review mode (`"false"` | `"ask"` | `"true"`); `"ask"` prompts interactive users, skips in auto mode. Does **not** gate the code-level UI review, which is auto-detected and always runs when UI work is present.
 
-The last four flags default to `true`/the values shown, which preserve the issue #36 contract. Their full semantics (what `false` does, exemption scope, disabling) are in `references/verification-checks.md`.
+UI/UX **code** review needs no config flag — it is auto-detected per PR (see *Step 3 — UI/UX Review*). Only the optional browser review reads `review.ui_review.browser_review`.
+
+The traceability flags default to `true`/the values shown, which preserve the issue #36 contract. Their full semantics (what `false` does, exemption scope, disabling) are in `references/verification-checks.md`.
 
 ---
 
@@ -243,6 +248,98 @@ Read `references/agents/code-reviewer.md` for the reviewer prompt template and `
 
 To minimize tokens, the loop **reuses the same reviewer across cycles**: cycle 1 is a cold-start spawn; cycles 2+ re-message that agent via `SendMessage` to re-review the updated diff; after the fixer reports zero fixable issues, one **fresh** confirmation reviewer does an unbiased final check. The full mechanics (exact spawn calls, the SendMessage re-review prompt, and the token-trade rationale) live in `references/review-loop-mechanics.md`.
 
+### UI/UX Review (Step 3 — auto-detected)
+
+UI review is **auto-detected per PR** — no config flag enables it. The skill examines the PR title/body and changed files to decide whether UI work is involved, then runs only the review that *can* and *should* run for this PR:
+
+- **Code UI review** is environment-independent — it reads the diff and changed files. It runs whenever UI work is detected, on any machine, **including a headless server with no display**. It is never gated on a GUI, a running app, or a browser.
+- **Browser UI review** is optional. It captures screenshots from a running app, so it only runs when there is a reachable running app *and* the user opted in. When it can't run (no app, no display capable of headless capture, capture unsafe, or auto mode without opt-in), it **skips with a warning and the code UI review still runs** — fail-soft to code-only, never block.
+
+This separation is the contract: detecting UI work always gives you a code UI review; the browser review is an additive bonus when the runtime allows it.
+
+#### Detection phase (runs once, after Step 2, before the review cycles)
+
+1. **Check PR context** for UI indicators:
+   ```bash
+   pr_body=$(gh pr view {N} --json body --jq .body)
+   ```
+   Scan title + body for UI keywords: `UI`, `frontend`, `component`, `style`, `css`, `html`, `design`, `layout`, `responsive`, `mobile`, `theme`, `dark mode`, `button`, `form`, `page`, `screen`, `visual`, `accessibility`, `a11y`, `icon`, `image`, `screenshot`, `dashboard`, `navigation`, `modal`, `dialog`, `card`, `table`, `chart`, `graph`.
+
+2. **Check PR diff** for UI file changes:
+   ```bash
+   ui_files=$(gh pr diff {N} --name-only | grep -E '\.(html|htm|css|scss|sass|less|styl|tsx|jsx|vue|svelte|astro)$|^(components|pages|views|layouts|app|src/app|screens|routes|templates)/|tailwind\.config\.|theme\.|tokens\.')
+   ```
+
+3. **Classify**:
+   - **`ui: detected`** — UI keywords in PR context OR UI files in diff → run the code UI review.
+   - **`ui: not detected`** — no UI indicators → skip UI review entirely (no agent spawned).
+
+4. **Propose review mix** (interactive mode only):
+   ```
+   ◆ UI Review Detected
+   ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+   
+     PR mentions:    responsive, mobile, button
+     Files changed:  src/components/Button.tsx, src/styles/main.css
+   
+     Proposed review:
+       ✓ Code review (a11y, responsive, interaction patterns) — runs now
+       ○ Browser review (screenshot capture) — needs a running app
+   
+     Enable browser review? [Y/n] (requires a reachable app + Playwright)
+   ```
+   In auto mode (`IDD_AUTO_MODE=1`): log the detection result and proceed with **code review only** — browser review requires user confirmation per `review.ui_review.browser_review`.
+
+#### Code-based review
+
+When detection returns `ui: detected`, spawn the `ui-reviewer` subagent in **code** mode (see `references/agents/ui-reviewer.md`):
+
+```python
+Agent(
+  description="UI/UX code review for PR #{N}",
+  prompt=<ui-reviewer.md prompt with mode=code, {variables} replaced>,
+  subagent_type="general-purpose"
+)
+```
+
+Pass `{branch_name}`, `{base_branch}`, `{pr_context}`, and `{diff_command}` (`gh pr diff {N}`). Merge UI reviewer findings into the code reviewer findings — both use the same `action: "fix" | "note"` semantics, so they flow into Step 6 unchanged.
+
+For cycle reuse, cycles 2+ re-message the existing UI reviewer via `SendMessage`:
+```
+The fixer applied changes. Re-review the PR diff for UI/UX issues.
+
+Run: gh pr diff {N}
+
+Return the same JSON format as before.
+```
+For the confirmation pass, spawn one **fresh** UI reviewer for an unbiased final check.
+
+#### Browser-based review (optional, gated)
+
+Browser review runs only when it both *can* and *should*. Check `review.ui_review.browser_review`:
+
+- **`"false"`** — skip; code review already ran.
+- **`"ask"`** — prompt interactive users; skip silently in auto mode.
+- **`"true"`** — proceed to the capability check below.
+
+Then verify the runtime can actually capture screenshots — **all** must hold:
+1. A target app is running and reachable (e.g. `curl -sf {app_url}` succeeds).
+2. A headless browser is available (Playwright/Chromium installed). A headless server with no physical display is fine — headless Chromium needs no display; what it needs is the browser binary and a reachable app.
+3. Capture is safe (not a production URL, no auth wall that would log real traffic).
+
+If the gate or any capability check fails, print a warning and skip — **without** affecting the code UI review that already ran:
+```
+⚠ Browser review skipped — {reason}
+  Code UI review still ran. Enable browser review with:
+  review.ui_review.browser_review: "true"  (and ensure the app is running and reachable)
+```
+
+When all hold, capture screenshots at mobile/tablet/desktop viewports and spawn the UI reviewer in **browser** mode with the screenshot paths and `{app_url}`.
+
+#### Integration with the fixer
+
+`action: "fix"` findings from the UI reviewer join the fixable issues in Step 6. The fixer handles file/line findings normally; browser-only findings without file/line are resolved by identifying the responsible files from the PR diff and issue context.
+
 Also fetch the linked issue for acceptance-criteria verification: `gh issue view {linked_issue} --json number,title,body,labels`.
 
 ```
@@ -254,21 +351,24 @@ Also fetch the linked issue for acceptance-criteria verification: `gh issue view
 
 Within a single review cycle, the work runs in this order:
 1. Spawn (or re-message) the reviewer subagent and collect its findings.
-2. Run per-criterion acceptance-criteria verification against the linked issue.
-3. Run the four traceability checks against the PR body and commit history.
-4. Aggregate reviewer findings + AC results + traceability results into the five user-facing dimensions for the cycle report.
+2. If UI work was detected (see *UI/UX Review* above), spawn (or re-message) the UI reviewer in **code** mode and collect its findings. Skip when `ui: not detected`.
+3. Run per-criterion acceptance-criteria verification against the linked issue.
+4. Run the four traceability checks against the PR body and commit history.
+5. Aggregate reviewer findings + UI reviewer findings + AC results + traceability results into the five user-facing dimensions for the cycle report.
 
 ### Dimensional review output
 
-Step 3 produces a single review verdict organized into **five dimensions**. The reviewer subagent reports findings against its own internal categories (correctness, test_coverage, code_quality, security, edge_cases); this skill maps those findings into the user-facing dimensions and adds two dimensions the reviewer does not produce (acceptance criteria, traceability). Mapping is fixed:
+Step 3 produces a single review verdict organized into **five dimensions**. The reviewer subagent reports findings against its own internal categories (correctness, test_coverage, code_quality, security, edge_cases); this skill maps those findings into the user-facing dimensions and adds two dimensions the reviewer does not produce (acceptance criteria, traceability). When UI work is detected, the UI reviewer's `ui_ux` findings fold into `maintainability` (a11y, responsive, interaction, and consistency are quality concerns). Mapping is fixed:
 
 | User-facing dimension | Source | Failure means |
 |----------------------|--------|---------------|
 | `correctness` | reviewer category `correctness` | logic, off-by-one, race conditions |
 | `acceptance_criteria` | per-criterion verification (this skill) | one or more criteria report `fail` |
 | `traceability` | PR-body and commit-history scan (this skill) | issue-to-code link is broken |
-| `maintainability` | reviewer categories `code_quality` + `test_coverage` | dead code, untested paths, complex logic |
+| `maintainability` | reviewer categories `code_quality` + `test_coverage`; UI reviewer `ui_ux` findings (when detected) | dead code, untested paths, complex logic, a11y/responsive/interaction defects |
 | `safety` | reviewer categories `security` + `edge_cases` | injection, auth bypass, unsafe nulls, crash paths |
+
+A UI `action: "fix"` finding makes `maintainability` report at least `partial` and contributes a fixable issue to Step 6 (`category: ui_ux`), so the dimensional verdict never shows all-pass while UI fixables remain.
 
 Each dimension reports `pass`, `partial`, or `fail`. A PR can pass tests and still fail on `traceability` or `acceptance_criteria` — those dimensions are not gated by test results.
 
@@ -374,6 +474,7 @@ In auto mode: proceed — the next cycle will re-check.
 Collect issues from Steps 3-5, but **only fix issues with `action: "fix"`**. Issues with `action: "note"` are reported in the summary but do not trigger a fix cycle. This is the key token optimization — note-only issues (medium code_quality, test_coverage suggestions) are skipped.
 
 - Code review issues with `action: "fix"` (from the reviewer agent — `correctness`, `maintainability`, `safety` dimensions)
+- UI/UX issues with `action: "fix"` (from the UI reviewer when UI work was detected — `category: ui_ux`, folded under `maintainability`)
 - Acceptance-criteria failures (from Step 3 per-criterion verification — one fixable issue per `fail` criterion, `category: acceptance_criteria`)
 - Traceability failures on `Closes #{N}` (from Step 3 traceability checks — `category: traceability`, suggested fix: edit the PR body to add the link)
 - Test failures (from Step 4)
@@ -470,6 +571,7 @@ A clean review prints the 7-step tracker and a summary — see the *Expected Inl
 ## Additional Resources
 
 - **`references/agents/code-reviewer.md`** — Review subagent prompt
+- **`references/agents/ui-reviewer.md`** — UI/UX review subagent prompt (Step 3, auto-detected)
 - **`references/agents/fixer.md`** — Fix subagent prompt
 - **`references/verification-checks.md`** — AC + traceability check procedure (Step 3)
 - **`references/review-loop-mechanics.md`** — reviewer/fixer spawn + reuse mechanics

--- a/skills/issue-pr-review/references/agents/ui-reviewer.md
+++ b/skills/issue-pr-review/references/agents/ui-reviewer.md
@@ -1,0 +1,143 @@
+<!-- Generated from /src/shared/agents/ui-reviewer.md. Do not edit. Edit source and run ./scripts/build.sh. -->
+<!-- Generated from /src/shared/agents/ui-reviewer.md. Do not edit. Edit source and run ./scripts/build.sh. -->
+# UI/UX Reviewer Agent
+
+Shared agent used by **issue-resolver** (Step 4 — QA) and **issue-pr-review** (Step 3 — Review).
+
+Reviews UI/UX-related code changes for accessibility, responsive design, visual hierarchy, and interaction patterns. Supports two modes: **code** (reviews the diff for UI files) and **browser** (evaluates screenshots captured from a running app).
+
+## Agent Tool Parameters
+
+```
+Agent tool parameters:
+  description: "UI/UX review" or "UI/UX browser review"
+  prompt: <contents of the Prompt section below, with {variables} replaced>
+```
+
+Do **NOT** set `subagent_type` — use the default general-purpose agent.
+
+## Role
+
+You are an expert UI/UX reviewer specializing in modern frontend development. Your primary responsibility is to evaluate user-interface code and visual output for accessibility, responsiveness, visual consistency, and interaction quality.
+
+## Input Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `{mode}` | Review mode: `code` or `browser` | `code` |
+| `{branch_name}` | Current branch | `feat/42-dark-mode` |
+| `{base_branch}` | Base branch for diff | `main` |
+| `{pr_context}` | PR title/body if available, or empty | `PR #47: Add dark mode` |
+| `{diff_command}` | Command to get the diff | `gh pr diff 47` or `git diff main...HEAD` |
+| `{screenshot_paths}` | Newline-separated paths to screenshots (browser mode only) | `screenshots/mobile.png\nscreenshots/desktop.png` |
+| `{app_url}` | Base URL of the running app (browser mode only) | `http://localhost:3000` |
+| `{issue_context}` | Linked issue description and acceptance criteria | (from issue body) |
+
+## Prompt
+
+```
+You are an expert UI/UX reviewer. You evaluate user-interface code and visual output for accessibility, responsiveness, visual consistency, and interaction quality.
+
+You are reviewing changes on branch "{branch_name}" against base branch "{base_branch}".
+{pr_context}
+
+## Mode: {mode}
+
+### Mode: code — Code-based UI/UX Review
+
+1. Get the diff:
+   {diff_command}
+
+2. Identify UI-related changed files. A file is UI-related if:
+   - Extension matches: `.html`, `.htm`, `.css`, `.scss`, `.sass`, `.less`, `.styl`, `.tsx`, `.jsx`, `.vue`, `.svelte`, `.astro`, `.ts`, `.js` (only when in UI directories)
+   - Path is inside: `components/`, `pages/`, `views/`, `layouts/`, `app/`, `src/app/`, `screens/`, `routes/`, `templates/`, `public/`
+   - File is a design-token/config file: `tailwind.config.*`, `theme.*`, `tokens.*`, `.storybook/*`, `*.stories.*`
+   - File references or imports UI libraries: `react-bootstrap`, `ant-design`, `chakra`, `material-ui`, `radix`, `headless-ui`, `shadcn`, `styled-components`, `tailwindcss`, `postcss`
+
+3. For each UI-related changed file, read the full file for context (not just the diff).
+
+4. If the project has a CLAUDE.md, design system doc, or component library docs, read them and verify adherence.
+
+5. Review each UI file across these dimensions:
+
+   - **Accessibility (a11y)**: Missing alt text on images/icons, insufficient color contrast, missing ARIA labels/roles, keyboard navigation gaps, focus management, screen-reader compatibility, touch target sizes (min 44x44px), form label associations
+   - **Responsive design**: Viewport meta tag, fluid layouts vs fixed widths, breakpoint handling, mobile-first approach, touch-friendly interactions, horizontal scroll issues, image sizing
+   - **Visual hierarchy**: Typography scale consistency, spacing rhythm (8px grid or project standard), alignment, visual weight distribution, grouping via proximity/contrast, whitespace usage
+   - **Interaction patterns**: Hover/active/focus/disabled states, transition smoothness, loading skeletons vs spinners, error/success states, form validation feedback, micro-interactions, gesture support
+   - **Consistency**: Design system adherence, component pattern consistency, icon style consistency, color palette usage, spacing token usage, naming conventions
+
+6. For each potential issue, assess confidence (0-100):
+   - **0**: False positive, pre-existing issue
+   - **25**: Might be real, might be false positive
+   - **50**: Real but minor, unlikely to affect users
+   - **75**: Verified real issue, will affect users in practice
+   - **100**: Absolutely certain, accessibility violation or critical UX flaw
+
+   **Only report issues with confidence >= 75.**
+
+7. For each issue, determine the **action** — whether the automated loop should spend a fix cycle on it or just note it:
+   - **"fix"**: accessibility violations (WCAG A/AA), broken layouts on common viewports, missing interactive states that cause confusion, form validation issues
+   - **"fix"**: missing focus indicators, unclickable touch targets, text that overflows containers
+   - **"note"**: minor spacing inconsistencies, non-critical contrast improvements (AA+), cosmetic alignment issues
+   - **"note"**: enhancement suggestions, nice-to-have animations, optional design system improvements
+
+## Mode: browser — Screenshot-based Visual Review
+
+You are evaluating screenshots captured from a running application. Use the provided screenshot paths and app URL to assess visual quality.
+
+1. Read each screenshot from the provided paths: {screenshot_paths}
+
+2. Note the app URL for context: {app_url}
+
+3. For each screenshot, evaluate:
+
+   - **Layout & Overflow**: Content clipping, horizontal scroll, overlapping elements, z-index issues, fixed-position breaking
+   - **Responsive Behavior**: Compare across viewports (mobile/tablet/desktop). Are elements stacked correctly? Is navigation responsive? Do images scale properly?
+   - **Visual Consistency**: Alignment, spacing, font sizes, color consistency, icon sizing, border/radius consistency
+   - **Interactive States**: Are hover/focus/active states visible? Do buttons look clickable? Are disabled states clear? Are loading states present?
+   - **Accessibility Indicators**: Visible focus rings, sufficient color contrast (visual assessment), alt text presence (if text alternatives visible), form label visibility
+   - **Content Rendering**: Image loading (broken icons?), text truncation/overflow, icon rendering, emoji display, whitespace handling
+   - **Cross-viewport Issues**: Elements that work on desktop but break on mobile, or vice versa. Navigation collapse, table overflow, card grid adaptation
+
+4. For each potential issue, assess confidence (0-100) using the same scale as code mode.
+
+5. For each issue, determine action: "fix" or "note" using the same criteria as code mode.
+
+## Output
+
+Return ONLY a JSON block:
+
+{
+  "result": "PASS" or "NEEDS_FIX",
+  "mode": "code" or "browser",
+  "issues_found": <count>,
+  "fixable_count": <count of issues with action "fix">,
+  "issues": [
+    {
+      "category": "ui_ux",
+      "dimension": "accessibility|responsive_design|visual_hierarchy|interaction|consistency|browser_visual",
+      "severity": "high|medium",
+      "confidence": <75-100>,
+      "action": "fix|note",
+      "description": "One-line description of the concrete UI/UX problem",
+      "file": "path/to/file or null for browser-only findings",
+      "line": <approximate line number or null for browser-only>,
+      "suggested_fix": "Brief description of how to fix it",
+      "evidence": ["optional screenshot paths or diff excerpts"]
+    }
+  ],
+  "summary": "One paragraph explaining the overall UI/UX state of the changes"
+}
+
+## Rules
+
+- If nothing is wrong, return "PASS" with empty issues array. Do not invent issues.
+- **PASS** when: zero issues with action "fix". Medium-severity "note" issues may exist — they don't block.
+- **NEEDS_FIX** when: at least one issue with action "fix".
+- Do NOT flag: subjective aesthetic preferences, brand color choices, or anything that requires design approval.
+- Focus on objective issues: accessibility violations, broken layouts, missing interactive states, overflow/clipping.
+- When reviewing across multiple viewports, prioritize mobile-first issues (they affect more users).
+- Browser-only findings (no file/line) are valid — include screenshot paths in `evidence` for traceability.
+- Contrast issues detected visually in screenshots should be flagged with "fix" action (WCAG compliance).
+- Do NOT report issues that are outside the scope of changed files (unless they are layout breakage caused by the changes).
+```

--- a/skills/issue-pr-review/references/agents/ui-reviewer.md
+++ b/skills/issue-pr-review/references/agents/ui-reviewer.md
@@ -1,5 +1,4 @@
 <!-- Generated from /src/shared/agents/ui-reviewer.md. Do not edit. Edit source and run ./scripts/build.sh. -->
-<!-- Generated from /src/shared/agents/ui-reviewer.md. Do not edit. Edit source and run ./scripts/build.sh. -->
 # UI/UX Reviewer Agent
 
 Shared agent used by **issue-resolver** (Step 4 — QA) and **issue-pr-review** (Step 3 — Review).
@@ -40,6 +39,7 @@ You are an expert UI/UX reviewer. You evaluate user-interface code and visual ou
 
 You are reviewing changes on branch "{branch_name}" against base branch "{base_branch}".
 {pr_context}
+{issue_context}
 
 ## Mode: {mode}
 

--- a/skills/issue-resolver/SKILL.md
+++ b/skills/issue-resolver/SKILL.md
@@ -423,7 +423,7 @@ Agent(
 )
 ```
 
-Pass `{branch_name}`, `{base_branch}`, `{issue_context}`, and `{diff_command}` (`git diff origin/${base}...HEAD`). Merge UI reviewer findings into the QA findings — both use the same `action: "fix" | "note"` semantics, so they flow into the fixer loop unchanged.
+Pass `{branch_name}`, `{base_branch}`, `{issue_context}` (the linked issue title/body + acceptance criteria), `{pr_context}` (empty — no PR exists yet at QA time), and `{diff_command}` (`git diff origin/${base}...HEAD`). Merge UI reviewer findings into the QA findings — both use the same `action: "fix" | "note"` semantics, so they flow into the fixer loop unchanged.
 
 #### Browser-based review (optional, gated)
 

--- a/skills/issue-resolver/SKILL.md
+++ b/skills/issue-resolver/SKILL.md
@@ -73,6 +73,7 @@ Defaults:
 - `resolve.pr_auto_link: true`
 - `resolve.max_commits: 10`
 - `resolve.qa_max_cycles: 5`
+- `resolve.ui_review.browser_review: "ask"` — browser (screenshot) review mode (`"false"` | `"ask"` | `"true"`); `"ask"` prompts interactive users, skips in auto mode. Does **not** gate the code-level UI review, which is auto-detected and always runs when UI work is present (see *Step 4 — UI/UX review*).
 
 ---
 
@@ -137,6 +138,7 @@ Check these files relative to the skill's directory (the dirname of this SKILL.m
 - `references/agents/synthesizer.md` — Plan subagent (Step 2)
 - `references/agents/implementer.md` — Implement subagent (Step 3)
 - `references/agents/code-reviewer.md` — QA review subagent (Step 4)
+- `references/agents/ui-reviewer.md` — UI/UX review subagent (Step 4, auto-detected)
 - `references/agents/fixer.md` — QA fix subagent (Step 4)
 - `references/pipeline-steps.md` — Full delegation payloads, phases, and inline fallbacks for Steps 1–4
 - `references/report-templates.md` — PR body template, final report templates, and expected inline output
@@ -393,6 +395,58 @@ Agent(
 
 Pass the issue context, branch/base branch, reviewer findings, failing test/build output, commit message `fix({scope}): address review feedback (#N)`, and `security_convention`: `references/docs/pre-commit-security.md` — the bundled pre-commit security scan the fixer MUST run before committing. The main agent collects the fixer's JSON result and decides whether to start another QA cycle; it should not apply fixes inline when the Agent tool is available.
 
+### UI/UX review (auto-detected)
+
+UI review is **auto-detected per issue** — no config flag enables it. Before the QA cycles, examine the issue body and the working diff to decide whether UI work is involved, then run only the review that *can* and *should* run:
+
+- **Code UI review** is environment-independent — it reads the diff and changed files. It runs whenever UI work is detected, on any machine, **including a headless server with no display**. It is never gated on a GUI, a running app, or a browser.
+- **Browser UI review** is optional and captures screenshots from a running app, so it only runs when there is a reachable running app *and* the user opted in. When it can't run, it **skips with a warning and the code UI review still runs** — fail-soft to code-only, never block.
+
+#### Detection
+
+1. Scan the issue title + body for UI keywords: `UI`, `frontend`, `component`, `style`, `css`, `html`, `design`, `layout`, `responsive`, `mobile`, `theme`, `dark mode`, `button`, `form`, `page`, `screen`, `visual`, `accessibility`, `a11y`, `icon`, `image`, `screenshot`, `dashboard`, `navigation`, `modal`, `dialog`, `card`, `table`, `chart`, `graph`.
+2. Scan the working diff for UI files:
+   ```bash
+   git diff --name-only "origin/${base}"...HEAD | grep -E '\.(html|htm|css|scss|sass|less|styl|tsx|jsx|vue|svelte|astro)$|^(components|pages|views|layouts|app|src/app|screens|routes|templates)/|tailwind\.config\.|theme\.|tokens\.'
+   ```
+3. Classify: **`ui: detected`** (keywords OR UI files) → run the code UI review; **`ui: not detected`** → skip UI review entirely.
+
+#### Code-based review
+
+When `ui: detected`, spawn the `ui-reviewer` subagent in **code** mode (see `references/agents/ui-reviewer.md`):
+
+```python
+Agent(
+  description="UI/UX code review (#N)",
+  prompt=<ui-reviewer.md prompt with mode=code, {variables} replaced>,
+  subagent_type="general-purpose"
+)
+```
+
+Pass `{branch_name}`, `{base_branch}`, `{issue_context}`, and `{diff_command}` (`git diff origin/${base}...HEAD`). Merge UI reviewer findings into the QA findings — both use the same `action: "fix" | "note"` semantics, so they flow into the fixer loop unchanged.
+
+#### Browser-based review (optional, gated)
+
+Browser review runs only when it both *can* and *should*. Check `resolve.ui_review.browser_review`:
+
+- **`"false"`** — skip; code review already ran.
+- **`"ask"`** — prompt interactive users; skip silently in auto mode.
+- **`"true"`** — proceed to the capability check.
+
+Then verify the runtime can actually capture screenshots — **all** must hold:
+1. A target app is running and reachable (e.g. `curl -sf {app_url}` succeeds).
+2. A headless browser is available (Playwright/Chromium installed). A headless server with no display is fine — headless Chromium needs no display, only the browser binary and a reachable app.
+3. Capture is safe (not a production URL, no auth wall that would log real traffic).
+
+If the gate or any check fails, print a warning and skip — **without** affecting the code UI review that already ran:
+```
+⚠ Browser review skipped — {reason}
+  Code UI review still ran. Enable browser review with:
+  resolve.ui_review.browser_review: "true"  (and ensure the app is running and reachable)
+```
+
+When all hold, capture screenshots at mobile/tablet/desktop viewports and spawn the UI reviewer in **browser** mode with the screenshot paths and `{app_url}`. UI `action: "fix"` findings join the QA fixable issues handled by the fixer.
+
 Cycle mechanics, loop controls (`resolve.qa_max_cycles`, exit-on-clean, exit-on-stagnation), and the remaining-issues flow are in `references/pipeline-steps.md` (*Step 4 — QA*).
 
 ---
@@ -533,6 +587,7 @@ All errors use rich format from `references/error-messages.md`:
 - **`references/agents/synthesizer.md`** — Plan subagent (Step 2)
 - **`references/agents/implementer.md`** — Implement subagent (Step 3)
 - **`references/agents/code-reviewer.md`** — QA review subagent (Step 4)
+- **`references/agents/ui-reviewer.md`** — UI/UX review subagent (Step 4, auto-detected)
 - **`references/agents/fixer.md`** — QA fix subagent (Step 4)
 - **`references/pipeline-steps.md`** — Full delegation payloads, phases, and inline fallbacks for Steps 1–4
 - **`references/report-templates.md`** — PR body template, final report templates, and expected inline output

--- a/skills/issue-resolver/references/agents/ui-reviewer.md
+++ b/skills/issue-resolver/references/agents/ui-reviewer.md
@@ -1,0 +1,143 @@
+<!-- Generated from /src/shared/agents/ui-reviewer.md. Do not edit. Edit source and run ./scripts/build.sh. -->
+<!-- Generated from /src/shared/agents/ui-reviewer.md. Do not edit. Edit source and run ./scripts/build.sh. -->
+# UI/UX Reviewer Agent
+
+Shared agent used by **issue-resolver** (Step 4 — QA) and **issue-pr-review** (Step 3 — Review).
+
+Reviews UI/UX-related code changes for accessibility, responsive design, visual hierarchy, and interaction patterns. Supports two modes: **code** (reviews the diff for UI files) and **browser** (evaluates screenshots captured from a running app).
+
+## Agent Tool Parameters
+
+```
+Agent tool parameters:
+  description: "UI/UX review" or "UI/UX browser review"
+  prompt: <contents of the Prompt section below, with {variables} replaced>
+```
+
+Do **NOT** set `subagent_type` — use the default general-purpose agent.
+
+## Role
+
+You are an expert UI/UX reviewer specializing in modern frontend development. Your primary responsibility is to evaluate user-interface code and visual output for accessibility, responsiveness, visual consistency, and interaction quality.
+
+## Input Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `{mode}` | Review mode: `code` or `browser` | `code` |
+| `{branch_name}` | Current branch | `feat/42-dark-mode` |
+| `{base_branch}` | Base branch for diff | `main` |
+| `{pr_context}` | PR title/body if available, or empty | `PR #47: Add dark mode` |
+| `{diff_command}` | Command to get the diff | `gh pr diff 47` or `git diff main...HEAD` |
+| `{screenshot_paths}` | Newline-separated paths to screenshots (browser mode only) | `screenshots/mobile.png\nscreenshots/desktop.png` |
+| `{app_url}` | Base URL of the running app (browser mode only) | `http://localhost:3000` |
+| `{issue_context}` | Linked issue description and acceptance criteria | (from issue body) |
+
+## Prompt
+
+```
+You are an expert UI/UX reviewer. You evaluate user-interface code and visual output for accessibility, responsiveness, visual consistency, and interaction quality.
+
+You are reviewing changes on branch "{branch_name}" against base branch "{base_branch}".
+{pr_context}
+
+## Mode: {mode}
+
+### Mode: code — Code-based UI/UX Review
+
+1. Get the diff:
+   {diff_command}
+
+2. Identify UI-related changed files. A file is UI-related if:
+   - Extension matches: `.html`, `.htm`, `.css`, `.scss`, `.sass`, `.less`, `.styl`, `.tsx`, `.jsx`, `.vue`, `.svelte`, `.astro`, `.ts`, `.js` (only when in UI directories)
+   - Path is inside: `components/`, `pages/`, `views/`, `layouts/`, `app/`, `src/app/`, `screens/`, `routes/`, `templates/`, `public/`
+   - File is a design-token/config file: `tailwind.config.*`, `theme.*`, `tokens.*`, `.storybook/*`, `*.stories.*`
+   - File references or imports UI libraries: `react-bootstrap`, `ant-design`, `chakra`, `material-ui`, `radix`, `headless-ui`, `shadcn`, `styled-components`, `tailwindcss`, `postcss`
+
+3. For each UI-related changed file, read the full file for context (not just the diff).
+
+4. If the project has a CLAUDE.md, design system doc, or component library docs, read them and verify adherence.
+
+5. Review each UI file across these dimensions:
+
+   - **Accessibility (a11y)**: Missing alt text on images/icons, insufficient color contrast, missing ARIA labels/roles, keyboard navigation gaps, focus management, screen-reader compatibility, touch target sizes (min 44x44px), form label associations
+   - **Responsive design**: Viewport meta tag, fluid layouts vs fixed widths, breakpoint handling, mobile-first approach, touch-friendly interactions, horizontal scroll issues, image sizing
+   - **Visual hierarchy**: Typography scale consistency, spacing rhythm (8px grid or project standard), alignment, visual weight distribution, grouping via proximity/contrast, whitespace usage
+   - **Interaction patterns**: Hover/active/focus/disabled states, transition smoothness, loading skeletons vs spinners, error/success states, form validation feedback, micro-interactions, gesture support
+   - **Consistency**: Design system adherence, component pattern consistency, icon style consistency, color palette usage, spacing token usage, naming conventions
+
+6. For each potential issue, assess confidence (0-100):
+   - **0**: False positive, pre-existing issue
+   - **25**: Might be real, might be false positive
+   - **50**: Real but minor, unlikely to affect users
+   - **75**: Verified real issue, will affect users in practice
+   - **100**: Absolutely certain, accessibility violation or critical UX flaw
+
+   **Only report issues with confidence >= 75.**
+
+7. For each issue, determine the **action** — whether the automated loop should spend a fix cycle on it or just note it:
+   - **"fix"**: accessibility violations (WCAG A/AA), broken layouts on common viewports, missing interactive states that cause confusion, form validation issues
+   - **"fix"**: missing focus indicators, unclickable touch targets, text that overflows containers
+   - **"note"**: minor spacing inconsistencies, non-critical contrast improvements (AA+), cosmetic alignment issues
+   - **"note"**: enhancement suggestions, nice-to-have animations, optional design system improvements
+
+## Mode: browser — Screenshot-based Visual Review
+
+You are evaluating screenshots captured from a running application. Use the provided screenshot paths and app URL to assess visual quality.
+
+1. Read each screenshot from the provided paths: {screenshot_paths}
+
+2. Note the app URL for context: {app_url}
+
+3. For each screenshot, evaluate:
+
+   - **Layout & Overflow**: Content clipping, horizontal scroll, overlapping elements, z-index issues, fixed-position breaking
+   - **Responsive Behavior**: Compare across viewports (mobile/tablet/desktop). Are elements stacked correctly? Is navigation responsive? Do images scale properly?
+   - **Visual Consistency**: Alignment, spacing, font sizes, color consistency, icon sizing, border/radius consistency
+   - **Interactive States**: Are hover/focus/active states visible? Do buttons look clickable? Are disabled states clear? Are loading states present?
+   - **Accessibility Indicators**: Visible focus rings, sufficient color contrast (visual assessment), alt text presence (if text alternatives visible), form label visibility
+   - **Content Rendering**: Image loading (broken icons?), text truncation/overflow, icon rendering, emoji display, whitespace handling
+   - **Cross-viewport Issues**: Elements that work on desktop but break on mobile, or vice versa. Navigation collapse, table overflow, card grid adaptation
+
+4. For each potential issue, assess confidence (0-100) using the same scale as code mode.
+
+5. For each issue, determine action: "fix" or "note" using the same criteria as code mode.
+
+## Output
+
+Return ONLY a JSON block:
+
+{
+  "result": "PASS" or "NEEDS_FIX",
+  "mode": "code" or "browser",
+  "issues_found": <count>,
+  "fixable_count": <count of issues with action "fix">,
+  "issues": [
+    {
+      "category": "ui_ux",
+      "dimension": "accessibility|responsive_design|visual_hierarchy|interaction|consistency|browser_visual",
+      "severity": "high|medium",
+      "confidence": <75-100>,
+      "action": "fix|note",
+      "description": "One-line description of the concrete UI/UX problem",
+      "file": "path/to/file or null for browser-only findings",
+      "line": <approximate line number or null for browser-only>,
+      "suggested_fix": "Brief description of how to fix it",
+      "evidence": ["optional screenshot paths or diff excerpts"]
+    }
+  ],
+  "summary": "One paragraph explaining the overall UI/UX state of the changes"
+}
+
+## Rules
+
+- If nothing is wrong, return "PASS" with empty issues array. Do not invent issues.
+- **PASS** when: zero issues with action "fix". Medium-severity "note" issues may exist — they don't block.
+- **NEEDS_FIX** when: at least one issue with action "fix".
+- Do NOT flag: subjective aesthetic preferences, brand color choices, or anything that requires design approval.
+- Focus on objective issues: accessibility violations, broken layouts, missing interactive states, overflow/clipping.
+- When reviewing across multiple viewports, prioritize mobile-first issues (they affect more users).
+- Browser-only findings (no file/line) are valid — include screenshot paths in `evidence` for traceability.
+- Contrast issues detected visually in screenshots should be flagged with "fix" action (WCAG compliance).
+- Do NOT report issues that are outside the scope of changed files (unless they are layout breakage caused by the changes).
+```

--- a/skills/issue-resolver/references/agents/ui-reviewer.md
+++ b/skills/issue-resolver/references/agents/ui-reviewer.md
@@ -1,5 +1,4 @@
 <!-- Generated from /src/shared/agents/ui-reviewer.md. Do not edit. Edit source and run ./scripts/build.sh. -->
-<!-- Generated from /src/shared/agents/ui-reviewer.md. Do not edit. Edit source and run ./scripts/build.sh. -->
 # UI/UX Reviewer Agent
 
 Shared agent used by **issue-resolver** (Step 4 — QA) and **issue-pr-review** (Step 3 — Review).
@@ -40,6 +39,7 @@ You are an expert UI/UX reviewer. You evaluate user-interface code and visual ou
 
 You are reviewing changes on branch "{branch_name}" against base branch "{base_branch}".
 {pr_context}
+{issue_context}
 
 ## Mode: {mode}
 

--- a/skills/issue-resolver/references/docs/config-schema.md
+++ b/skills/issue-resolver/references/docs/config-schema.md
@@ -120,6 +120,20 @@ resolve:
   # Maximum: 10
   qa_max_cycles: 5
 
+  # UI/UX review settings (Step 4 — QA)
+  # Code-level UI review is auto-detected per issue and always runs when UI
+  # work is present; it needs no flag and runs in any environment (including
+  # headless servers with no display). Only the optional browser (screenshot)
+  # review is gated here.
+  ui_review:
+    # Browser (screenshot) review mode
+    # Type: string enum
+    # Values: "false" (never) | "ask" (prompt interactive, skip in auto) | "true" (always attempt)
+    # Default: "ask"
+    # Note: when enabled it still skips (fail-soft to code-only) if no app is
+    #       running/reachable or capture is unsafe — it never blocks code review.
+    browser_review: "ask"
+
 # PR review settings (used by /issue-pr-review and /auto-pilot)
 review:
   # Max review-fix cycles before stopping
@@ -219,6 +233,20 @@ review:
   # Set to "" to disable pattern-based exemption. Setting both this and
   # traceability_exempt_labels to empty restores strict issue #36 behavior.
   traceability_exempt_pattern: "^\\s*Type:\\s*(refactor|chore)\\s*$"
+
+  # UI/UX review settings (Step 3 — Review)
+  # Code-level UI review is auto-detected per PR and always runs when UI work is
+  # present; it needs no flag and runs in any environment (including headless
+  # servers with no display). Only the optional browser (screenshot) review is
+  # gated here.
+  ui_review:
+    # Browser (screenshot) review mode
+    # Type: string enum
+    # Values: "false" (never) | "ask" (prompt interactive, skip in auto) | "true" (always attempt)
+    # Default: "ask"
+    # Note: when enabled it still skips (fail-soft to code-only) if no app is
+    #       running/reachable or capture is unsafe — it never blocks code review.
+    browser_review: "ask"
 
 # Auto-pilot settings (used by /auto-pilot)
 autopilot:
@@ -527,6 +555,7 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `resolve.test_timeout` | `300` | 5 minute test timeout |
 | `resolve.pr_auto_link` | `true` | Auto-close issue on merge |
 | `resolve.max_commits` | `10` | Max commits warning |
+| `resolve.ui_review.browser_review` | `"ask"` | Browser (screenshot) UI review mode; code UI review is auto-detected and always runs |
 | `review.max_cycles` | `3` | Max review-fix cycles |
 | `review.auto_merge` | `false` | Auto-merge PR when clean |
 | `review.confidence_threshold` | `80` | Min confidence level for issues |
@@ -540,6 +569,7 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `review.require_traceability_check` | `true` | Run the four traceability checks; missing `Closes #N` blocks soft-pass |
 | `review.traceability_exempt_labels` | `["refactor", "chore"]` | PR labels that exempt a PR from the `Closes #N` hard-fail (check 1 only; other three checks still run) |
 | `review.traceability_exempt_pattern` | `"^\\s*Type:\\s*(refactor\|chore)\\s*$"` | Regex (multiline, case-insensitive) matched against PR body for exemption from check 1 |
+| `review.ui_review.browser_review` | `"ask"` | Browser (screenshot) UI review mode; code UI review is auto-detected and always runs |
 | `autopilot.mode` | `balanced` | Merge mode: `balanced` (auto-merge clean PRs), `conservative` (never merge), `aggressive` (merge clean + partial w/ `merge_partial: true`) |
 | `autopilot.merge_partial` | `false` | Allow merging PRs with unresolved review issues. Only honored when `mode: aggressive` |
 | `autopilot.max_iterations` | `10` | Max issues to process |

--- a/skills/issue-triage/references/docs/config-schema.md
+++ b/skills/issue-triage/references/docs/config-schema.md
@@ -120,6 +120,20 @@ resolve:
   # Maximum: 10
   qa_max_cycles: 5
 
+  # UI/UX review settings (Step 4 — QA)
+  # Code-level UI review is auto-detected per issue and always runs when UI
+  # work is present; it needs no flag and runs in any environment (including
+  # headless servers with no display). Only the optional browser (screenshot)
+  # review is gated here.
+  ui_review:
+    # Browser (screenshot) review mode
+    # Type: string enum
+    # Values: "false" (never) | "ask" (prompt interactive, skip in auto) | "true" (always attempt)
+    # Default: "ask"
+    # Note: when enabled it still skips (fail-soft to code-only) if no app is
+    #       running/reachable or capture is unsafe — it never blocks code review.
+    browser_review: "ask"
+
 # PR review settings (used by /issue-pr-review and /auto-pilot)
 review:
   # Max review-fix cycles before stopping
@@ -219,6 +233,20 @@ review:
   # Set to "" to disable pattern-based exemption. Setting both this and
   # traceability_exempt_labels to empty restores strict issue #36 behavior.
   traceability_exempt_pattern: "^\\s*Type:\\s*(refactor|chore)\\s*$"
+
+  # UI/UX review settings (Step 3 — Review)
+  # Code-level UI review is auto-detected per PR and always runs when UI work is
+  # present; it needs no flag and runs in any environment (including headless
+  # servers with no display). Only the optional browser (screenshot) review is
+  # gated here.
+  ui_review:
+    # Browser (screenshot) review mode
+    # Type: string enum
+    # Values: "false" (never) | "ask" (prompt interactive, skip in auto) | "true" (always attempt)
+    # Default: "ask"
+    # Note: when enabled it still skips (fail-soft to code-only) if no app is
+    #       running/reachable or capture is unsafe — it never blocks code review.
+    browser_review: "ask"
 
 # Auto-pilot settings (used by /auto-pilot)
 autopilot:
@@ -527,6 +555,7 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `resolve.test_timeout` | `300` | 5 minute test timeout |
 | `resolve.pr_auto_link` | `true` | Auto-close issue on merge |
 | `resolve.max_commits` | `10` | Max commits warning |
+| `resolve.ui_review.browser_review` | `"ask"` | Browser (screenshot) UI review mode; code UI review is auto-detected and always runs |
 | `review.max_cycles` | `3` | Max review-fix cycles |
 | `review.auto_merge` | `false` | Auto-merge PR when clean |
 | `review.confidence_threshold` | `80` | Min confidence level for issues |
@@ -540,6 +569,7 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `review.require_traceability_check` | `true` | Run the four traceability checks; missing `Closes #N` blocks soft-pass |
 | `review.traceability_exempt_labels` | `["refactor", "chore"]` | PR labels that exempt a PR from the `Closes #N` hard-fail (check 1 only; other three checks still run) |
 | `review.traceability_exempt_pattern` | `"^\\s*Type:\\s*(refactor\|chore)\\s*$"` | Regex (multiline, case-insensitive) matched against PR body for exemption from check 1 |
+| `review.ui_review.browser_review` | `"ask"` | Browser (screenshot) UI review mode; code UI review is auto-detected and always runs |
 | `autopilot.mode` | `balanced` | Merge mode: `balanced` (auto-merge clean PRs), `conservative` (never merge), `aggressive` (merge clean + partial w/ `merge_partial: true`) |
 | `autopilot.merge_partial` | `false` | Allow merging PRs with unresolved review issues. Only honored when `mode: aggressive` |
 | `autopilot.max_iterations` | `10` | Max issues to process |

--- a/src/shared/agents/ui-reviewer.md
+++ b/src/shared/agents/ui-reviewer.md
@@ -1,0 +1,142 @@
+<!-- Generated from /src/shared/agents/ui-reviewer.md. Do not edit. Edit source and run ./scripts/build.sh. -->
+# UI/UX Reviewer Agent
+
+Shared agent used by **issue-resolver** (Step 4 — QA) and **issue-pr-review** (Step 3 — Review).
+
+Reviews UI/UX-related code changes for accessibility, responsive design, visual hierarchy, and interaction patterns. Supports two modes: **code** (reviews the diff for UI files) and **browser** (evaluates screenshots captured from a running app).
+
+## Agent Tool Parameters
+
+```
+Agent tool parameters:
+  description: "UI/UX review" or "UI/UX browser review"
+  prompt: <contents of the Prompt section below, with {variables} replaced>
+```
+
+Do **NOT** set `subagent_type` — use the default general-purpose agent.
+
+## Role
+
+You are an expert UI/UX reviewer specializing in modern frontend development. Your primary responsibility is to evaluate user-interface code and visual output for accessibility, responsiveness, visual consistency, and interaction quality.
+
+## Input Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `{mode}` | Review mode: `code` or `browser` | `code` |
+| `{branch_name}` | Current branch | `feat/42-dark-mode` |
+| `{base_branch}` | Base branch for diff | `main` |
+| `{pr_context}` | PR title/body if available, or empty | `PR #47: Add dark mode` |
+| `{diff_command}` | Command to get the diff | `gh pr diff 47` or `git diff main...HEAD` |
+| `{screenshot_paths}` | Newline-separated paths to screenshots (browser mode only) | `screenshots/mobile.png\nscreenshots/desktop.png` |
+| `{app_url}` | Base URL of the running app (browser mode only) | `http://localhost:3000` |
+| `{issue_context}` | Linked issue description and acceptance criteria | (from issue body) |
+
+## Prompt
+
+```
+You are an expert UI/UX reviewer. You evaluate user-interface code and visual output for accessibility, responsiveness, visual consistency, and interaction quality.
+
+You are reviewing changes on branch "{branch_name}" against base branch "{base_branch}".
+{pr_context}
+
+## Mode: {mode}
+
+### Mode: code — Code-based UI/UX Review
+
+1. Get the diff:
+   {diff_command}
+
+2. Identify UI-related changed files. A file is UI-related if:
+   - Extension matches: `.html`, `.htm`, `.css`, `.scss`, `.sass`, `.less`, `.styl`, `.tsx`, `.jsx`, `.vue`, `.svelte`, `.astro`, `.ts`, `.js` (only when in UI directories)
+   - Path is inside: `components/`, `pages/`, `views/`, `layouts/`, `app/`, `src/app/`, `screens/`, `routes/`, `templates/`, `public/`
+   - File is a design-token/config file: `tailwind.config.*`, `theme.*`, `tokens.*`, `.storybook/*`, `*.stories.*`
+   - File references or imports UI libraries: `react-bootstrap`, `ant-design`, `chakra`, `material-ui`, `radix`, `headless-ui`, `shadcn`, `styled-components`, `tailwindcss`, `postcss`
+
+3. For each UI-related changed file, read the full file for context (not just the diff).
+
+4. If the project has a CLAUDE.md, design system doc, or component library docs, read them and verify adherence.
+
+5. Review each UI file across these dimensions:
+
+   - **Accessibility (a11y)**: Missing alt text on images/icons, insufficient color contrast, missing ARIA labels/roles, keyboard navigation gaps, focus management, screen-reader compatibility, touch target sizes (min 44x44px), form label associations
+   - **Responsive design**: Viewport meta tag, fluid layouts vs fixed widths, breakpoint handling, mobile-first approach, touch-friendly interactions, horizontal scroll issues, image sizing
+   - **Visual hierarchy**: Typography scale consistency, spacing rhythm (8px grid or project standard), alignment, visual weight distribution, grouping via proximity/contrast, whitespace usage
+   - **Interaction patterns**: Hover/active/focus/disabled states, transition smoothness, loading skeletons vs spinners, error/success states, form validation feedback, micro-interactions, gesture support
+   - **Consistency**: Design system adherence, component pattern consistency, icon style consistency, color palette usage, spacing token usage, naming conventions
+
+6. For each potential issue, assess confidence (0-100):
+   - **0**: False positive, pre-existing issue
+   - **25**: Might be real, might be false positive
+   - **50**: Real but minor, unlikely to affect users
+   - **75**: Verified real issue, will affect users in practice
+   - **100**: Absolutely certain, accessibility violation or critical UX flaw
+
+   **Only report issues with confidence >= 75.**
+
+7. For each issue, determine the **action** — whether the automated loop should spend a fix cycle on it or just note it:
+   - **"fix"**: accessibility violations (WCAG A/AA), broken layouts on common viewports, missing interactive states that cause confusion, form validation issues
+   - **"fix"**: missing focus indicators, unclickable touch targets, text that overflows containers
+   - **"note"**: minor spacing inconsistencies, non-critical contrast improvements (AA+), cosmetic alignment issues
+   - **"note"**: enhancement suggestions, nice-to-have animations, optional design system improvements
+
+## Mode: browser — Screenshot-based Visual Review
+
+You are evaluating screenshots captured from a running application. Use the provided screenshot paths and app URL to assess visual quality.
+
+1. Read each screenshot from the provided paths: {screenshot_paths}
+
+2. Note the app URL for context: {app_url}
+
+3. For each screenshot, evaluate:
+
+   - **Layout & Overflow**: Content clipping, horizontal scroll, overlapping elements, z-index issues, fixed-position breaking
+   - **Responsive Behavior**: Compare across viewports (mobile/tablet/desktop). Are elements stacked correctly? Is navigation responsive? Do images scale properly?
+   - **Visual Consistency**: Alignment, spacing, font sizes, color consistency, icon sizing, border/radius consistency
+   - **Interactive States**: Are hover/focus/active states visible? Do buttons look clickable? Are disabled states clear? Are loading states present?
+   - **Accessibility Indicators**: Visible focus rings, sufficient color contrast (visual assessment), alt text presence (if text alternatives visible), form label visibility
+   - **Content Rendering**: Image loading (broken icons?), text truncation/overflow, icon rendering, emoji display, whitespace handling
+   - **Cross-viewport Issues**: Elements that work on desktop but break on mobile, or vice versa. Navigation collapse, table overflow, card grid adaptation
+
+4. For each potential issue, assess confidence (0-100) using the same scale as code mode.
+
+5. For each issue, determine action: "fix" or "note" using the same criteria as code mode.
+
+## Output
+
+Return ONLY a JSON block:
+
+{
+  "result": "PASS" or "NEEDS_FIX",
+  "mode": "code" or "browser",
+  "issues_found": <count>,
+  "fixable_count": <count of issues with action "fix">,
+  "issues": [
+    {
+      "category": "ui_ux",
+      "dimension": "accessibility|responsive_design|visual_hierarchy|interaction|consistency|browser_visual",
+      "severity": "high|medium",
+      "confidence": <75-100>,
+      "action": "fix|note",
+      "description": "One-line description of the concrete UI/UX problem",
+      "file": "path/to/file or null for browser-only findings",
+      "line": <approximate line number or null for browser-only>,
+      "suggested_fix": "Brief description of how to fix it",
+      "evidence": ["optional screenshot paths or diff excerpts"]
+    }
+  ],
+  "summary": "One paragraph explaining the overall UI/UX state of the changes"
+}
+
+## Rules
+
+- If nothing is wrong, return "PASS" with empty issues array. Do not invent issues.
+- **PASS** when: zero issues with action "fix". Medium-severity "note" issues may exist — they don't block.
+- **NEEDS_FIX** when: at least one issue with action "fix".
+- Do NOT flag: subjective aesthetic preferences, brand color choices, or anything that requires design approval.
+- Focus on objective issues: accessibility violations, broken layouts, missing interactive states, overflow/clipping.
+- When reviewing across multiple viewports, prioritize mobile-first issues (they affect more users).
+- Browser-only findings (no file/line) are valid — include screenshot paths in `evidence` for traceability.
+- Contrast issues detected visually in screenshots should be flagged with "fix" action (WCAG compliance).
+- Do NOT report issues that are outside the scope of changed files (unless they are layout breakage caused by the changes).
+```

--- a/src/shared/agents/ui-reviewer.md
+++ b/src/shared/agents/ui-reviewer.md
@@ -1,4 +1,3 @@
-<!-- Generated from /src/shared/agents/ui-reviewer.md. Do not edit. Edit source and run ./scripts/build.sh. -->
 # UI/UX Reviewer Agent
 
 Shared agent used by **issue-resolver** (Step 4 — QA) and **issue-pr-review** (Step 3 — Review).
@@ -39,6 +38,7 @@ You are an expert UI/UX reviewer. You evaluate user-interface code and visual ou
 
 You are reviewing changes on branch "{branch_name}" against base branch "{base_branch}".
 {pr_context}
+{issue_context}
 
 ## Mode: {mode}
 

--- a/src/skills/issue-pr-review/SKILL.source.md
+++ b/src/skills/issue-pr-review/SKILL.source.md
@@ -302,7 +302,7 @@ Agent(
 )
 ```
 
-Pass `{branch_name}`, `{base_branch}`, `{pr_context}`, and `{diff_command}` (`gh pr diff {N}`). Merge UI reviewer findings into the code reviewer findings — both use the same `action: "fix" | "note"` semantics, so they flow into Step 6 unchanged.
+Pass `{branch_name}`, `{base_branch}`, `{pr_context}` (PR title + body), `{issue_context}` (the linked issue title/body + acceptance criteria, or empty if none), and `{diff_command}` (`gh pr diff {N}`). Merge UI reviewer findings into the code reviewer findings — both use the same `action: "fix" | "note"` semantics, so they flow into Step 6 unchanged.
 
 For cycle reuse, cycles 2+ re-message the existing UI reviewer via `SendMessage`:
 ```

--- a/src/skills/issue-pr-review/SKILL.source.md
+++ b/src/skills/issue-pr-review/SKILL.source.md
@@ -32,6 +32,7 @@ In auto mode, export `IDD_AUTO_MODE=1` before any shell snippet that consults it
 2. Confirm `gh` is installed and authenticated: `gh auth status`
 3. Confirm the bundled reviewer agent exists at `references/agents/code-reviewer.md`
 4. Confirm the bundled fixer agent exists at `references/agents/fixer.md`
+5. Confirm the bundled UI reviewer agent exists at `references/agents/ui-reviewer.md`
 
 ### Bundled dependency precheck
 
@@ -48,6 +49,7 @@ In auto mode, export `IDD_AUTO_MODE=1` before any shell snippet that consults it
 
 - `references/agents/code-reviewer.md` — Review subagent prompt
 - `references/agents/fixer.md` — Fix subagent prompt
+- `references/agents/ui-reviewer.md` — UI/UX review subagent prompt (auto-detected; see Step 3)
 - `references/verification-checks.md` — AC + traceability check procedure (Step 3)
 - `references/review-loop-mechanics.md` — reviewer/fixer spawn + reuse mechanics
 - `references/report-templates.md` — Step 7 summary templates, auto-merge flow, expected inline output
@@ -95,8 +97,11 @@ Load `.gitissue.yml` once. Defaults:
 - `review.require_traceability_check: true` — gate for the four traceability checks
 - `review.traceability_exempt_labels: ["refactor", "chore"]` — labels that exempt a PR from the `Closes #N` hard-fail
 - `review.traceability_exempt_pattern: "^\\s*Type:\\s*(refactor|chore)\\s*$"` — body-line regex exempting a PR from the `Closes #N` hard-fail
+- `review.ui_review.browser_review: "ask"` — browser (screenshot) review mode (`"false"` | `"ask"` | `"true"`); `"ask"` prompts interactive users, skips in auto mode. Does **not** gate the code-level UI review, which is auto-detected and always runs when UI work is present.
 
-The last four flags default to `true`/the values shown, which preserve the issue #36 contract. Their full semantics (what `false` does, exemption scope, disabling) are in `references/verification-checks.md`.
+UI/UX **code** review needs no config flag — it is auto-detected per PR (see *Step 3 — UI/UX Review*). Only the optional browser review reads `review.ui_review.browser_review`.
+
+The traceability flags default to `true`/the values shown, which preserve the issue #36 contract. Their full semantics (what `false` does, exemption scope, disabling) are in `references/verification-checks.md`.
 
 ---
 
@@ -243,6 +248,98 @@ Read `shared/agents/code-reviewer.md` for the reviewer prompt template and `shar
 
 To minimize tokens, the loop **reuses the same reviewer across cycles**: cycle 1 is a cold-start spawn; cycles 2+ re-message that agent via `SendMessage` to re-review the updated diff; after the fixer reports zero fixable issues, one **fresh** confirmation reviewer does an unbiased final check. The full mechanics (exact spawn calls, the SendMessage re-review prompt, and the token-trade rationale) live in `references/review-loop-mechanics.md`.
 
+### UI/UX Review (Step 3 — auto-detected)
+
+UI review is **auto-detected per PR** — no config flag enables it. The skill examines the PR title/body and changed files to decide whether UI work is involved, then runs only the review that *can* and *should* run for this PR:
+
+- **Code UI review** is environment-independent — it reads the diff and changed files. It runs whenever UI work is detected, on any machine, **including a headless server with no display**. It is never gated on a GUI, a running app, or a browser.
+- **Browser UI review** is optional. It captures screenshots from a running app, so it only runs when there is a reachable running app *and* the user opted in. When it can't run (no app, no display capable of headless capture, capture unsafe, or auto mode without opt-in), it **skips with a warning and the code UI review still runs** — fail-soft to code-only, never block.
+
+This separation is the contract: detecting UI work always gives you a code UI review; the browser review is an additive bonus when the runtime allows it.
+
+#### Detection phase (runs once, after Step 2, before the review cycles)
+
+1. **Check PR context** for UI indicators:
+   ```bash
+   pr_body=$(gh pr view {N} --json body --jq .body)
+   ```
+   Scan title + body for UI keywords: `UI`, `frontend`, `component`, `style`, `css`, `html`, `design`, `layout`, `responsive`, `mobile`, `theme`, `dark mode`, `button`, `form`, `page`, `screen`, `visual`, `accessibility`, `a11y`, `icon`, `image`, `screenshot`, `dashboard`, `navigation`, `modal`, `dialog`, `card`, `table`, `chart`, `graph`.
+
+2. **Check PR diff** for UI file changes:
+   ```bash
+   ui_files=$(gh pr diff {N} --name-only | grep -E '\.(html|htm|css|scss|sass|less|styl|tsx|jsx|vue|svelte|astro)$|^(components|pages|views|layouts|app|src/app|screens|routes|templates)/|tailwind\.config\.|theme\.|tokens\.')
+   ```
+
+3. **Classify**:
+   - **`ui: detected`** — UI keywords in PR context OR UI files in diff → run the code UI review.
+   - **`ui: not detected`** — no UI indicators → skip UI review entirely (no agent spawned).
+
+4. **Propose review mix** (interactive mode only):
+   ```
+   ◆ UI Review Detected
+   ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+   
+     PR mentions:    responsive, mobile, button
+     Files changed:  src/components/Button.tsx, src/styles/main.css
+   
+     Proposed review:
+       ✓ Code review (a11y, responsive, interaction patterns) — runs now
+       ○ Browser review (screenshot capture) — needs a running app
+   
+     Enable browser review? [Y/n] (requires a reachable app + Playwright)
+   ```
+   In auto mode (`IDD_AUTO_MODE=1`): log the detection result and proceed with **code review only** — browser review requires user confirmation per `review.ui_review.browser_review`.
+
+#### Code-based review
+
+When detection returns `ui: detected`, spawn the `ui-reviewer` subagent in **code** mode (see `shared/agents/ui-reviewer.md`):
+
+```python
+Agent(
+  description="UI/UX code review for PR #{N}",
+  prompt=<ui-reviewer.md prompt with mode=code, {variables} replaced>,
+  subagent_type="general-purpose"
+)
+```
+
+Pass `{branch_name}`, `{base_branch}`, `{pr_context}`, and `{diff_command}` (`gh pr diff {N}`). Merge UI reviewer findings into the code reviewer findings — both use the same `action: "fix" | "note"` semantics, so they flow into Step 6 unchanged.
+
+For cycle reuse, cycles 2+ re-message the existing UI reviewer via `SendMessage`:
+```
+The fixer applied changes. Re-review the PR diff for UI/UX issues.
+
+Run: gh pr diff {N}
+
+Return the same JSON format as before.
+```
+For the confirmation pass, spawn one **fresh** UI reviewer for an unbiased final check.
+
+#### Browser-based review (optional, gated)
+
+Browser review runs only when it both *can* and *should*. Check `review.ui_review.browser_review`:
+
+- **`"false"`** — skip; code review already ran.
+- **`"ask"`** — prompt interactive users; skip silently in auto mode.
+- **`"true"`** — proceed to the capability check below.
+
+Then verify the runtime can actually capture screenshots — **all** must hold:
+1. A target app is running and reachable (e.g. `curl -sf {app_url}` succeeds).
+2. A headless browser is available (Playwright/Chromium installed). A headless server with no physical display is fine — headless Chromium needs no display; what it needs is the browser binary and a reachable app.
+3. Capture is safe (not a production URL, no auth wall that would log real traffic).
+
+If the gate or any capability check fails, print a warning and skip — **without** affecting the code UI review that already ran:
+```
+⚠ Browser review skipped — {reason}
+  Code UI review still ran. Enable browser review with:
+  review.ui_review.browser_review: "true"  (and ensure the app is running and reachable)
+```
+
+When all hold, capture screenshots at mobile/tablet/desktop viewports and spawn the UI reviewer in **browser** mode with the screenshot paths and `{app_url}`.
+
+#### Integration with the fixer
+
+`action: "fix"` findings from the UI reviewer join the fixable issues in Step 6. The fixer handles file/line findings normally; browser-only findings without file/line are resolved by identifying the responsible files from the PR diff and issue context.
+
 Also fetch the linked issue for acceptance-criteria verification: `gh issue view {linked_issue} --json number,title,body,labels`.
 
 ```
@@ -254,21 +351,24 @@ Also fetch the linked issue for acceptance-criteria verification: `gh issue view
 
 Within a single review cycle, the work runs in this order:
 1. Spawn (or re-message) the reviewer subagent and collect its findings.
-2. Run per-criterion acceptance-criteria verification against the linked issue.
-3. Run the four traceability checks against the PR body and commit history.
-4. Aggregate reviewer findings + AC results + traceability results into the five user-facing dimensions for the cycle report.
+2. If UI work was detected (see *UI/UX Review* above), spawn (or re-message) the UI reviewer in **code** mode and collect its findings. Skip when `ui: not detected`.
+3. Run per-criterion acceptance-criteria verification against the linked issue.
+4. Run the four traceability checks against the PR body and commit history.
+5. Aggregate reviewer findings + UI reviewer findings + AC results + traceability results into the five user-facing dimensions for the cycle report.
 
 ### Dimensional review output
 
-Step 3 produces a single review verdict organized into **five dimensions**. The reviewer subagent reports findings against its own internal categories (correctness, test_coverage, code_quality, security, edge_cases); this skill maps those findings into the user-facing dimensions and adds two dimensions the reviewer does not produce (acceptance criteria, traceability). Mapping is fixed:
+Step 3 produces a single review verdict organized into **five dimensions**. The reviewer subagent reports findings against its own internal categories (correctness, test_coverage, code_quality, security, edge_cases); this skill maps those findings into the user-facing dimensions and adds two dimensions the reviewer does not produce (acceptance criteria, traceability). When UI work is detected, the UI reviewer's `ui_ux` findings fold into `maintainability` (a11y, responsive, interaction, and consistency are quality concerns). Mapping is fixed:
 
 | User-facing dimension | Source | Failure means |
 |----------------------|--------|---------------|
 | `correctness` | reviewer category `correctness` | logic, off-by-one, race conditions |
 | `acceptance_criteria` | per-criterion verification (this skill) | one or more criteria report `fail` |
 | `traceability` | PR-body and commit-history scan (this skill) | issue-to-code link is broken |
-| `maintainability` | reviewer categories `code_quality` + `test_coverage` | dead code, untested paths, complex logic |
+| `maintainability` | reviewer categories `code_quality` + `test_coverage`; UI reviewer `ui_ux` findings (when detected) | dead code, untested paths, complex logic, a11y/responsive/interaction defects |
 | `safety` | reviewer categories `security` + `edge_cases` | injection, auth bypass, unsafe nulls, crash paths |
+
+A UI `action: "fix"` finding makes `maintainability` report at least `partial` and contributes a fixable issue to Step 6 (`category: ui_ux`), so the dimensional verdict never shows all-pass while UI fixables remain.
 
 Each dimension reports `pass`, `partial`, or `fail`. A PR can pass tests and still fail on `traceability` or `acceptance_criteria` — those dimensions are not gated by test results.
 
@@ -374,6 +474,7 @@ In auto mode: proceed — the next cycle will re-check.
 Collect issues from Steps 3-5, but **only fix issues with `action: "fix"`**. Issues with `action: "note"` are reported in the summary but do not trigger a fix cycle. This is the key token optimization — note-only issues (medium code_quality, test_coverage suggestions) are skipped.
 
 - Code review issues with `action: "fix"` (from the reviewer agent — `correctness`, `maintainability`, `safety` dimensions)
+- UI/UX issues with `action: "fix"` (from the UI reviewer when UI work was detected — `category: ui_ux`, folded under `maintainability`)
 - Acceptance-criteria failures (from Step 3 per-criterion verification — one fixable issue per `fail` criterion, `category: acceptance_criteria`)
 - Traceability failures on `Closes #{N}` (from Step 3 traceability checks — `category: traceability`, suggested fix: edit the PR body to add the link)
 - Test failures (from Step 4)
@@ -470,6 +571,7 @@ A clean review prints the 7-step tracker and a summary — see the *Expected Inl
 ## Additional Resources
 
 - **`shared/agents/code-reviewer.md`** — Review subagent prompt
+- **`shared/agents/ui-reviewer.md`** — UI/UX review subagent prompt (Step 3, auto-detected)
 - **`shared/agents/fixer.md`** — Fix subagent prompt
 - **`references/verification-checks.md`** — AC + traceability check procedure (Step 3)
 - **`references/review-loop-mechanics.md`** — reviewer/fixer spawn + reuse mechanics

--- a/src/skills/issue-resolver/SKILL.source.md
+++ b/src/skills/issue-resolver/SKILL.source.md
@@ -73,6 +73,7 @@ Defaults:
 - `resolve.pr_auto_link: true`
 - `resolve.max_commits: 10`
 - `resolve.qa_max_cycles: 5`
+- `resolve.ui_review.browser_review: "ask"` — browser (screenshot) review mode (`"false"` | `"ask"` | `"true"`); `"ask"` prompts interactive users, skips in auto mode. Does **not** gate the code-level UI review, which is auto-detected and always runs when UI work is present (see *Step 4 — UI/UX review*).
 
 ---
 
@@ -137,6 +138,7 @@ Check these files relative to the skill's directory (the dirname of this SKILL.m
 - `references/agents/synthesizer.md` — Plan subagent (Step 2)
 - `references/agents/implementer.md` — Implement subagent (Step 3)
 - `references/agents/code-reviewer.md` — QA review subagent (Step 4)
+- `references/agents/ui-reviewer.md` — UI/UX review subagent (Step 4, auto-detected)
 - `references/agents/fixer.md` — QA fix subagent (Step 4)
 - `references/pipeline-steps.md` — Full delegation payloads, phases, and inline fallbacks for Steps 1–4
 - `references/report-templates.md` — PR body template, final report templates, and expected inline output
@@ -393,6 +395,58 @@ Agent(
 
 Pass the issue context, branch/base branch, reviewer findings, failing test/build output, commit message `fix({scope}): address review feedback (#N)`, and `security_convention`: `references/docs/pre-commit-security.md` — the bundled pre-commit security scan the fixer MUST run before committing. The main agent collects the fixer's JSON result and decides whether to start another QA cycle; it should not apply fixes inline when the Agent tool is available.
 
+### UI/UX review (auto-detected)
+
+UI review is **auto-detected per issue** — no config flag enables it. Before the QA cycles, examine the issue body and the working diff to decide whether UI work is involved, then run only the review that *can* and *should* run:
+
+- **Code UI review** is environment-independent — it reads the diff and changed files. It runs whenever UI work is detected, on any machine, **including a headless server with no display**. It is never gated on a GUI, a running app, or a browser.
+- **Browser UI review** is optional and captures screenshots from a running app, so it only runs when there is a reachable running app *and* the user opted in. When it can't run, it **skips with a warning and the code UI review still runs** — fail-soft to code-only, never block.
+
+#### Detection
+
+1. Scan the issue title + body for UI keywords: `UI`, `frontend`, `component`, `style`, `css`, `html`, `design`, `layout`, `responsive`, `mobile`, `theme`, `dark mode`, `button`, `form`, `page`, `screen`, `visual`, `accessibility`, `a11y`, `icon`, `image`, `screenshot`, `dashboard`, `navigation`, `modal`, `dialog`, `card`, `table`, `chart`, `graph`.
+2. Scan the working diff for UI files:
+   ```bash
+   git diff --name-only "origin/${base}"...HEAD | grep -E '\.(html|htm|css|scss|sass|less|styl|tsx|jsx|vue|svelte|astro)$|^(components|pages|views|layouts|app|src/app|screens|routes|templates)/|tailwind\.config\.|theme\.|tokens\.'
+   ```
+3. Classify: **`ui: detected`** (keywords OR UI files) → run the code UI review; **`ui: not detected`** → skip UI review entirely.
+
+#### Code-based review
+
+When `ui: detected`, spawn the `ui-reviewer` subagent in **code** mode (see `shared/agents/ui-reviewer.md`):
+
+```python
+Agent(
+  description="UI/UX code review (#N)",
+  prompt=<ui-reviewer.md prompt with mode=code, {variables} replaced>,
+  subagent_type="general-purpose"
+)
+```
+
+Pass `{branch_name}`, `{base_branch}`, `{issue_context}`, and `{diff_command}` (`git diff origin/${base}...HEAD`). Merge UI reviewer findings into the QA findings — both use the same `action: "fix" | "note"` semantics, so they flow into the fixer loop unchanged.
+
+#### Browser-based review (optional, gated)
+
+Browser review runs only when it both *can* and *should*. Check `resolve.ui_review.browser_review`:
+
+- **`"false"`** — skip; code review already ran.
+- **`"ask"`** — prompt interactive users; skip silently in auto mode.
+- **`"true"`** — proceed to the capability check.
+
+Then verify the runtime can actually capture screenshots — **all** must hold:
+1. A target app is running and reachable (e.g. `curl -sf {app_url}` succeeds).
+2. A headless browser is available (Playwright/Chromium installed). A headless server with no display is fine — headless Chromium needs no display, only the browser binary and a reachable app.
+3. Capture is safe (not a production URL, no auth wall that would log real traffic).
+
+If the gate or any check fails, print a warning and skip — **without** affecting the code UI review that already ran:
+```
+⚠ Browser review skipped — {reason}
+  Code UI review still ran. Enable browser review with:
+  resolve.ui_review.browser_review: "true"  (and ensure the app is running and reachable)
+```
+
+When all hold, capture screenshots at mobile/tablet/desktop viewports and spawn the UI reviewer in **browser** mode with the screenshot paths and `{app_url}`. UI `action: "fix"` findings join the QA fixable issues handled by the fixer.
+
 Cycle mechanics, loop controls (`resolve.qa_max_cycles`, exit-on-clean, exit-on-stagnation), and the remaining-issues flow are in `references/pipeline-steps.md` (*Step 4 — QA*).
 
 ---
@@ -533,6 +587,7 @@ All errors use rich format from `references/error-messages.md`:
 - **`shared/agents/synthesizer.md`** — Plan subagent (Step 2)
 - **`shared/agents/implementer.md`** — Implement subagent (Step 3)
 - **`shared/agents/code-reviewer.md`** — QA review subagent (Step 4)
+- **`shared/agents/ui-reviewer.md`** — UI/UX review subagent (Step 4, auto-detected)
 - **`shared/agents/fixer.md`** — QA fix subagent (Step 4)
 - **`references/pipeline-steps.md`** — Full delegation payloads, phases, and inline fallbacks for Steps 1–4
 - **`references/report-templates.md`** — PR body template, final report templates, and expected inline output

--- a/src/skills/issue-resolver/SKILL.source.md
+++ b/src/skills/issue-resolver/SKILL.source.md
@@ -423,7 +423,7 @@ Agent(
 )
 ```
 
-Pass `{branch_name}`, `{base_branch}`, `{issue_context}`, and `{diff_command}` (`git diff origin/${base}...HEAD`). Merge UI reviewer findings into the QA findings — both use the same `action: "fix" | "note"` semantics, so they flow into the fixer loop unchanged.
+Pass `{branch_name}`, `{base_branch}`, `{issue_context}` (the linked issue title/body + acceptance criteria), `{pr_context}` (empty — no PR exists yet at QA time), and `{diff_command}` (`git diff origin/${base}...HEAD`). Merge UI reviewer findings into the QA findings — both use the same `action: "fix" | "note"` semantics, so they flow into the fixer loop unchanged.
 
 #### Browser-based review (optional, gated)
 


### PR DESCRIPTION
Closes #132

## What

Add a new shared `ui-reviewer` agent that auto-detects UI work per task and proposes the appropriate review mix (code review + optional browser screenshot review).

## Why

Previously, UI review had to be manually enabled via config (`ui_review.enabled: true`). This adds automatic detection so the skill proposes the right review dimensions based on the actual issue/PR content — no config changes needed for most projects.

## Changes

### New: `src/shared/agents/ui-reviewer.md`

Shared agent with two modes:

| Mode | What it does |
|------|--------------|
| `code` | Reviews UI-related changed files for accessibility (a11y), responsive design, visual hierarchy, interaction patterns, and consistency |
| `browser` | Evaluates screenshots captured from a running app at mobile/tablet/desktop viewports for layout, overflow, visual consistency, interactive states |

Uses the same JSON contract as `code-reviewer.md` (`category: "ui_ux"`, `action: "fix" | "note"`) so findings merge into the existing fixer loop.

### Auto-detection logic (both skills)

Scans issue/PR body for UI keywords (`component`, `style`, `responsive`, `mobile`, `theme`, `dark mode`, `accessibility`, etc.) and changed files for UI extensions/directories (`.tsx`, `.css`, `components/`, `pages/`, `tailwind.config.*`, etc.).

- **`ui: detected`** → spawn UI reviewer code-mode alongside code reviewer
- **`ui: not detected`** → skip UI review entirely

### Integration: issue-resolver (Step 4 QA)

```
◆ UI Review Detected
┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
  
  Issue mentions: component, responsive, mobile
  Files changed:  src/components/Button.tsx, src/styles/main.css
  
  Proposed review:
    ✓ Code review (a11y, responsive, interaction patterns)
    ○ Browser review (screenshot capture) — app running on :3000?
```

Browser review gated on `resolve.ui_review.browser_review` (`"false"` | `"ask"` | `"true"`) + 3-condition verification (app running, Playwright available, safe to capture).

### Integration: issue-pr-review (Step 3 Review)

Same detection and proposal flow. Respects cycle reuse (SendMessage for cycles 2+, fresh spawn for confirmation pass).

### Config simplification

```yaml
# Before
resolve:
  ui_review:
    enabled: false
    browser_review: "false"
    detect: "auto"

# After — detection is always-on, only browser_review remains
resolve:
  ui_review:
    browser_review: "ask"
```

## Testing

- [ ] Non-UI diff → UI reviewer skipped
- [ ] UI diff → UI reviewer code-mode invoked
- [ ] Browser disabled → no Playwright steps
- [ ] Browser `ask` interactive → permission prompt appears
- [ ] Browser `ask` auto mode → skipped with note
- [ ] JSON contract compatible with existing fixer loop

## Related

Extends the reviewer architecture established in #code-reviewer. Complements existing code review, acceptance criteria verification, and traceability checks.
