### PR TITLE
refactor(issue-creator): make intent clarification active (#139)

### DIFF
--- a/docs/idd-methodology.md
+++ b/docs/idd-methodology.md
@@ -33,11 +33,12 @@ Expressing what you actually want is one of the hardest problems in software dev
 `/issue-creator` addresses this through an **iterative clarification loop**:
 
 1. **Describe the problem** — loosely, incompletely, however it comes to mind
-2. **The agent proposes a structured issue** — classifying the type, preserving reporter context, and generating acceptance criteria
-3. **Read back what it captured** — and realize what you actually meant, what's missing, what's imprecise
-4. **Refine through conversation** — correct, add detail, sharpen the intent through multi-turn discussion until the issue says exactly what you want
+2. **The agent disambiguates intent first** — when a core field is genuinely ambiguous (the type is unclear, or the requirements are unstated), the agent asks one or two targeted questions before drafting, each with a recommended default, and resolves anything the repository can answer by inspecting it rather than asking. When the input is already clear, it skips straight to the draft — no needless questions.
+3. **The agent proposes a structured issue** — classifying the type, preserving reporter context, and generating acceptance criteria
+4. **Read back what it captured** — and realize what you actually meant, what's missing, what's imprecise
+5. **Refine through conversation** — correct, add detail, sharpen the intent until the issue says exactly what you want
 
-This process does something no template or form can do: it helps you **discover your own intention**. The agent acts as both a mirror and a structured interviewer — reflecting your input back in a standardized format and prompting you to think more precisely about what you need.
+This process does something no template or form can do: it helps you **discover your own intention**. The agent acts as both a mirror and a structured interviewer — reflecting your input back in a standardized format, and asking a precise question exactly when ambiguity would otherwise be guessed at. The questioning is targeted, not an interrogation: it engages only on the fields that are genuinely unclear, and never adds friction when intent is already plain.
 
 By the time the issue is finalized, it represents what the creator wants in a format that both humans and AI agents can inspect, question, and execute against.
 

--- a/skills/auto-pilot/references/docs/idd-methodology.md
+++ b/skills/auto-pilot/references/docs/idd-methodology.md
@@ -34,11 +34,12 @@ Expressing what you actually want is one of the hardest problems in software dev
 `/issue-creator` addresses this through an **iterative clarification loop**:
 
 1. **Describe the problem** — loosely, incompletely, however it comes to mind
-2. **The agent proposes a structured issue** — classifying the type, preserving reporter context, and generating acceptance criteria
-3. **Read back what it captured** — and realize what you actually meant, what's missing, what's imprecise
-4. **Refine through conversation** — correct, add detail, sharpen the intent through multi-turn discussion until the issue says exactly what you want
+2. **The agent disambiguates intent first** — when a core field is genuinely ambiguous (the type is unclear, or the requirements are unstated), the agent asks one or two targeted questions before drafting, each with a recommended default, and resolves anything the repository can answer by inspecting it rather than asking. When the input is already clear, it skips straight to the draft — no needless questions.
+3. **The agent proposes a structured issue** — classifying the type, preserving reporter context, and generating acceptance criteria
+4. **Read back what it captured** — and realize what you actually meant, what's missing, what's imprecise
+5. **Refine through conversation** — correct, add detail, sharpen the intent until the issue says exactly what you want
 
-This process does something no template or form can do: it helps you **discover your own intention**. The agent acts as both a mirror and a structured interviewer — reflecting your input back in a standardized format and prompting you to think more precisely about what you need.
+This process does something no template or form can do: it helps you **discover your own intention**. The agent acts as both a mirror and a structured interviewer — reflecting your input back in a standardized format, and asking a precise question exactly when ambiguity would otherwise be guessed at. The questioning is targeted, not an interrogation: it engages only on the fields that are genuinely unclear, and never adds friction when intent is already plain.
 
 By the time the issue is finalized, it represents what the creator wants in a format that both humans and AI agents can inspect, question, and execute against.
 

--- a/skills/init-gitissue/references/docs/idd-methodology.md
+++ b/skills/init-gitissue/references/docs/idd-methodology.md
@@ -34,11 +34,12 @@ Expressing what you actually want is one of the hardest problems in software dev
 `/issue-creator` addresses this through an **iterative clarification loop**:
 
 1. **Describe the problem** — loosely, incompletely, however it comes to mind
-2. **The agent proposes a structured issue** — classifying the type, preserving reporter context, and generating acceptance criteria
-3. **Read back what it captured** — and realize what you actually meant, what's missing, what's imprecise
-4. **Refine through conversation** — correct, add detail, sharpen the intent through multi-turn discussion until the issue says exactly what you want
+2. **The agent disambiguates intent first** — when a core field is genuinely ambiguous (the type is unclear, or the requirements are unstated), the agent asks one or two targeted questions before drafting, each with a recommended default, and resolves anything the repository can answer by inspecting it rather than asking. When the input is already clear, it skips straight to the draft — no needless questions.
+3. **The agent proposes a structured issue** — classifying the type, preserving reporter context, and generating acceptance criteria
+4. **Read back what it captured** — and realize what you actually meant, what's missing, what's imprecise
+5. **Refine through conversation** — correct, add detail, sharpen the intent until the issue says exactly what you want
 
-This process does something no template or form can do: it helps you **discover your own intention**. The agent acts as both a mirror and a structured interviewer — reflecting your input back in a standardized format and prompting you to think more precisely about what you need.
+This process does something no template or form can do: it helps you **discover your own intention**. The agent acts as both a mirror and a structured interviewer — reflecting your input back in a standardized format, and asking a precise question exactly when ambiguity would otherwise be guessed at. The questioning is targeted, not an interrogation: it engages only on the fields that are genuinely unclear, and never adds friction when intent is already plain.
 
 By the time the issue is finalized, it represents what the creator wants in a format that both humans and AI agents can inspect, question, and execute against.
 

--- a/skills/issue-analysis/references/docs/idd-methodology.md
+++ b/skills/issue-analysis/references/docs/idd-methodology.md
@@ -34,11 +34,12 @@ Expressing what you actually want is one of the hardest problems in software dev
 `/issue-creator` addresses this through an **iterative clarification loop**:
 
 1. **Describe the problem** — loosely, incompletely, however it comes to mind
-2. **The agent proposes a structured issue** — classifying the type, preserving reporter context, and generating acceptance criteria
-3. **Read back what it captured** — and realize what you actually meant, what's missing, what's imprecise
-4. **Refine through conversation** — correct, add detail, sharpen the intent through multi-turn discussion until the issue says exactly what you want
+2. **The agent disambiguates intent first** — when a core field is genuinely ambiguous (the type is unclear, or the requirements are unstated), the agent asks one or two targeted questions before drafting, each with a recommended default, and resolves anything the repository can answer by inspecting it rather than asking. When the input is already clear, it skips straight to the draft — no needless questions.
+3. **The agent proposes a structured issue** — classifying the type, preserving reporter context, and generating acceptance criteria
+4. **Read back what it captured** — and realize what you actually meant, what's missing, what's imprecise
+5. **Refine through conversation** — correct, add detail, sharpen the intent until the issue says exactly what you want
 
-This process does something no template or form can do: it helps you **discover your own intention**. The agent acts as both a mirror and a structured interviewer — reflecting your input back in a standardized format and prompting you to think more precisely about what you need.
+This process does something no template or form can do: it helps you **discover your own intention**. The agent acts as both a mirror and a structured interviewer — reflecting your input back in a standardized format, and asking a precise question exactly when ambiguity would otherwise be guessed at. The questioning is targeted, not an interrogation: it engages only on the fields that are genuinely unclear, and never adds friction when intent is already plain.
 
 By the time the issue is finalized, it represents what the creator wants in a format that both humans and AI agents can inspect, question, and execute against.
 

--- a/skills/issue-creator/SKILL.md
+++ b/skills/issue-creator/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Requires git and GitHub CLI (gh) with authentication. Run `gh auth status` to verify."
 effort: medium
 metadata:
-  version: 0.6.0
+  version: 0.7.0
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -106,6 +106,11 @@ Main Agent (orchestrator) — Create mode
 │   Fetches open issues, scores proposed item(s) against them
 │   In batch mode, also cross-checks items against each other
 │   Returns: structured duplicate matches with confidence levels
+│
+├── Step 3.5: Clarify Ambiguous Intent (main agent — interactive Create only)
+│   Runs only when type/criteria confidence is low; resolves repo-answerable
+│   ambiguity by inspection, else asks one targeted question (with default).
+│   Silent no-op when confidence is high; skipped in Batch/auto contexts.
 │
 ├── Step 4: Generate Issue Content (main agent — uses template)
 ├── Step 5: Preview and Confirm (main agent — user interaction)
@@ -336,6 +341,54 @@ If the subagent (or fallback) found potential duplicates (confidence `medium` or
 ```
 
 If no duplicates found, proceed silently.
+
+### Step 3.5 — Clarify Ambiguous Intent
+
+This step makes intent capture **active** rather than passive: before drafting, the skill resolves genuine ambiguity by asking — but only when confidence is genuinely low, and only in interactive Create mode. When confidence is high, this step is a silent no-op and the one-shot path (Step 3 → Step 4) is unchanged.
+
+#### When this step runs
+
+Run this step only if **all** of these hold:
+
+- Interactive Create mode (not Batch, not Normalize). Batch and any non-interactive/auto context **never** ask — see *Non-interactive contexts* below.
+- The predicted confidence of **type classification** (from Step 2) or **acceptance criteria** is `low`. Predict acceptance-criteria confidence from the same signals the Confidence Scoring System uses: `low` when the input states no explicit requirements and criteria would be generic template defaults.
+- The ambiguity is about **intent** (what the reporter wants), not implementation. In practice type and acceptance criteria are always intent, so a genuinely low-confidence field always qualifies — this clause only forbids drifting into "how should we build it?" questions, which belong to the resolver, never to issue creation.
+
+If type and criteria are both `high` or `medium`, skip this step entirely and proceed to Step 4. No question is asked; no friction is added.
+
+#### Resolve from the repo before asking
+
+A question is only worth the user's attention if the repo cannot answer it. Before asking anything, check whether repo inspection resolves the ambiguity — for example, "is dark mode a new capability or a broken existing one?" is answered by checking whether a dark-mode toggle already exists (→ `improvement`/`bug` vs `feature`). If repo inspection settles the field, **do not ask**: raise its confidence to `high` when the inspection is conclusive, or `medium` when it is suggestive but not definitive.
+
+> **Output Contract boundary (critical):** Repo inspection here serves *only* to disambiguate intent and set confidence. Its findings MUST NOT leak into the issue body. The Output Contract still holds in full — no predicted affected files, no generated technical notes, no root cause, no implementation hints. Knowing "a `ThemeToggle` component exists" may flip the type from feature to bug, but neither that component name nor any path appears in the draft. This step changes *classification*, never *body content*.
+
+#### How to ask
+
+For each remaining low-confidence field (at most one or two — do not interrogate):
+
+1. Ask **one question at a time**, each phrased to capture intent, never implementation.
+2. Offer a **recommended default** — and make that default exactly the assumption the one-shot path would have made today (the `(needs review)` guess). This is the unifying rule: high confidence skips the question; low-confidence interactive asks with today's guess as the default; non-interactive takes that same default silently.
+3. Use the project's plain `[Y/n]`-style prompt idiom with the default shown in the line — never a special UI widget (the skill must also run on Claude.ai). Wait for the answer before asking the next question.
+
+```
+◆ One quick question before I draft this
+┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+
+  This reads as ambiguous: is "export broken" a bug in existing
+  export, or a request for a new export format?
+
+  ⚡ Recommended: bug (something that used to work now fails)
+
+  Type — [bug] / feature / improvement:
+```
+
+If the user accepts the default (empty answer or confirmation), record the field at its defaulted value but **raise its confidence to `medium`** — the human confirmed it. If the user overrides, use their answer at `high` confidence. Either way, fold the answer into the Step 4 draft; do not re-ask in the preview.
+
+After at most two questions, proceed to Step 4 regardless — this is targeted disambiguation, not an open-ended interview.
+
+#### Non-interactive contexts (never block)
+
+In Batch mode and any auto/non-interactive context, **skip this step entirely**. Proceed straight to Step 4, draft with the defaulted assumptions, and mark those fields `(needs review)` in the body exactly as today. The skill never pauses for input outside interactive Create mode.
 
 ### Step 4 — Generate Issue Content
 

--- a/skills/issue-creator/references/docs/idd-methodology.md
+++ b/skills/issue-creator/references/docs/idd-methodology.md
@@ -34,11 +34,12 @@ Expressing what you actually want is one of the hardest problems in software dev
 `/issue-creator` addresses this through an **iterative clarification loop**:
 
 1. **Describe the problem** — loosely, incompletely, however it comes to mind
-2. **The agent proposes a structured issue** — classifying the type, preserving reporter context, and generating acceptance criteria
-3. **Read back what it captured** — and realize what you actually meant, what's missing, what's imprecise
-4. **Refine through conversation** — correct, add detail, sharpen the intent through multi-turn discussion until the issue says exactly what you want
+2. **The agent disambiguates intent first** — when a core field is genuinely ambiguous (the type is unclear, or the requirements are unstated), the agent asks one or two targeted questions before drafting, each with a recommended default, and resolves anything the repository can answer by inspecting it rather than asking. When the input is already clear, it skips straight to the draft — no needless questions.
+3. **The agent proposes a structured issue** — classifying the type, preserving reporter context, and generating acceptance criteria
+4. **Read back what it captured** — and realize what you actually meant, what's missing, what's imprecise
+5. **Refine through conversation** — correct, add detail, sharpen the intent until the issue says exactly what you want
 
-This process does something no template or form can do: it helps you **discover your own intention**. The agent acts as both a mirror and a structured interviewer — reflecting your input back in a standardized format and prompting you to think more precisely about what you need.
+This process does something no template or form can do: it helps you **discover your own intention**. The agent acts as both a mirror and a structured interviewer — reflecting your input back in a standardized format, and asking a precise question exactly when ambiguity would otherwise be guessed at. The questioning is targeted, not an interrogation: it engages only on the fields that are genuinely unclear, and never adds friction when intent is already plain.
 
 By the time the issue is finalized, it represents what the creator wants in a format that both humans and AI agents can inspect, question, and execute against.
 

--- a/skills/issue-creator/references/modes.md
+++ b/skills/issue-creator/references/modes.md
@@ -268,6 +268,8 @@ Create {N} issues? [A]ll / [e]dit / [c]ancel
 
 Create each approved issue sequentially using the same pipeline as single Create mode (generate content from template, `gh issue create`). Each issue gets the full template treatment — `<!-- gitissue:normalized v1 -->` marker, all sections populated.
 
+> **Batch never blocks for clarification.** The single Create pipeline includes an interactive *Step 3.5 — Clarify Ambiguous Intent* that asks one targeted question when type/criteria confidence is low. Batch mode **skips that step entirely** — it never pauses to ask the user about an individual item. Low-confidence fields are drafted with their defaulted assumptions and marked `(needs review)` in the body, exactly as before. Batch's only interactive gate remains the Step 4 approval prompt over the whole set.
+
 **Rate limiting:** If `gh issue create` returns a rate limit error, wait and retry with exponential backoff (5s, 10s, 20s). After 3 retries for a single item, skip it and continue with remaining items.
 
 **Progress output:** Show per-item progress:

--- a/skills/issue-pr-review/references/docs/idd-methodology.md
+++ b/skills/issue-pr-review/references/docs/idd-methodology.md
@@ -34,11 +34,12 @@ Expressing what you actually want is one of the hardest problems in software dev
 `/issue-creator` addresses this through an **iterative clarification loop**:
 
 1. **Describe the problem** — loosely, incompletely, however it comes to mind
-2. **The agent proposes a structured issue** — classifying the type, preserving reporter context, and generating acceptance criteria
-3. **Read back what it captured** — and realize what you actually meant, what's missing, what's imprecise
-4. **Refine through conversation** — correct, add detail, sharpen the intent through multi-turn discussion until the issue says exactly what you want
+2. **The agent disambiguates intent first** — when a core field is genuinely ambiguous (the type is unclear, or the requirements are unstated), the agent asks one or two targeted questions before drafting, each with a recommended default, and resolves anything the repository can answer by inspecting it rather than asking. When the input is already clear, it skips straight to the draft — no needless questions.
+3. **The agent proposes a structured issue** — classifying the type, preserving reporter context, and generating acceptance criteria
+4. **Read back what it captured** — and realize what you actually meant, what's missing, what's imprecise
+5. **Refine through conversation** — correct, add detail, sharpen the intent until the issue says exactly what you want
 
-This process does something no template or form can do: it helps you **discover your own intention**. The agent acts as both a mirror and a structured interviewer — reflecting your input back in a standardized format and prompting you to think more precisely about what you need.
+This process does something no template or form can do: it helps you **discover your own intention**. The agent acts as both a mirror and a structured interviewer — reflecting your input back in a standardized format, and asking a precise question exactly when ambiguity would otherwise be guessed at. The questioning is targeted, not an interrogation: it engages only on the fields that are genuinely unclear, and never adds friction when intent is already plain.
 
 By the time the issue is finalized, it represents what the creator wants in a format that both humans and AI agents can inspect, question, and execute against.
 

--- a/skills/issue-resolver/references/docs/idd-methodology.md
+++ b/skills/issue-resolver/references/docs/idd-methodology.md
@@ -34,11 +34,12 @@ Expressing what you actually want is one of the hardest problems in software dev
 `/issue-creator` addresses this through an **iterative clarification loop**:
 
 1. **Describe the problem** — loosely, incompletely, however it comes to mind
-2. **The agent proposes a structured issue** — classifying the type, preserving reporter context, and generating acceptance criteria
-3. **Read back what it captured** — and realize what you actually meant, what's missing, what's imprecise
-4. **Refine through conversation** — correct, add detail, sharpen the intent through multi-turn discussion until the issue says exactly what you want
+2. **The agent disambiguates intent first** — when a core field is genuinely ambiguous (the type is unclear, or the requirements are unstated), the agent asks one or two targeted questions before drafting, each with a recommended default, and resolves anything the repository can answer by inspecting it rather than asking. When the input is already clear, it skips straight to the draft — no needless questions.
+3. **The agent proposes a structured issue** — classifying the type, preserving reporter context, and generating acceptance criteria
+4. **Read back what it captured** — and realize what you actually meant, what's missing, what's imprecise
+5. **Refine through conversation** — correct, add detail, sharpen the intent until the issue says exactly what you want
 
-This process does something no template or form can do: it helps you **discover your own intention**. The agent acts as both a mirror and a structured interviewer — reflecting your input back in a standardized format and prompting you to think more precisely about what you need.
+This process does something no template or form can do: it helps you **discover your own intention**. The agent acts as both a mirror and a structured interviewer — reflecting your input back in a standardized format, and asking a precise question exactly when ambiguity would otherwise be guessed at. The questioning is targeted, not an interrogation: it engages only on the fields that are genuinely unclear, and never adds friction when intent is already plain.
 
 By the time the issue is finalized, it represents what the creator wants in a format that both humans and AI agents can inspect, question, and execute against.
 

--- a/skills/issue-triage/references/docs/idd-methodology.md
+++ b/skills/issue-triage/references/docs/idd-methodology.md
@@ -34,11 +34,12 @@ Expressing what you actually want is one of the hardest problems in software dev
 `/issue-creator` addresses this through an **iterative clarification loop**:
 
 1. **Describe the problem** — loosely, incompletely, however it comes to mind
-2. **The agent proposes a structured issue** — classifying the type, preserving reporter context, and generating acceptance criteria
-3. **Read back what it captured** — and realize what you actually meant, what's missing, what's imprecise
-4. **Refine through conversation** — correct, add detail, sharpen the intent through multi-turn discussion until the issue says exactly what you want
+2. **The agent disambiguates intent first** — when a core field is genuinely ambiguous (the type is unclear, or the requirements are unstated), the agent asks one or two targeted questions before drafting, each with a recommended default, and resolves anything the repository can answer by inspecting it rather than asking. When the input is already clear, it skips straight to the draft — no needless questions.
+3. **The agent proposes a structured issue** — classifying the type, preserving reporter context, and generating acceptance criteria
+4. **Read back what it captured** — and realize what you actually meant, what's missing, what's imprecise
+5. **Refine through conversation** — correct, add detail, sharpen the intent until the issue says exactly what you want
 
-This process does something no template or form can do: it helps you **discover your own intention**. The agent acts as both a mirror and a structured interviewer — reflecting your input back in a standardized format and prompting you to think more precisely about what you need.
+This process does something no template or form can do: it helps you **discover your own intention**. The agent acts as both a mirror and a structured interviewer — reflecting your input back in a standardized format, and asking a precise question exactly when ambiguity would otherwise be guessed at. The questioning is targeted, not an interrogation: it engages only on the fields that are genuinely unclear, and never adds friction when intent is already plain.
 
 By the time the issue is finalized, it represents what the creator wants in a format that both humans and AI agents can inspect, question, and execute against.
 

--- a/src/skills/issue-creator/SKILL.source.md
+++ b/src/skills/issue-creator/SKILL.source.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Requires git and GitHub CLI (gh) with authentication. Run `gh auth status` to verify."
 effort: medium
 metadata:
-  version: 0.6.0
+  version: 0.7.0
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -106,6 +106,11 @@ Main Agent (orchestrator) — Create mode
 │   Fetches open issues, scores proposed item(s) against them
 │   In batch mode, also cross-checks items against each other
 │   Returns: structured duplicate matches with confidence levels
+│
+├── Step 3.5: Clarify Ambiguous Intent (main agent — interactive Create only)
+│   Runs only when type/criteria confidence is low; resolves repo-answerable
+│   ambiguity by inspection, else asks one targeted question (with default).
+│   Silent no-op when confidence is high; skipped in Batch/auto contexts.
 │
 ├── Step 4: Generate Issue Content (main agent — uses template)
 ├── Step 5: Preview and Confirm (main agent — user interaction)
@@ -336,6 +341,54 @@ If the subagent (or fallback) found potential duplicates (confidence `medium` or
 ```
 
 If no duplicates found, proceed silently.
+
+### Step 3.5 — Clarify Ambiguous Intent
+
+This step makes intent capture **active** rather than passive: before drafting, the skill resolves genuine ambiguity by asking — but only when confidence is genuinely low, and only in interactive Create mode. When confidence is high, this step is a silent no-op and the one-shot path (Step 3 → Step 4) is unchanged.
+
+#### When this step runs
+
+Run this step only if **all** of these hold:
+
+- Interactive Create mode (not Batch, not Normalize). Batch and any non-interactive/auto context **never** ask — see *Non-interactive contexts* below.
+- The predicted confidence of **type classification** (from Step 2) or **acceptance criteria** is `low`. Predict acceptance-criteria confidence from the same signals the Confidence Scoring System uses: `low` when the input states no explicit requirements and criteria would be generic template defaults.
+- The ambiguity is about **intent** (what the reporter wants), not implementation. In practice type and acceptance criteria are always intent, so a genuinely low-confidence field always qualifies — this clause only forbids drifting into "how should we build it?" questions, which belong to the resolver, never to issue creation.
+
+If type and criteria are both `high` or `medium`, skip this step entirely and proceed to Step 4. No question is asked; no friction is added.
+
+#### Resolve from the repo before asking
+
+A question is only worth the user's attention if the repo cannot answer it. Before asking anything, check whether repo inspection resolves the ambiguity — for example, "is dark mode a new capability or a broken existing one?" is answered by checking whether a dark-mode toggle already exists (→ `improvement`/`bug` vs `feature`). If repo inspection settles the field, **do not ask**: raise its confidence to `high` when the inspection is conclusive, or `medium` when it is suggestive but not definitive.
+
+> **Output Contract boundary (critical):** Repo inspection here serves *only* to disambiguate intent and set confidence. Its findings MUST NOT leak into the issue body. The Output Contract still holds in full — no predicted affected files, no generated technical notes, no root cause, no implementation hints. Knowing "a `ThemeToggle` component exists" may flip the type from feature to bug, but neither that component name nor any path appears in the draft. This step changes *classification*, never *body content*.
+
+#### How to ask
+
+For each remaining low-confidence field (at most one or two — do not interrogate):
+
+1. Ask **one question at a time**, each phrased to capture intent, never implementation.
+2. Offer a **recommended default** — and make that default exactly the assumption the one-shot path would have made today (the `(needs review)` guess). This is the unifying rule: high confidence skips the question; low-confidence interactive asks with today's guess as the default; non-interactive takes that same default silently.
+3. Use the project's plain `[Y/n]`-style prompt idiom with the default shown in the line — never a special UI widget (the skill must also run on Claude.ai). Wait for the answer before asking the next question.
+
+```
+◆ One quick question before I draft this
+┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+
+  This reads as ambiguous: is "export broken" a bug in existing
+  export, or a request for a new export format?
+
+  ⚡ Recommended: bug (something that used to work now fails)
+
+  Type — [bug] / feature / improvement:
+```
+
+If the user accepts the default (empty answer or confirmation), record the field at its defaulted value but **raise its confidence to `medium`** — the human confirmed it. If the user overrides, use their answer at `high` confidence. Either way, fold the answer into the Step 4 draft; do not re-ask in the preview.
+
+After at most two questions, proceed to Step 4 regardless — this is targeted disambiguation, not an open-ended interview.
+
+#### Non-interactive contexts (never block)
+
+In Batch mode and any auto/non-interactive context, **skip this step entirely**. Proceed straight to Step 4, draft with the defaulted assumptions, and mark those fields `(needs review)` in the body exactly as today. The skill never pauses for input outside interactive Create mode.
 
 ### Step 4 — Generate Issue Content
 

--- a/src/skills/issue-creator/references/modes.md
+++ b/src/skills/issue-creator/references/modes.md
@@ -268,6 +268,8 @@ Create {N} issues? [A]ll / [e]dit / [c]ancel
 
 Create each approved issue sequentially using the same pipeline as single Create mode (generate content from template, `gh issue create`). Each issue gets the full template treatment — `<!-- gitissue:normalized v1 -->` marker, all sections populated.
 
+> **Batch never blocks for clarification.** The single Create pipeline includes an interactive *Step 3.5 — Clarify Ambiguous Intent* that asks one targeted question when type/criteria confidence is low. Batch mode **skips that step entirely** — it never pauses to ask the user about an individual item. Low-confidence fields are drafted with their defaulted assumptions and marked `(needs review)` in the body, exactly as before. Batch's only interactive gate remains the Step 4 approval prompt over the whole set.
+
 **Rate limiting:** If `gh issue create` returns a rate limit error, wait and retry with exponential backoff (5s, 10s, 20s). After 3 retries for a single item, skip it and continue with remaining items.
 
 **Progress output:** Show per-item progress:


### PR DESCRIPTION
Closes #139

## Summary

Makes intent capture in `/issue-creator` **active** instead of passive. Today the skill drafts a full issue from the raw input and only then asks the user to confirm or correct it — even when type or acceptance-criteria confidence is `low`. This PR adds a conditional **Step 3.5 — Clarify Ambiguous Intent** that asks one targeted question (with a recommended default) *before* drafting, but only when confidence is genuinely low and only in interactive Create mode. This closes weakness **W1** from the IDD honest review and makes the methodology doc's existing "structured interviewer" claim true.

## Approach

The change is **strictly additive** and gated on the skill's existing Confidence Scoring System. The design is unified by one rule:

> Each clarifying question's **recommended default = the assumption the one-shot path would have made today** (the `(needs review)` guess).

That single mechanism collapses all four behavioral requirements into one path:

| Context | Behavior |
|---------|----------|
| Type/criteria confidence `high`/`medium` | Silent no-op — one-shot path unchanged, zero new friction |
| Interactive Create, confidence `low` | Ask one question at a time, default = today's guess; accept → `medium`, override → `high` |
| Repo can answer the ambiguity | Resolve by inspection, don't ask; raise confidence (`high` if conclusive, `medium` if suggestive) |
| Batch / auto / non-interactive | Skip entirely — draft with defaults, stamp `(needs review)`, never block |

### Decision Record

- **Problem (W1):** `docs/idd-methodology.md` describes `/issue-creator` as a "multi-turn iterative clarification loop" with the agent as a "structured interviewer," but the real flow was single-shot (parse → classify → dedup → draft → confirm). It was *reactive* (user may correct the draft), never *active* (agent interrogates ambiguity). The gap sat directly on IDD's core strength.
- **Placement:** New step inserted **after dedup (Step 3), before draft (Step 4)** — so the skill never interrogates the user about an issue it's about to flag as a duplicate.
- **Gating:** Reuses the existing Confidence Scoring System. Acceptance-criteria confidence is normally a Step-4 artifact; Step 3.5 *predicts* it from the same input signals (no explicit requirements → `low`) so the decision to ask happens *before* drafting.
- **Output Contract tension (the key decision):** Criterion 5 (resolve questions via repo inspection) collides with the skill's Output Contract, which forbids codebase-derived content (affected files, technical notes, root cause, implementation hints) in the issue body. **Resolution:** repo inspection is allowed *only* to disambiguate intent and set confidence/classification — its findings must never leak into the body. Knowing a `ThemeToggle` component exists may flip a type from feature to bug, but neither the name nor any path appears in the draft. This boundary is stated explicitly in the new step.
- **Prompt idiom:** Plain `[Y/n]`-style text prompt with the default shown in-line — not a special UI widget — because the skill must also run on Claude.ai.
- **Doc tuning (avoid overshoot):** The methodology doc is tuned to describe *targeted, one-or-two-question, low-confidence-only* clarification — not open-ended multi-turn interrogation — so W1 isn't recreated in the opposite direction.
- **Scope discipline:** At most two questions, then proceed regardless. Targeted disambiguation, not an interview.

## Changes

| File | Change |
|------|--------|
| `src/skills/issue-creator/SKILL.source.md` | New **Step 3.5 — Clarify Ambiguous Intent**; architecture diagram updated; version `0.6.0` → `0.7.0` |
| `src/skills/issue-creator/references/modes.md` | Batch Step 5 note: Batch never blocks for clarification |
| `docs/idd-methodology.md` | Clarification-loop section rewritten — agent disambiguates intent *first*; "structured interviewer" claim made accurate |
| `skills/**` (built mirror) | Regenerated via `./scripts/build.sh` — `issue-creator/SKILL.md`, `references/modes.md`, and the bundled `idd-methodology.md` across all 7 skills |

This is a skills-only repo: source lives in `src/`, and the committed root-level `skills/` tree is the built install surface (regenerated, not hand-edited). Both are included so source and build stay in sync.

## Test Results

No runtime/test suite applies (`resolve.auto_test: false` — this is a documentation/skill-content change). Verification performed:

- ✅ `./scripts/build.sh` succeeds; built `skills/` mirror regenerated deterministically.
- ✅ Source ↔ build drift check: `Step 3.5` block is byte-identical between `SKILL.source.md` and built `SKILL.md`.
- ✅ Pre-push security scan (canonical Primary Pattern over the full branch diff): clean — no secrets, no warnings.
- ✅ Independent code-reviewer subagent pass: CLEAN verdict, all 6 criteria PASS, Output Contract reconciliation confirmed strong; 3 minor precision notes raised and all 3 addressed.

## Acceptance Criteria Verification

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | When type/criteria confidence is `low`, ask ≥1 clarifying question before drafting | ✅ Pass | Step 3.5 gates on `low` type/criteria confidence and runs before Step 4 (draft) |
| 2 | Questions asked one at a time, each with a recommended default | ✅ Pass | "Ask **one question at a time**… Offer a **recommended default**… Wait for the answer before asking the next"; example shows `⚡ Recommended:` + `[bug]` default |
| 3 | When confidence is `high`, no questions — one-shot path preserved | ✅ Pass | "When confidence is high, this step is a silent no-op and the one-shot path (Step 3 → Step 4) is unchanged" |
| 4 | Batch/auto never blocks — proceeds with `(needs review)` as today | ✅ Pass | *Non-interactive contexts* section + modes.md Batch note: skip entirely, draft with defaults, mark `(needs review)` |
| 5 | Repo-answerable questions resolved by inspection, not asked | ✅ Pass | *Resolve from the repo before asking* — settle the field and don't ask; Output Contract boundary keeps findings out of the body |
| 6 | `docs/idd-methodology.md` and skill behavior agree | ✅ Pass | Doc rewritten: agent "disambiguates intent first" with targeted, default-bearing, repo-first questions matching the skill |

> **Note:** This PR modifies skill *instructions* (Markdown), not executable code. The acceptance criteria are verified against the authored behavior specification and its built mirror.
