### PR TITLE
feat(landing): add Ice Driven Development cooldown-launch skin (#133)

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,10 @@ Browse the authored source for each skill — these links point to `src/` for re
 
 ## What is IDD?
 
+<!-- COOLDOWN-LAUNCH START · seasonal note · issue #133 — delete this block to revert to standard branding -->
+> 🧊 **Cooldown launch:** during the heat wave you may see **Ice Driven Development** floating around the site — it's a temporary, humor-only skin, *not* a rename. **IDD always means Intention-Driven Development:** capturing durable human intention so AI understands what you actually want and ships higher-quality output.
+<!-- COOLDOWN-LAUNCH END · seasonal note -->
+
 Issue-Driven Development — also **Intention-Driven Development** — treats GitHub issues as the atomic unit of all development work. Every change starts as a structured issue and ends as a PR linked to that issue.
 
 The key idea: the gap between "someone describes a problem" and "someone ships a fix" is both a **translation gap** and an **intention gap**. IDD automates that translation — turning vague reports into structured work orders with acceptance criteria — while helping creators discover and articulate what they actually want through iterative refinement.

--- a/landing.html
+++ b/landing.html
@@ -481,9 +481,105 @@
     /* reveal */
     .reveal { opacity: 0; transform: translateY(22px); transition: opacity .6s ease, transform .6s ease; }
     .reveal.in { opacity: 1; transform: none; }
+
+    /* ╔═══════════════════════════════════════════════════════════════╗
+       ║ COOLDOWN-LAUNCH START · "Ice Driven Development" seasonal skin ║
+       ║ Temporary heat-wave gag — issues #133 (rebrand), #135 (hero    ║
+       ║ humor), #134 (ice-cube effect). To REVERT to standard          ║
+       ║ branding, delete every block marked COOLDOWN-LAUNCH (this CSS  ║
+       ║ block, the .cooldown-ice overlay in <body>, and the marked     ║
+       ║ hero / methodology copy). Nothing else depends on these rules. ║
+       ╚═══════════════════════════════════════════════════════════════╝ */
+    :root {
+      --ice: #9fe8ff;
+      --ice-dim: #6fcfe8;
+      --ice-glow: rgba(120, 200, 235, 0.30);
+    }
+    /* #134 — atmospheric falling ice cubes, purely decorative & behind content */
+    .cooldown-ice {
+      position: fixed;
+      inset: 0;
+      z-index: 0;            /* content is lifted to z-index:1 below, nav stays at 50 */
+      pointer-events: none;  /* never intercepts clicks / selection */
+      overflow: hidden;
+    }
+    .cooldown-ice .ice-cube {
+      position: absolute;
+      top: -10vh;
+      width: 18px;
+      height: 18px;
+      border-radius: 5px;
+      background: linear-gradient(135deg, rgba(200, 240, 255, 0.20), rgba(120, 200, 235, 0.07));
+      border: 1px solid rgba(190, 235, 255, 0.28);
+      box-shadow: inset 0 0 6px rgba(255, 255, 255, 0.22), 0 0 12px var(--ice-glow);
+      opacity: 0;
+      animation: ice-fall linear infinite;
+      will-change: transform, opacity;  /* GPU-friendly: only transform + opacity animate */
+    }
+    @keyframes ice-fall {
+      0%   { transform: translate3d(0, -10vh, 0) rotate(0deg);    opacity: 0; }
+      12%  { opacity: 0.65; }
+      88%  { opacity: 0.55; }
+      100% { transform: translate3d(0, 112vh, 0) rotate(220deg);  opacity: 0; }
+    }
+    /* Lift all page content above the ice overlay (kept inside this block so a
+       clean delete fully reverts the stacking change). */
+    body > header,
+    body > section,
+    body > .final,
+    body > footer { position: relative; z-index: 1; }
+    /* Trim the cube count on small screens for performance / less clutter. */
+    @media (max-width: 600px) {
+      .cooldown-ice .ice-cube:nth-child(n+10) { display: none; }
+    }
+    /* Honour reduced-motion: drop the animation entirely. */
+    @media (prefers-reduced-motion: reduce) {
+      .cooldown-ice { display: none; }
+    }
+
+    /* #133 / #135 — icy hero copy treatment */
+    .cooldown-eyebrow {
+      color: var(--ice);
+      background: rgba(120, 200, 235, 0.08);
+      border-color: rgba(150, 220, 245, 0.30);
+      font-weight: 500;
+      max-width: 100%;
+    }
+    .cooldown-eyebrow .dot { background: var(--ice); box-shadow: 0 0 10px var(--ice); }
+    .cooldown-eyebrow strong { color: var(--ice); font-weight: 700; }
+    .cooldown-quip { color: var(--ice-dim); font-style: italic; }
+    .cooldown-quip strong { color: var(--ice); font-style: normal; font-weight: 600; }
+    .cooldown-note {
+      border-left: 2px solid rgba(150, 220, 245, 0.35);
+      padding-left: 16px;
+      color: var(--fg-muted);
+    }
+    .cooldown-note strong { color: var(--ice); }
+    /* ── COOLDOWN-LAUNCH END (CSS) ── */
   </style>
 </head>
 <body>
+
+  <!-- COOLDOWN-LAUNCH START · ice-cube overlay · issue #134 — delete this whole block to revert.
+       Decorative only: aria-hidden, pointer-events:none, sits behind content (z-index), and is
+       disabled under prefers-reduced-motion. -->
+  <div class="cooldown-ice" aria-hidden="true">
+    <span class="ice-cube" style="left:4%;  width:16px; height:16px; animation-duration:15s; animation-delay:-1s;"></span>
+    <span class="ice-cube" style="left:12%; width:22px; height:22px; animation-duration:19s; animation-delay:-6s;"></span>
+    <span class="ice-cube" style="left:21%; width:12px; height:12px; animation-duration:13s; animation-delay:-3s;"></span>
+    <span class="ice-cube" style="left:30%; width:19px; height:19px; animation-duration:21s; animation-delay:-9s;"></span>
+    <span class="ice-cube" style="left:39%; width:14px; height:14px; animation-duration:16s; animation-delay:-12s;"></span>
+    <span class="ice-cube" style="left:48%; width:24px; height:24px; animation-duration:23s; animation-delay:-2s;"></span>
+    <span class="ice-cube" style="left:57%; width:13px; height:13px; animation-duration:14s; animation-delay:-7s;"></span>
+    <span class="ice-cube" style="left:66%; width:20px; height:20px; animation-duration:18s; animation-delay:-15s;"></span>
+    <span class="ice-cube" style="left:74%; width:15px; height:15px; animation-duration:17s; animation-delay:-5s;"></span>
+    <span class="ice-cube" style="left:82%; width:23px; height:23px; animation-duration:22s; animation-delay:-10s;"></span>
+    <span class="ice-cube" style="left:89%; width:12px; height:12px; animation-duration:13s; animation-delay:-4s;"></span>
+    <span class="ice-cube" style="left:95%; width:18px; height:18px; animation-duration:20s; animation-delay:-8s;"></span>
+    <span class="ice-cube" style="left:17%; width:13px; height:13px; animation-duration:24s; animation-delay:-18s;"></span>
+    <span class="ice-cube" style="left:61%; width:16px; height:16px; animation-duration:19s; animation-delay:-13s;"></span>
+  </div>
+  <!-- COOLDOWN-LAUNCH END · ice-cube overlay -->
 
   <!-- ───────────────────────── NAV ───────────────────────── -->
   <header class="nav">
@@ -510,12 +606,22 @@
   <section class="hero" id="top">
     <div class="wrap hero-grid">
       <div>
+        <!-- COOLDOWN-LAUNCH START · seasonal banner · issues #133 #135 — delete to revert to standard branding -->
+        <span class="eyebrow cooldown-eyebrow"><span class="dot"></span>🧊 Cooldown launch · <strong>Ice</strong> Driven Development — a temporary heat-wave gag. IDD still means <strong>Intention</strong>-Driven Development.</span>
+        <!-- COOLDOWN-LAUNCH END · seasonal banner -->
         <span class="eyebrow"><span class="dot"></span>Issue-Driven Development · 8 commands · MIT</span>
         <h1 class="hero-title">Turn GitHub issues into <span class="accent">agent-ready work orders.</span></h1>
         <p class="hero-sub">
           Eight terminal commands that <strong>structure, analyze, triage, resolve, and review</strong> your GitHub issues —
           so any developer or AI agent can pick up an issue and ship a tested PR. Zero config. Works with the tools you already use.
         </p>
+        <!-- COOLDOWN-LAUNCH START · hero ice humor · issue #135 — delete to revert to standard messaging -->
+        <p class="hero-sub cooldown-quip">
+          No frostbite, just fewer burned hours: we keep your backlog <strong>cool</strong>, your intentions
+          <strong>crystal-clear</strong>, and your merge conflicts on ice. 🧊 Same IDD — capturing what humans
+          actually mean so AI ships the right fix — now served chilled.
+        </p>
+        <!-- COOLDOWN-LAUNCH END · hero ice humor -->
         <div class="hero-cta">
           <a class="btn btn-primary" href="./#install">▶ Get Started</a>
           <a class="btn btn-ghost" href="docs.html">Read the Docs</a>
@@ -753,6 +859,10 @@
       <div class="section-tag">What is IDD?</div>
       <h2 class="sec-title">Two names for one idea: issues as the atomic unit of work.</h2>
       <p class="sec-lead">Every change starts as a structured issue and ends as a PR linked to it. The methodology is plain markdown — issuedev just automates the translation.</p>
+
+      <!-- COOLDOWN-LAUNCH START · methodology note · issue #133 — delete to revert. Keeps the intention thesis canonical while the ice gag is live. -->
+      <p class="sec-lead cooldown-note">🧊 During our heat-wave <strong>cooldown launch</strong> you'll spot <strong>Ice</strong> Driven Development sprinkled around — it's a temporary joke, not a rename. The canonical meaning never melts: <strong>IDD = Intention-Driven Development</strong> — capturing durable human intention so AI understands what you actually want and ships higher-quality output.</p>
+      <!-- COOLDOWN-LAUNCH END · methodology note -->
 
       <div class="split">
         <div class="idd-card reveal">


### PR DESCRIPTION
Closes #133
Closes #135
Closes #134

## Summary

A temporary, **fully reversible** "cooldown launch" seasonal skin for the heat wave, layered over `landing.html` (and lightly over `README.md`). It introduces an *Ice Driven Development* gag while keeping the project's real thesis — **IDD = Intention-Driven Development** — dominant and canonical. Resolved as one batch because all three issues touch the same hero region / page and would otherwise collide.

## How each issue's acceptance criteria are met

### #133 — Rebrand as Ice Driven Development (temporary, humor-only)
- Hero banner + methodology note + README note all state explicitly that "Ice Driven Development" is a **temporary heat-wave gag, not a rename**.
- The **IDD acronym is preserved**; every cooldown mention pairs it with "IDD = Intention-Driven Development — capturing durable human intention so AI understands what you actually want and ships higher-quality output."
- The original hero title, sub-copy, and the canonical methodology section are untouched, so the intention thesis stays dominant — the ice copy is an additive wrapper.
- Fully reversible (see below).

### #135 — Ice-themed hero humor
- Adds a tasteful, inclusive ice-pun line to the hero ("keep your backlog **cool**, your intentions **crystal-clear**, merge conflicts on ice… now served chilled").
- The original hero headline ("Turn GitHub issues into agent-ready work orders"), explainer sub-copy, and the primary **Get Started** CTA remain intact and unchanged.
- Copy is isolated in marked blocks and reverts to standard messaging on delete.

### #134 — Animated ice-cube effect across the page
- A fixed full-page `.cooldown-ice` overlay of falling CSS-animated ice cubes spanning the whole landing page.
- Non-intrusive: `aria-hidden="true"`, `pointer-events: none`, low opacity, and **behind content** (overlay `z-index:0`; page content lifted to `z-index:1`; nav stays at `z-index:50`).
- Performance-conscious: CSS-only, animates only `transform`/`opacity` with `translate3d` + `will-change`; no JS loops. Cube count is trimmed on small screens (`max-width:600px`).
- Responsive and accessible: disabled entirely under `prefers-reduced-motion: reduce`.
- Cleanly removable via a single container + its CSS block.

## Reversibility approach
Every addition is wrapped in clearly-paired `COOLDOWN-LAUNCH START` … `COOLDOWN-LAUNCH END` comment markers:
- `landing.html`: CSS block (ice overlay styles + icy copy styles), the `.cooldown-ice` overlay in `<body>`, the hero banner, the hero quip, and the methodology note — 5 marked pairs.
- `README.md`: 1 marked note under "What is IDD?".

Deleting these blocks returns the site to standard `issuedev` / Issue-Driven Development branding with no leftover dependencies.

## QA / Verification
This is a static, hand-authored HTML page with no JS test runner (`auto_test: false` in `.gitissue.yml`), so no test framework was invented. Verification instead:
- **Well-formed HTML** — parsed `landing.html` with Python's `html.parser`; tag stack is fully balanced (identical parser result to the pre-change file).
- **Markers paired & self-contained** — 5 `COOLDOWN-LAUNCH START`/`END` pairs in `landing.html`, 1 pair in `README.md`.
- **Hero still communicates the product + CTA** — original headline, sub-copy, and the Get Started CTA confirmed present and unchanged.
- **Methodology stays canonical** — Intention-Driven Development still presented as the durable meaning; cooldown note reinforces rather than replaces it.
- **Accessibility/perf rules confirmed present** — `pointer-events: none`, `aria-hidden`, content `z-index:1` lift, and `prefers-reduced-motion` guard all verified in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)