### PR TITLE
docs(landing): shorten hero tagline and align meta copy

### DIFF
--- a/landing.html
+++ b/landing.html
@@ -4,28 +4,28 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>issuedev — GitHub Issue Workflow for AI Coding Agents</title>
-  <meta name="description" content="Issue-Driven Development for GitHub: structure, triage, resolve, and review issues with eight agent-ready terminal commands that ship tested PRs." />
+  <meta name="description" content="Issue-Driven Development for GitHub: turn issues into agent-ready work orders. Eight terminal commands structure, triage, resolve, and review — shipping tested PRs." />
   <link rel="canonical" href="https://luongnv.com/idd/" />
   <link rel="icon" type="image/svg+xml" href="assets/logo/favicon.svg" />
   <meta name="theme-color" content="#0A0A0A" />
 
   <!-- Open Graph -->
   <meta property="og:title" content="issuedev — GitHub Issue Workflow for AI Coding Agents" />
-  <meta property="og:description" content="Issue-Driven Development for GitHub: structure, triage, resolve, and review issues with eight agent-ready terminal commands." />
+  <meta property="og:description" content="Turn issues into agent-ready work orders — eight terminal commands that structure, triage, resolve, and review." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://luongnv.com/idd/" />
   <meta property="og:site_name" content="issuedev" />
   <meta property="og:image" content="https://luongnv.com/idd/assets/og/og-card.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
-  <meta property="og:image:alt" content="issuedev — turn GitHub issues into agent-ready work orders" />
+  <meta property="og:image:alt" content="issuedev — issues → agent-ready work orders" />
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="issuedev — GitHub Issue Workflow for AI Coding Agents" />
-  <meta name="twitter:description" content="Structure, triage, resolve, and review GitHub issues with eight agent-ready commands that ship tested PRs." />
+  <meta name="twitter:description" content="Turn issues into agent-ready work orders — eight agent-ready commands that structure, triage, resolve, and review, shipping tested PRs." />
   <meta name="twitter:image" content="https://luongnv.com/idd/assets/og/og-card.png" />
-  <meta name="twitter:image:alt" content="issuedev — turn GitHub issues into agent-ready work orders" />
+  <meta name="twitter:image:alt" content="issuedev — issues → agent-ready work orders" />
 
   <!-- Structured data -->
   <script type="application/ld+json">
@@ -44,7 +44,7 @@
         "@id": "https://luongnv.com/idd/#website",
         "url": "https://luongnv.com/idd/",
         "name": "issuedev",
-        "description": "Issue-Driven Development — eight terminal commands that turn GitHub issues into agent-ready work orders.",
+        "description": "Issue-Driven Development — eight terminal commands that turn issues into agent-ready work orders.",
         "inLanguage": "en",
         "publisher": { "@id": "https://luongnv.com/#organization" }
       },
@@ -715,9 +715,9 @@
         <!-- COOLDOWN-LAUNCH START · seasonal banner · issues #133 #135 — to revert to standard
              branding, swap the icy pill below back to the standard eyebrow copy:
              "Issue-Driven Development · 8 commands · MIT" (drop the cooldown-eyebrow class). -->
-        <span class="eyebrow cooldown-eyebrow"><span class="dot"></span>🧊 <strong>Ice</strong> Driven Development — a cooldown-launch gag · 8 commands · MIT</span>
+        <span class="eyebrow cooldown-eyebrow"><span class="dot"></span>🧊 <strong>Ice</strong> Driven Development</span>
         <!-- COOLDOWN-LAUNCH END · seasonal banner -->
-        <h1 class="hero-title">Turn GitHub issues into <span class="accent">agent-ready work orders.</span></h1>
+        <h1 class="hero-title">Issues → <span class="accent">agent-ready work orders.</span></h1>
         <p class="hero-sub">
           Eight terminal commands that <strong>structure, analyze, triage, resolve, and review</strong> your GitHub issues —
           so any developer or AI agent can pick up an issue and ship a tested PR. Zero config.


### PR DESCRIPTION
Tighten the landing page copy around a shorter tagline.

## Changes
- **Hero headline** → `Issues → agent-ready work orders.`
- **Cooldown eyebrow** → `🧊 Ice Driven Development` (dropped "— a cooldown-launch gag · 8 commands · MIT")
- **Meta / OG / Twitter descriptions** and **JSON-LD description** aligned around the "issues → agent-ready work orders" tagline; image `alt` text uses the `→` arrow form, prose descriptions keep sentence form for SEO.

Copy-only change to `landing.html`; no functional/markup-structure changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)