### PR TITLE
refactor(agents): define severity high/medium boundary for reviewers (#172)

### DIFF
--- a/skills/issue-pr-review/references/agents/code-reviewer.md
+++ b/skills/issue-pr-review/references/agents/code-reviewer.md
@@ -36,7 +36,8 @@ You are reviewing branch "{branch_name}" against base "{base_branch}".
    - **Security**: injection (SQL/XSS/command), hardcoded secrets, auth bypass, unsafe deserialization, path traversal
    - **Edge cases**: null/undefined, empty arrays, boundaries, crashing error paths
 5. Score each candidate 0–100 (scale in references/docs/shared-agent-conventions.md). **Report only >= 80.**
-6. Set each issue's **action**:
+6. Set each issue's **severity**: `high` if a realistic input/timing reaches it and it corrupts data, breaks auth, or crashes a user-facing path; `medium` if real but needs an unlikely precondition, or is confined to an internal/admin/dev-only path.
+7. Set each issue's **action**:
    - **"fix"**: high-severity correctness / security / edge_cases; test failures (broken tests block merge)
    - **"note"**: code_quality or test_coverage medium issues; anything cosmetic, stylistic, or subjective
    Reserve fix cycles for issues that affect correctness, security, or functionality.

--- a/skills/issue-pr-review/references/agents/ui-reviewer.md
+++ b/skills/issue-pr-review/references/agents/ui-reviewer.md
@@ -44,7 +44,7 @@ Reviewing branch "{branch_name}" against base "{base_branch}".
 3. Per screenshot evaluate: layout & overflow (clipping, horizontal scroll, overlap, z-index, fixed-position breaking); responsive behavior across viewports; visual consistency (alignment, spacing, fonts, color, icon sizing, radius); interactive states (hover/focus/active/disabled, loading); accessibility indicators (focus rings, contrast, visible labels); content rendering (broken icons, truncation, emoji); cross-viewport breakage.
 
 ## Scoring (both modes)
-Score each candidate 0–100 (scale in references/docs/shared-agent-conventions.md). **Report only >= 75.** Set **action**:
+Score each candidate 0–100 (scale in references/docs/shared-agent-conventions.md). **Report only >= 75.** Set **severity**: `high` if it blocks a user from completing a task (can't read, click, focus, or submit) on a common viewport/AT; `medium` if the task is still completable but degraded (e.g. visible but sub-AA contrast, awkward but reachable target). Set **action**:
 - **"fix"**: WCAG A/AA violations, broken layouts on common viewports, missing focus indicators, unclickable touch targets, overflowing text, form-validation issues
 - **"note"**: minor spacing, AA+ contrast nice-to-haves, cosmetic alignment, enhancement suggestions
 

--- a/skills/issue-resolver/references/agents/code-reviewer.md
+++ b/skills/issue-resolver/references/agents/code-reviewer.md
@@ -36,7 +36,8 @@ You are reviewing branch "{branch_name}" against base "{base_branch}".
    - **Security**: injection (SQL/XSS/command), hardcoded secrets, auth bypass, unsafe deserialization, path traversal
    - **Edge cases**: null/undefined, empty arrays, boundaries, crashing error paths
 5. Score each candidate 0–100 (scale in references/docs/shared-agent-conventions.md). **Report only >= 80.**
-6. Set each issue's **action**:
+6. Set each issue's **severity**: `high` if a realistic input/timing reaches it and it corrupts data, breaks auth, or crashes a user-facing path; `medium` if real but needs an unlikely precondition, or is confined to an internal/admin/dev-only path.
+7. Set each issue's **action**:
    - **"fix"**: high-severity correctness / security / edge_cases; test failures (broken tests block merge)
    - **"note"**: code_quality or test_coverage medium issues; anything cosmetic, stylistic, or subjective
    Reserve fix cycles for issues that affect correctness, security, or functionality.

--- a/skills/issue-resolver/references/agents/ui-reviewer.md
+++ b/skills/issue-resolver/references/agents/ui-reviewer.md
@@ -44,7 +44,7 @@ Reviewing branch "{branch_name}" against base "{base_branch}".
 3. Per screenshot evaluate: layout & overflow (clipping, horizontal scroll, overlap, z-index, fixed-position breaking); responsive behavior across viewports; visual consistency (alignment, spacing, fonts, color, icon sizing, radius); interactive states (hover/focus/active/disabled, loading); accessibility indicators (focus rings, contrast, visible labels); content rendering (broken icons, truncation, emoji); cross-viewport breakage.
 
 ## Scoring (both modes)
-Score each candidate 0–100 (scale in references/docs/shared-agent-conventions.md). **Report only >= 75.** Set **action**:
+Score each candidate 0–100 (scale in references/docs/shared-agent-conventions.md). **Report only >= 75.** Set **severity**: `high` if it blocks a user from completing a task (can't read, click, focus, or submit) on a common viewport/AT; `medium` if the task is still completable but degraded (e.g. visible but sub-AA contrast, awkward but reachable target). Set **action**:
 - **"fix"**: WCAG A/AA violations, broken layouts on common viewports, missing focus indicators, unclickable touch targets, overflowing text, form-validation issues
 - **"note"**: minor spacing, AA+ contrast nice-to-haves, cosmetic alignment, enhancement suggestions
 

--- a/src/shared/agents/code-reviewer.md
+++ b/src/shared/agents/code-reviewer.md
@@ -35,7 +35,8 @@ You are reviewing branch "{branch_name}" against base "{base_branch}".
    - **Security**: injection (SQL/XSS/command), hardcoded secrets, auth bypass, unsafe deserialization, path traversal
    - **Edge cases**: null/undefined, empty arrays, boundaries, crashing error paths
 5. Score each candidate 0–100 (scale in docs/shared-agent-conventions.md). **Report only >= 80.**
-6. Set each issue's **action**:
+6. Set each issue's **severity**: `high` if a realistic input/timing reaches it and it corrupts data, breaks auth, or crashes a user-facing path; `medium` if real but needs an unlikely precondition, or is confined to an internal/admin/dev-only path.
+7. Set each issue's **action**:
    - **"fix"**: high-severity correctness / security / edge_cases; test failures (broken tests block merge)
    - **"note"**: code_quality or test_coverage medium issues; anything cosmetic, stylistic, or subjective
    Reserve fix cycles for issues that affect correctness, security, or functionality.

--- a/src/shared/agents/ui-reviewer.md
+++ b/src/shared/agents/ui-reviewer.md
@@ -43,7 +43,7 @@ Reviewing branch "{branch_name}" against base "{base_branch}".
 3. Per screenshot evaluate: layout & overflow (clipping, horizontal scroll, overlap, z-index, fixed-position breaking); responsive behavior across viewports; visual consistency (alignment, spacing, fonts, color, icon sizing, radius); interactive states (hover/focus/active/disabled, loading); accessibility indicators (focus rings, contrast, visible labels); content rendering (broken icons, truncation, emoji); cross-viewport breakage.
 
 ## Scoring (both modes)
-Score each candidate 0–100 (scale in docs/shared-agent-conventions.md). **Report only >= 75.** Set **action**:
+Score each candidate 0–100 (scale in docs/shared-agent-conventions.md). **Report only >= 75.** Set **severity**: `high` if it blocks a user from completing a task (can't read, click, focus, or submit) on a common viewport/AT; `medium` if the task is still completable but degraded (e.g. visible but sub-AA contrast, awkward but reachable target). Set **action**:
 - **"fix"**: WCAG A/AA violations, broken layouts on common viewports, missing focus indicators, unclickable touch targets, overflowing text, form-validation issues
 - **"note"**: minor spacing, AA+ contrast nice-to-haves, cosmetic alignment, enhancement suggestions
 


### PR DESCRIPTION
Closes #172

## Summary
- `code-reviewer` and `ui-reviewer` (`src/shared/agents/`) emitted `severity: "high"|"medium"` in their JSON output with no defined boundary between the two — risking inconsistent classification of the same finding across runs.
- Added a one-line discriminator to each agent's scoring step:
  - **code-reviewer**: high = realistic input/timing reaches it and corrupts data, breaks auth, or crashes a user-facing path; medium = real but needs an unlikely precondition, or confined to an internal/admin/dev-only path.
  - **ui-reviewer**: high = blocks task completion (can't read/click/focus/submit) on a common viewport/AT; medium = task still completable but degraded.
- No change to the JSON output contract — field names and shape are unchanged.
- Rebuilt via `./scripts/build.sh`; bundled copies in `skills/issue-resolver/` and `skills/issue-pr-review/` are in sync with `src/`.

## Test plan
- [x] `./scripts/build.sh` completed cleanly (8 agents, all flattened skills verification passed)
- [x] Confirmed `severity` is not branched on by any skill (only `action` routes to the fixer agent) — this is a clarity fix, not a behavior change
- [x] Diffed bundled copies to confirm propagation matches source