### PR TITLE
fix(landing): repair hero/card layout, add screenshot slideshow, simplify install (#147)

### DIFF
--- a/landing.html
+++ b/landing.html
@@ -411,13 +411,19 @@
     .shots-nav.prev { left: 12px; }
     .shots-nav.next { right: 12px; }
     /* Dots */
-    .shots-dots { display: flex; justify-content: center; gap: 10px; margin-top: 22px; }
+    .shots-dots { display: flex; justify-content: center; gap: 2px; margin-top: 22px; }
     .shots-dots button {
-      width: 9px; height: 9px; border-radius: 50%; padding: 0;
-      border: 1px solid var(--fg-dim); background: transparent;
-      cursor: pointer; transition: all .15s;
+      width: 28px; height: 28px; padding: 0;
+      border: 0; background: transparent;
+      display: grid; place-items: center;
+      cursor: pointer;
     }
-    .shots-dots button.active { background: var(--green); border-color: var(--green); box-shadow: 0 0 10px var(--green-glow); }
+    .shots-dots button::before {
+      content: ''; width: 9px; height: 9px; border-radius: 50%;
+      border: 1px solid var(--fg-dim); background: transparent;
+      transition: all .15s;
+    }
+    .shots-dots button.active::before { background: var(--green); border-color: var(--green); box-shadow: 0 0 10px var(--green-glow); }
     @media (max-width: 560px) {
       .shots-nav { width: 38px; height: 38px; font-size: 16px; }
       .shot .shot-frame, .shot img { max-height: 320px; }

--- a/landing.html
+++ b/landing.html
@@ -371,10 +371,19 @@
     .step p { margin: 0; color: var(--fg-muted); font-size: 0.94rem; line-height: 1.55; }
     .step code { font-family: var(--mono); color: var(--green); font-size: 0.88em; }
 
-    /* ── Screenshots showcase ── */
-    .shots { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; margin-top: 50px; }
-    @media (max-width: 860px) { .shots { grid-template-columns: 1fr; } }
+    /* ── Screenshots slideshow (compact carousel) ── */
+    .shots {
+      margin: 50px auto 0; max-width: 900px;
+      position: relative;
+    }
+    .shots-viewport { overflow: hidden; border-radius: var(--radius); }
+    .shots-track {
+      display: flex;
+      transition: transform .4s cubic-bezier(.4, 0, .2, 1);
+      will-change: transform;
+    }
     .shot {
+      flex: 0 0 100%; min-width: 0;
       border: 1px solid var(--line); border-radius: var(--radius); overflow: hidden;
       background: var(--bg-soft); box-shadow: 0 24px 70px -36px rgba(0,0,0,0.8);
     }
@@ -384,8 +393,35 @@
       display: flex; align-items: center; gap: 9px;
     }
     .shot .cap .green { color: var(--green); font-weight: 600; }
-    .shot img { display: block; width: 100%; height: auto; }
-    .shot.wide { grid-column: 1 / -1; }
+    .shot .shot-frame {
+      display: flex; align-items: center; justify-content: center;
+      max-height: 460px; overflow: hidden; background: #0b0c0d;
+    }
+    .shot img { display: block; max-width: 100%; max-height: 460px; height: auto; width: auto; }
+    /* Prev / next arrows */
+    .shots-nav {
+      position: absolute; top: 50%; transform: translateY(-50%);
+      width: 44px; height: 44px; border-radius: 50%;
+      display: flex; align-items: center; justify-content: center;
+      background: rgba(10,10,10,0.72); border: 1px solid var(--line);
+      color: var(--fg); font-family: var(--mono); font-size: 18px;
+      cursor: pointer; transition: all .15s; z-index: 2; backdrop-filter: blur(8px);
+    }
+    .shots-nav:hover { border-color: var(--green); color: var(--green); }
+    .shots-nav.prev { left: 12px; }
+    .shots-nav.next { right: 12px; }
+    /* Dots */
+    .shots-dots { display: flex; justify-content: center; gap: 10px; margin-top: 22px; }
+    .shots-dots button {
+      width: 9px; height: 9px; border-radius: 50%; padding: 0;
+      border: 1px solid var(--fg-dim); background: transparent;
+      cursor: pointer; transition: all .15s;
+    }
+    .shots-dots button.active { background: var(--green); border-color: var(--green); box-shadow: 0 0 10px var(--green-glow); }
+    @media (max-width: 560px) {
+      .shots-nav { width: 38px; height: 38px; font-size: 16px; }
+      .shot .shot-frame, .shot img { max-height: 320px; }
+    }
 
     /* ── Works with ── */
     .tools { display: flex; flex-wrap: wrap; gap: 14px; margin-top: 44px; justify-content: center; }
@@ -486,19 +522,10 @@
       overflow: hidden; max-width: 820px; margin-left: auto; margin-right: auto;
       background: #0c0e0f;
     }
-    .install-tabs { display: flex; border-bottom: 1px solid var(--line); background: #101315; }
-    .install-tabs button {
-      flex: 1; font-family: var(--mono); font-size: 13.5px; font-weight: 600;
-      background: transparent; color: var(--fg-dim); border: none; padding: 14px;
-      cursor: pointer; border-bottom: 2px solid transparent; transition: all .15s;
-    }
-    .install-tabs button.active { color: var(--green); border-bottom-color: var(--green); background: rgba(0,255,65,0.04); }
     .install-body { padding: 24px 26px; font-family: var(--mono); font-size: 14px; line-height: 1.9; }
     .install-body .cmt { color: var(--fg-dim); }
     .install-body .cmd { color: var(--fg); }
     .install-body .cmd .green { color: var(--green); }
-    .install-pane { display: none; }
-    .install-pane.active { display: block; }
     .copy-row { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
     .copy-btn {
       font-family: var(--mono); font-size: 12px; color: var(--fg-dim);
@@ -679,20 +706,19 @@
   <section class="hero" id="top">
     <div class="wrap hero-grid">
       <div>
-        <!-- COOLDOWN-LAUNCH START · seasonal banner · issues #133 #135 — delete to revert to standard branding -->
-        <span class="eyebrow cooldown-eyebrow"><span class="dot"></span>🧊 Cooldown launch · <strong>Ice</strong> Driven Development — a temporary heat-wave gag. IDD still means <strong>Intention</strong>-Driven Development.</span>
+        <!-- COOLDOWN-LAUNCH START · seasonal banner · issues #133 #135 — to revert to standard
+             branding, swap the icy pill below back to the standard eyebrow copy:
+             "Issue-Driven Development · 8 commands · MIT" (drop the cooldown-eyebrow class). -->
+        <span class="eyebrow cooldown-eyebrow"><span class="dot"></span>🧊 <strong>Ice</strong> Driven Development — a cooldown-launch gag · 8 commands · MIT</span>
         <!-- COOLDOWN-LAUNCH END · seasonal banner -->
-        <span class="eyebrow"><span class="dot"></span>Issue-Driven Development · 8 commands · MIT</span>
         <h1 class="hero-title">Turn GitHub issues into <span class="accent">agent-ready work orders.</span></h1>
         <p class="hero-sub">
           Eight terminal commands that <strong>structure, analyze, triage, resolve, and review</strong> your GitHub issues —
-          so any developer or AI agent can pick up an issue and ship a tested PR. Zero config. Works with the tools you already use.
+          so any developer or AI agent can pick up an issue and ship a tested PR. Zero config.
         </p>
         <!-- COOLDOWN-LAUNCH START · hero ice humor · issue #135 — delete to revert to standard messaging -->
         <p class="hero-sub cooldown-quip">
-          No frostbite, just fewer burned hours: we keep your backlog <strong>cool</strong>, your intentions
-          <strong>crystal-clear</strong>, and your merge conflicts on ice. 🧊 Same IDD — capturing what humans
-          actually mean so AI ships the right fix — now served chilled.
+          🧊 Same IDD, served chilled — backlog <strong>cool</strong>, intentions <strong>crystal-clear</strong>, merge conflicts on ice.
         </p>
         <!-- COOLDOWN-LAUNCH END · hero ice humor -->
         <div class="hero-cta">
@@ -711,26 +737,22 @@
       </div>
 
       <!-- Live terminal mock -->
-      <div class="terminal reveal">
+      <div class="terminal compact reveal">
         <div class="term-bar">
           <div class="dots"><i></i><i></i><i></i></div>
           <span class="title">~/your-repo — issuedev</span>
         </div>
         <div class="term-body">
 <div class="ln"><span class="c-prompt">❯</span> /issue-resolver 42</div>
-<div class="ln">&nbsp;</div>
 <div class="ln"><span class="c-head">◆ Resolve Pipeline</span></div>
-<div class="ln c-dim">┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄</div>
-<div class="ln"><span class="c-step">[0/5] Preflight</span>    <span class="c-ok">✓</span> issue #42 open, not yet resolved</div>
-<div class="ln"><span class="c-step">[1/5] Research </span>    <span class="c-ok">✓</span> read 5 files, complexity: medium</div>
-<div class="ln"><span class="c-step">[2/5] Plan     </span>    <span class="c-ok">✓</span> approach: fix redirect logic</div>
-<div class="ln"><span class="c-step">[3/5] Implement</span>    <span class="c-ok">✓</span> 2 files changed, 45 lines</div>
+<div class="ln"><span class="c-step">[0/5] Preflight</span>    <span class="c-ok">✓</span> issue #42 open</div>
+<div class="ln"><span class="c-step">[1/5] Research </span>    <span class="c-ok">✓</span> read 5 files</div>
+<div class="ln"><span class="c-step">[2/5] Plan     </span>    <span class="c-ok">✓</span> fix redirect logic</div>
+<div class="ln"><span class="c-step">[3/5] Implement</span>    <span class="c-ok">✓</span> 2 files, 45 lines</div>
 <div class="ln"><span class="c-step">[4/5] QA       </span>    <span class="c-ok">✓</span> clean after 2 cycles</div>
 <div class="ln"><span class="c-step">[5/5] Deliver  </span>    <span class="c-ok">✓</span> PR #87 created</div>
 <div class="ln">&nbsp;</div>
 <div class="ln"><span class="c-ok">✓</span> Done — <span class="c-cyan">PR #87</span>: fix(auth): resolve redirect (#42)</div>
-<div class="ln c-cyan">&nbsp;&nbsp;&nbsp;github.com/you/repo/pull/87</div>
-<div class="ln c-dim">&nbsp;&nbsp;&nbsp;Closes #42</div>
 <div class="ln"><span class="c-prompt">❯</span> <span class="cursor"></span></div>
         </div>
       </div>
@@ -800,6 +822,8 @@
           <p>Triage → resolve → review → merge, looped across the backlog. Clean PRs merge; partial ones stay open for review unless you opt into aggressive mode. Dependency-aware merge gate keeps order sane.</p>
           <div class="effort">effort <b>max</b></div>
         </div>
+      </div>
+
       <div class="model-highlight reveal">
         <div class="model-panel">
           <div class="section-tag" style="margin-bottom: 10px;">Cost-aware by default</div>
@@ -881,27 +905,34 @@
       <h2 class="sec-title">Transparency, not a black box.</h2>
       <p class="sec-lead">Confidence scores, step progress, and exactly what's happening at each phase — straight from your terminal. Every symbol carries meaning.</p>
 
-      <div class="shots">
-        <div class="shot wide reveal">
-          <div class="cap"><span class="green">❯</span> /issue-creator <span class="muted">— classify, effort, model + thinking hint, acceptance criteria</span></div>
-          <img src="assets/screenshots/issue-creator.png" alt="issue-creator terminal output showing a structured issue preview" width="898" height="735" loading="eager" fetchpriority="high" />
+      <div class="shots reveal" id="shots" role="region" tabindex="0" aria-roledescription="carousel" aria-label="Product screenshots (use arrow keys to navigate)">
+        <div class="shots-viewport">
+          <div class="shots-track" id="shots-track">
+            <div class="shot" role="group" aria-roledescription="slide" aria-label="1 of 5">
+              <div class="cap"><span class="green">❯</span> /issue-creator <span class="muted">— classify, effort, model + thinking hint, acceptance criteria</span></div>
+              <div class="shot-frame"><img src="assets/screenshots/issue-creator.png" alt="issue-creator terminal output showing a structured issue preview" width="898" height="735" loading="eager" fetchpriority="high" /></div>
+            </div>
+            <div class="shot" role="group" aria-roledescription="slide" aria-label="2 of 5">
+              <div class="cap"><span class="green">❯</span> /issue-resolver 11</div>
+              <div class="shot-frame"><img src="assets/screenshots/issue-resolver-11.png" alt="issue-resolver running its 6-step pipeline" width="766" height="725" loading="lazy" /></div>
+            </div>
+            <div class="shot" role="group" aria-roledescription="slide" aria-label="3 of 5">
+              <div class="cap"><span class="green">❯</span> /issue-triage <span class="muted">— execution order</span></div>
+              <div class="shot-frame"><img src="assets/screenshots/issue-triage-suggestion.png" alt="issue-triage suggested execution order" width="1049" height="335" loading="lazy" /></div>
+            </div>
+            <div class="shot" role="group" aria-roledescription="slide" aria-label="4 of 5">
+              <div class="cap"><span class="green">❯</span> /issue-triage <span class="muted">— backlog view</span></div>
+              <div class="shot-frame"><img src="assets/screenshots/issue-triage-view.png" alt="issue-triage backlog table with priorities and blockers" width="585" height="555" loading="lazy" /></div>
+            </div>
+            <div class="shot" role="group" aria-roledescription="slide" aria-label="5 of 5">
+              <div class="cap"><span class="green">❯</span> /issue-triage <span class="muted">— hot-spot &amp; critical path</span></div>
+              <div class="shot-frame"><img src="assets/screenshots/issue-triage-asm.png" alt="issue-triage hot-spot files and critical path analysis" width="668" height="436" loading="lazy" /></div>
+            </div>
+          </div>
         </div>
-        <div class="shot reveal">
-          <div class="cap"><span class="green">❯</span> /issue-resolver 11</div>
-          <img src="assets/screenshots/issue-resolver-11.png" alt="issue-resolver running its 6-step pipeline" width="766" height="725" loading="lazy" />
-        </div>
-        <div class="shot reveal">
-          <div class="cap"><span class="green">❯</span> /issue-triage <span class="muted">— execution order</span></div>
-          <img src="assets/screenshots/issue-triage-suggestion.png" alt="issue-triage suggested execution order" width="1049" height="335" loading="lazy" />
-        </div>
-        <div class="shot reveal">
-          <div class="cap"><span class="green">❯</span> /issue-triage <span class="muted">— backlog view</span></div>
-          <img src="assets/screenshots/issue-triage-view.png" alt="issue-triage backlog table with priorities and blockers" width="585" height="555" loading="lazy" />
-        </div>
-        <div class="shot reveal">
-          <div class="cap"><span class="green">❯</span> /issue-triage <span class="muted">— hot-spot &amp; critical path</span></div>
-          <img src="assets/screenshots/issue-triage-asm.png" alt="issue-triage hot-spot files and critical path analysis" width="668" height="436" loading="lazy" />
-        </div>
+        <button class="shots-nav prev" id="shots-prev" type="button" aria-label="Previous screenshot">‹</button>
+        <button class="shots-nav next" id="shots-next" type="button" aria-label="Next screenshot">›</button>
+        <div class="shots-dots" id="shots-dots" aria-label="Choose screenshot"></div>
       </div>
     </div>
   </section>
@@ -1092,52 +1123,13 @@
       <p class="sec-lead">Needs <code class="mono green">gh</code> 2.0+, Git 2.30+, and Claude Code (or any SKILL.md agent). Zero config to start.</p>
 
       <div class="install-box reveal">
-        <div class="install-tabs">
-          <button class="active" data-tab="asm">asm install</button>
-          <button data-tab="source">from source</button>
-          <button data-tab="use">first run</button>
-        </div>
-
         <div class="install-body">
-          <div class="install-pane active" id="pane-asm">
-            <div class="copy-row">
-              <div>
-                <div class="cmt"># recommended — pick any skill from the repo with a single command</div>
-                <div class="cmd"><span class="green">asm</span> install https://github.com/luongnv89/idd</div>
-              </div>
-              <button class="copy-btn" data-copy="asm install https://github.com/luongnv89/idd">copy</button>
+          <div class="copy-row">
+            <div>
+              <div class="cmt"># one command installs the whole pack — all eight skills</div>
+              <div class="cmd"><span class="green">asm</span> install https://github.com/luongnv89/idd</div>
             </div>
-            <div class="copy-row" style="margin-top:14px;">
-              <div>
-                <div class="cmt"># or install a specific skill directly</div>
-                <div class="cmd"><span class="green">asm</span> install https://github.com/luongnv89/idd#main:skills/issue-resolver</div>
-              </div>
-              <button class="copy-btn" data-copy="asm install https://github.com/luongnv89/idd#main:skills/issue-resolver">copy</button>
-            </div>
-          </div>
-
-          <div class="install-pane" id="pane-source">
-            <div class="copy-row">
-              <div>
-                <div class="cmt"># no asm required — clone and run the installer</div>
-                <div class="cmd"><span class="green">git</span> clone https://github.com/luongnv89/idd.git</div>
-                <div class="cmd">cd idd &amp;&amp; ./scripts/install.sh</div>
-              </div>
-              <button class="copy-btn" data-copy="git clone https://github.com/luongnv89/idd.git && cd idd && ./scripts/install.sh">copy</button>
-            </div>
-          </div>
-
-          <div class="install-pane" id="pane-use">
-            <div class="copy-row">
-              <div>
-                <div class="cmt"># create a structured issue, then resolve it</div>
-                <div class="cmd"><span class="green">/issue-creator</span> "Login fails on mobile when the session cookie expires"</div>
-                <div class="cmd"><span class="green">/issue-resolver</span> 42</div>
-                <div class="cmt"># …or go hands-free across the whole backlog</div>
-                <div class="cmd"><span class="green">/auto-pilot</span></div>
-              </div>
-              <button class="copy-btn" data-copy='/issue-creator "Login fails on mobile when the session cookie expires"'>copy</button>
-            </div>
+            <button class="copy-btn" data-copy="asm install https://github.com/luongnv89/idd">copy</button>
           </div>
         </div>
       </div>
@@ -1220,15 +1212,45 @@
   </footer>
 
   <script>
-    // Install tabs
-    document.querySelectorAll('.install-tabs button').forEach(function (b) {
-      b.addEventListener('click', function () {
-        document.querySelectorAll('.install-tabs button').forEach(function (x) { x.classList.remove('active'); });
-        document.querySelectorAll('.install-pane').forEach(function (x) { x.classList.remove('active'); });
-        b.classList.add('active');
-        document.getElementById('pane-' + b.dataset.tab).classList.add('active');
+    // Screenshots slideshow
+    (function () {
+      var track = document.getElementById('shots-track');
+      if (!track) return;
+      var slides = track.children;
+      var total = slides.length;
+      var dotsWrap = document.getElementById('shots-dots');
+      var prev = document.getElementById('shots-prev');
+      var next = document.getElementById('shots-next');
+      var index = 0;
+
+      function go(i) {
+        index = (i + total) % total;
+        track.style.transform = 'translateX(' + (-index * 100) + '%)';
+        var dots = dotsWrap.children;
+        for (var d = 0; d < dots.length; d++) {
+          dots[d].classList.toggle('active', d === index);
+          dots[d].setAttribute('aria-current', d === index ? 'true' : 'false');
+        }
+      }
+
+      for (var i = 0; i < total; i++) {
+        (function (i) {
+          var dot = document.createElement('button');
+          dot.type = 'button';
+          dot.setAttribute('aria-label', 'Go to screenshot ' + (i + 1));
+          dot.addEventListener('click', function () { go(i); });
+          dotsWrap.appendChild(dot);
+        }(i));
+      }
+
+      prev.addEventListener('click', function () { go(index - 1); });
+      next.addEventListener('click', function () { go(index + 1); });
+      document.getElementById('shots').addEventListener('keydown', function (e) {
+        if (e.key === 'ArrowLeft') { go(index - 1); }
+        else if (e.key === 'ArrowRight') { go(index + 1); }
       });
-    });
+      go(0);
+    }());
 
     // Copy buttons
     document.querySelectorAll('.copy-btn').forEach(function (btn) {

--- a/tests/test-landing-structure.sh
+++ b/tests/test-landing-structure.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# test-landing-structure.sh — Validate landing.html structure for the batched
+# landing-page fixes (issues #147, #148, #149, #150).
+#
+# Asserts:
+#   #147 — hero terminal is compact; redundant second eyebrow pill removed
+#   #148 — .feat-grid is explicitly closed before .model-highlight so the
+#          "Cost-aware by default" panel is full-width (balanced <div> count)
+#   #149 — screenshots render as a single slideshow (track + 5 slides + nav/dots)
+#   #150 — install section shows only the single full-pack command; the multi-tab
+#          UI and partial/source/first-run commands are gone
+#
+# This is a static HTML page — there is no JS test runner — so this test does
+# structural string + tag-balance checks only.
+#
+# Usage: bash tests/test-landing-structure.sh
+# Returns: exit 0 on pass, exit 1 on failure.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LANDING="$REPO_ROOT/landing.html"
+
+PASS=0
+FAIL=0
+
+pass() { echo "  ✓ $1"; PASS=$((PASS + 1)); }
+fail() { echo "  ✗ $1"; FAIL=$((FAIL + 1)); }
+
+echo "◆ Landing Structure Tests (issues #147 #148 #149 #150)"
+echo "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄"
+
+# T0: file exists
+if [ -f "$LANDING" ]; then
+  pass "T0: landing.html exists"
+else
+  fail "T0: landing.html missing"
+  echo "Result: $PASS passed, $FAIL failed"
+  exit 1
+fi
+
+# ── Tag balance (overall integrity; #148 root cause was an unclosed grid) ──
+opens=$(grep -o '<div\b' "$LANDING" | wc -l | tr -d ' ')
+closes=$(grep -o '</div>' "$LANDING" | wc -l | tr -d ' ')
+if [ "$opens" = "$closes" ]; then
+  pass "T1: <div> tags balanced ($opens open / $closes close)"
+else
+  fail "T1: <div> imbalance — $opens open vs $closes close"
+fi
+
+# ── #147: hero terminal compact + single eyebrow ──
+if grep -q 'class="terminal compact reveal"' "$LANDING"; then
+  pass "T2 (#147): hero terminal uses compact sizing"
+else
+  fail "T2 (#147): hero terminal not marked compact"
+fi
+eyebrows=$(grep -c 'class="eyebrow' "$LANDING" || true)
+if [ "$eyebrows" -le 1 ]; then
+  pass "T3 (#147): redundant hero eyebrow pill removed ($eyebrows remaining)"
+else
+  fail "T3 (#147): expected <=1 hero eyebrow, found $eyebrows"
+fi
+
+# ── #148: model-highlight sits OUTSIDE feat-grid ──
+# The feat-grid must close (</div>) before .model-highlight opens.
+if grep -Pzoq '</div>\s*\n\s*<div class="model-highlight' "$LANDING"; then
+  pass "T4 (#148): .model-highlight is a sibling of .feat-grid (panel full-width)"
+else
+  fail "T4 (#148): .model-highlight still nested inside .feat-grid"
+fi
+
+# ── #149: slideshow markup present ──
+if grep -q 'id="shots-track"' "$LANDING" \
+   && grep -q 'id="shots-prev"' "$LANDING" \
+   && grep -q 'id="shots-next"' "$LANDING" \
+   && grep -q 'id="shots-dots"' "$LANDING"; then
+  pass "T5 (#149): slideshow track + prev/next + dots present"
+else
+  fail "T5 (#149): slideshow controls missing"
+fi
+slides=$(grep -c 'aria-roledescription="slide"' "$LANDING" || true)
+if [ "$slides" = "5" ]; then
+  pass "T6 (#149): all 5 screenshots preserved as slides"
+else
+  fail "T6 (#149): expected 5 slides, found $slides"
+fi
+if ! grep -q 'class="shot wide' "$LANDING"; then
+  pass "T7 (#149): old static grid layout removed (no .shot.wide)"
+else
+  fail "T7 (#149): leftover static grid markup (.shot.wide)"
+fi
+
+# ── #150: single full-pack install command only ──
+if grep -q 'asm install https://github.com/luongnv89/idd' "$LANDING"; then
+  pass "T8 (#150): full-pack install command present"
+else
+  fail "T8 (#150): full-pack install command missing"
+fi
+if ! grep -q 'install-tabs' "$LANDING" \
+   && ! grep -q 'install-pane' "$LANDING" \
+   && ! grep -q '#main:skills/issue-resolver' "$LANDING" \
+   && ! grep -q './scripts/install.sh' "$LANDING"; then
+  pass "T9 (#150): tabs + partial/source/first-run install commands removed"
+else
+  fail "T9 (#150): leftover partial install commands or tab UI"
+fi
+
+echo "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄"
+echo "Result: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Batched resolution of four landing-page issues that all edit `landing.html` in distinct sections — shipped as one PR to avoid repeated merge conflicts in the same file.

Closes #147
Closes #148
Closes #149
Closes #150

## Approach

Each issue maps to an isolated section of `landing.html`; the fixes were applied with the minimum changes needed and the existing visual design language (neon-green/mono terminal aesthetic, Ice/Cooldown seasonal skin) preserved.

## Decision Record

- **#148 root cause** was structural, not cosmetic: `.model-highlight` was nested inside `.feat-grid` (a 2-column grid) whose closing `</div>` was missing, so the wide "Cost-aware by default" panel was forced into a half-width cell and overflowed. Adding the missing `</div>` makes `.model-highlight` a full-width sibling — a one-line fix at the true cause rather than masking with `overflow`/clamps.
- **#149** chose a dependency-free CSS transform + vanilla-JS carousel (translateX track, arrows, dots, keyboard support) over a library, consistent with this static single-file page.
- **#150** interpreted "only keep the command to install the whole pack" as removing the entire tab UI and all partial/alternate commands, leaving one clear copyable command. Dead `.install-tabs`/`.install-pane` CSS and the tab-init JS were removed too.
- **#147** reduced left-column volume (merged the two stacked eyebrow pills into one, shortened the cooldown quip and hero-sub) and applied the pre-existing `.terminal.compact` style plus fewer mock lines to shrink the terminal — keeping the Ice skin intact.

## Changes

| Area | Change |
|------|--------|
| Hero (#147) | One eyebrow pill, shorter sub/quip, `terminal compact` + trimmed mock lines |
| The Fix (#148) | `.feat-grid` explicitly closed; `.model-highlight` now full-width |
| Screenshots (#149) | Static 2-col grid → compact slideshow (track, arrows, dots, arrow keys); all 5 shots kept |
| Install (#150) | Single full-pack `asm install` command; tabs/partial/source/first-run + dead CSS/JS removed |
| Tests | New `tests/test-landing-structure.sh` (structure + tag-balance) |

## Test Results

- `tests/test-landing-structure.sh` — 10/10 pass
- Embedded JS `node --check` — pass
- HTML tag balance — `<div>` 161/161, all block tags balanced (Python HTMLParser: no auto-close/stray)

## Acceptance Criteria Verification

| Issue | Criteria | Status |
|-------|----------|--------|
| #147 | Hero renders without broken/overflow; left text shortened; terminal smaller; balanced | Met |
| #148 | "Cost-aware by default" fits its card; Fix section consistent; holds on mobile | Met |
| #149 | Single compact slideshow; navigable (arrows/dots/keys); less vertical space; responsive | Met |
| #150 | Only full-pack install command; partial commands removed; copyable | Met |

> Note: visual/responsive criteria validated via HTML structure checks and code review (static page, no browser test runner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)