### PR TITLE
fix(auto-pilot): run dependency gate before partial merges (#184)

### DIFF
--- a/skills/auto-pilot/references/error-messages.md
+++ b/skills/auto-pilot/references/error-messages.md
@@ -190,7 +190,7 @@ All errors follow the rich error format: what went wrong + fix command + docs li
 
 ## Review
 
-### Review cycles exhausted (non-critical issue)
+### Review cycles exhausted (non-critical issue, aggressive + merge_partial)
 ```
 ⚠ PR #{pr_number} has unresolved issues after {review_cycles} cycles
 
@@ -199,13 +199,32 @@ All errors follow the rich error format: what went wrong + fix command + docs li
     ● {issue_description_2}
 
   ✓ Created follow-up issue #{followup_number}
-  ⟶ Merging PR with partial fix...
-  ✓ PR #{pr_number} merged (partial fix)
+    "Follow-up: unresolved review issues from #{issue_number}"
+  ⟶ mode: aggressive + merge_partial: true — merging partial PR...
+  ✓ PR #{pr_number} merged (partial fix) — #{issue_number} closed
     Unresolved issues tracked in #{followup_number}
+    Outcome: partial_followup
   Continuing to next issue...
 ```
-**Trigger:** All review-fix cycles exhausted and the original issue does NOT have a `critical_labels` label.
-**Action:** Create a follow-up GitHub issue with `auto-pilot-followup` label describing the unresolved problems. Merge the PR to preserve progress. Continue to next issue. Non-fatal.
+**Trigger:** All review-fix cycles exhausted, the original issue does NOT have a `critical_labels` label, and the effective mode is `aggressive` with `autopilot.merge_partial: true`. Step 2a (Step 5.1b dependency gate) must pass before this output is shown.
+**Action:** Create follow-up issue, merge PR only after dependency gate passes. If the gate blocks, use *PR blocked by unmerged dependency* instead (fatal pause). Otherwise continue to next issue. Non-fatal when merged.
+
+### Review cycles exhausted (non-critical issue, PR left open)
+```
+⚠ PR #{pr_number} has unresolved issues after {review_cycles} cycles
+
+  Remaining issues:
+    ● {issue_description_1}
+    ● {issue_description_2}
+
+  ✓ Created follow-up issue #{followup_number}
+    "Follow-up: unresolved review issues from #{issue_number}"
+  ○ mode: {mode} — PR left open for manual merge
+    Outcome: left_open
+  Continuing to next issue...
+```
+**Trigger:** All review-fix cycles exhausted, the original issue does NOT have a `critical_labels` label, and the effective mode is `conservative`, `balanced`, or `aggressive` with `merge_partial: false`.
+**Action:** Create follow-up issue; leave PR open. Continue to next issue. Non-fatal.
 
 ### Review cycles exhausted (critical issue)
 ```

--- a/skills/auto-pilot/references/phases.md
+++ b/skills/auto-pilot/references/phases.md
@@ -293,9 +293,13 @@ EOF
 
 **Step 2 — Mode-gated merge decision:**
 
-If the effective mode is `aggressive` AND `autopilot.merge_partial` is `true`, merge the PR to preserve the partial progress; otherwise leave the PR open. Compute the **effective mode** by reading `autopilot.mode` if set, else applying the legacy mapping (`auto_merge: true` → aggressive+merge_partial; `auto_merge: false` → conservative).
+Compute the **effective mode** by reading `autopilot.mode` if set, else applying the legacy mapping (`auto_merge: true` → aggressive+merge_partial; `auto_merge: false` → conservative). If the effective mode is `aggressive` AND `autopilot.merge_partial` is `true`, the PR may be merged to preserve partial progress after the dependency gate passes; otherwise leave the PR open.
 
-If merging (aggressive + merge_partial: true):
+**Step 2a — Dependency gate (before any merge):**
+
+Whenever Step 2 would merge a PR (aggressive + `merge_partial: true`), run **Step 5.1b — Dependency Gate** first using the originating issue `#{issue_number}`. SPEC §2 requires this check before **any** automated merge, including partial merges. If the gate finds unsatisfied dependencies, do **not** merge: print the structured alert from `references/error-messages.md` (*PR blocked by unmerged dependency*), record the iteration outcome as `blocked_by_dependency`, and stop the loop (same pause semantics as Phase 5). If all dependencies are satisfied, proceed to Step 2b.
+
+**Step 2b — Merge (only when aggressive + merge_partial: true and Step 2a passed):**
 
 ```bash
 gh pr merge {pr_number} --squash --delete-branch
@@ -492,7 +496,7 @@ Continue to Step 5.2.
 
 ### Step 5.2 — Merge (mode-gated)
 
-Merge behavior is controlled by `autopilot.mode`. This step only runs after the PR review returned PASS (clean PR, no unresolved fixable issues). The partial-merge case is handled in Phase 3-4.
+Merge behavior is controlled by `autopilot.mode`. This step runs for clean PRs after review PASS. Partial merges (Phase 3-4 Step 2) use the same Step 5.1b dependency gate before `gh pr merge`.
 
 **Compute the effective mode:**
 

--- a/src/skills/auto-pilot/references/error-messages.md
+++ b/src/skills/auto-pilot/references/error-messages.md
@@ -190,7 +190,7 @@ All errors follow the rich error format: what went wrong + fix command + docs li
 
 ## Review
 
-### Review cycles exhausted (non-critical issue)
+### Review cycles exhausted (non-critical issue, aggressive + merge_partial)
 ```
 ⚠ PR #{pr_number} has unresolved issues after {review_cycles} cycles
 
@@ -199,13 +199,32 @@ All errors follow the rich error format: what went wrong + fix command + docs li
     ● {issue_description_2}
 
   ✓ Created follow-up issue #{followup_number}
-  ⟶ Merging PR with partial fix...
-  ✓ PR #{pr_number} merged (partial fix)
+    "Follow-up: unresolved review issues from #{issue_number}"
+  ⟶ mode: aggressive + merge_partial: true — merging partial PR...
+  ✓ PR #{pr_number} merged (partial fix) — #{issue_number} closed
     Unresolved issues tracked in #{followup_number}
+    Outcome: partial_followup
   Continuing to next issue...
 ```
-**Trigger:** All review-fix cycles exhausted and the original issue does NOT have a `critical_labels` label.
-**Action:** Create a follow-up GitHub issue with `auto-pilot-followup` label describing the unresolved problems. Merge the PR to preserve progress. Continue to next issue. Non-fatal.
+**Trigger:** All review-fix cycles exhausted, the original issue does NOT have a `critical_labels` label, and the effective mode is `aggressive` with `autopilot.merge_partial: true`. Step 2a (Step 5.1b dependency gate) must pass before this output is shown.
+**Action:** Create follow-up issue, merge PR only after dependency gate passes. If the gate blocks, use *PR blocked by unmerged dependency* instead (fatal pause). Otherwise continue to next issue. Non-fatal when merged.
+
+### Review cycles exhausted (non-critical issue, PR left open)
+```
+⚠ PR #{pr_number} has unresolved issues after {review_cycles} cycles
+
+  Remaining issues:
+    ● {issue_description_1}
+    ● {issue_description_2}
+
+  ✓ Created follow-up issue #{followup_number}
+    "Follow-up: unresolved review issues from #{issue_number}"
+  ○ mode: {mode} — PR left open for manual merge
+    Outcome: left_open
+  Continuing to next issue...
+```
+**Trigger:** All review-fix cycles exhausted, the original issue does NOT have a `critical_labels` label, and the effective mode is `conservative`, `balanced`, or `aggressive` with `merge_partial: false`.
+**Action:** Create follow-up issue; leave PR open. Continue to next issue. Non-fatal.
 
 ### Review cycles exhausted (critical issue)
 ```

--- a/src/skills/auto-pilot/references/phases.md
+++ b/src/skills/auto-pilot/references/phases.md
@@ -293,9 +293,13 @@ EOF
 
 **Step 2 — Mode-gated merge decision:**
 
-If the effective mode is `aggressive` AND `autopilot.merge_partial` is `true`, merge the PR to preserve the partial progress; otherwise leave the PR open. Compute the **effective mode** by reading `autopilot.mode` if set, else applying the legacy mapping (`auto_merge: true` → aggressive+merge_partial; `auto_merge: false` → conservative).
+Compute the **effective mode** by reading `autopilot.mode` if set, else applying the legacy mapping (`auto_merge: true` → aggressive+merge_partial; `auto_merge: false` → conservative). If the effective mode is `aggressive` AND `autopilot.merge_partial` is `true`, the PR may be merged to preserve partial progress after the dependency gate passes; otherwise leave the PR open.
 
-If merging (aggressive + merge_partial: true):
+**Step 2a — Dependency gate (before any merge):**
+
+Whenever Step 2 would merge a PR (aggressive + `merge_partial: true`), run **Step 5.1b — Dependency Gate** first using the originating issue `#{issue_number}`. SPEC §2 requires this check before **any** automated merge, including partial merges. If the gate finds unsatisfied dependencies, do **not** merge: print the structured alert from `references/error-messages.md` (*PR blocked by unmerged dependency*), record the iteration outcome as `blocked_by_dependency`, and stop the loop (same pause semantics as Phase 5). If all dependencies are satisfied, proceed to Step 2b.
+
+**Step 2b — Merge (only when aggressive + merge_partial: true and Step 2a passed):**
 
 ```bash
 gh pr merge {pr_number} --squash --delete-branch
@@ -492,7 +496,7 @@ Continue to Step 5.2.
 
 ### Step 5.2 — Merge (mode-gated)
 
-Merge behavior is controlled by `autopilot.mode`. This step only runs after the PR review returned PASS (clean PR, no unresolved fixable issues). The partial-merge case is handled in Phase 3-4.
+Merge behavior is controlled by `autopilot.mode`. This step runs for clean PRs after review PASS. Partial merges (Phase 3-4 Step 2) use the same Step 5.1b dependency gate before `gh pr merge`.
 
 **Compute the effective mode:**
 

--- a/tests/test-autopilot-partial-merge-dependency-gate.sh
+++ b/tests/test-autopilot-partial-merge-dependency-gate.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# test-autopilot-partial-merge-dependency-gate.sh — Issue #184 acceptance checks
+#
+# Usage: bash tests/test-autopilot-partial-merge-dependency-gate.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0
+FAIL=0
+
+pass() { echo "  ✓ $1"; PASS=$((PASS + 1)); }
+fail() { echo "  ✗ $1"; FAIL=$((FAIL + 1)); }
+
+echo "◆ Auto-Pilot Partial-Merge Dependency Gate (issue #184)"
+echo "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄"
+
+PHASES="$REPO_ROOT/src/skills/auto-pilot/references/phases.md"
+ERRORS="$REPO_ROOT/src/skills/auto-pilot/references/error-messages.md"
+
+# AC1: Phase 3-4 partial path runs dependency gate before merge
+if grep -qE 'Step 2a — Dependency gate' "$PHASES" \
+  && awk '/Step 2a — Dependency gate/{f=1} f && /Step 5\.1b — Dependency Gate/{found=1; exit} END{exit !found}' "$PHASES"; then
+  pass "T1: Phase 3-4 Step 2a runs Step 5.1b before partial merge"
+else
+  fail "T1: Phase 3-4 missing Step 2a dependency gate before merge"
+fi
+
+# AC2: blocked_by_dependency on partial path when deps open
+if awk '/Step 2a — Dependency gate/{f=1} f && /blocked_by_dependency/{found=1; exit} END{exit !found}' "$PHASES"; then
+  pass "T2: partial-merge path pauses with blocked_by_dependency when gate fails"
+else
+  fail "T2: partial-merge path missing blocked_by_dependency pause"
+fi
+
+# AC3: error catalog has mode-gated variants, no unconditional partial merge
+if grep -qE '^### Review cycles exhausted \(non-critical issue, aggressive \+ merge_partial\)' "$ERRORS" \
+  && grep -qE '^### Review cycles exhausted \(non-critical issue, PR left open\)' "$ERRORS"; then
+  pass "T3.1: error-messages.md has two mode-gated non-critical variants"
+else
+  fail "T3.1: error-messages.md missing mode-gated non-critical variants"
+fi
+
+if grep -qE 'Merging PR with partial fix\.\.\.' "$ERRORS"; then
+  fail "T3.2: unconditional 'Merging PR with partial fix' still in error catalog"
+else
+  pass "T3.2: no unconditional 'Merging PR with partial fix' in error catalog"
+fi
+
+# AC4: Step 5.2 no longer scopes dependency gate to PASS-only
+if grep -qE 'only runs after the PR review returned PASS' "$PHASES"; then
+  fail "T4: phases.md still scopes merge/dependency gate to PASS-reviewed PRs only"
+else
+  pass "T4: PASS-only scoping text removed from Step 5.2"
+fi
+
+if grep -qE 'Partial merges \(Phase 3-4 Step 2\) use the same Step 5\.1b' "$PHASES"; then
+  pass "T4.1: Step 5.2 documents partial path uses Step 5.1b"
+else
+  fail "T4.1: Step 5.2 does not document partial path dependency gate"
+fi
+
+echo ""
+echo "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄"
+echo "  Result: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #184

## Summary

Aligns auto-pilot documentation with SPEC §2: the Step 5.1b dependency gate runs before any automated merge, including the Phase 3-4 aggressive partial-merge path. Replaces the unconditional partial-merge error catalog entry with the two mode-gated variants from phases.md.

## Approach

Balanced documentation fix: extend Phase 3-4 Step 2 with Step 2a (dependency gate) and Step 2b (merge), update Step 5.2 wording, sync error-messages.md, add regression tests.

## Decision Record

- **Root cause:** Phase 3-4 Step 2 merged partial PRs without Step 5.1b; error-messages.md still prescribed unconditional partial merge; Step 5.2 text scoped the gate to PASS-only clean PRs.
- **Options considered:** Option 1 — doc-only gate before partial merge; Option 2 — route all merges through Phase 5; Option 3 — implement runtime gate in code
- **Options rejected:** Option 2 — larger orchestration change; Option 3 — no runtime merge code in this repo (skills-only)
- **Selected option:** Option 1 — doc-only gate before partial merge
- **Residual risk:** Harnesses must follow updated phases.md; no executable enforcement in-repo

Analyzed at: `fix/184-dependency-gate-partial-merge @ deba0e0` (2026-07-09)

## Changes

| File | Change |
|------|--------|
| `src/skills/auto-pilot/references/phases.md` | Step 2a/2b dependency gate before partial merge; Step 5.2 wording |
| `src/skills/auto-pilot/references/error-messages.md` | Two mode-gated non-critical exhausted-review variants |
| `skills/auto-pilot/references/*` | Build mirror |
| `tests/test-autopilot-partial-merge-dependency-gate.sh` | Issue #184 AC regression tests |

## Test Results

- Unit tests: 0 (N/A — shell regression scripts)
- Integration tests: 6 passed (`test-autopilot-partial-merge-dependency-gate.sh`); related suites pass except 2 pre-existing schema table checks in `test-autopilot-modes.sh`
- E2e tests: skipped
- Build: passed (`./scripts/build.sh`)
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Phase 3-4 partial-merge path runs Step 5.1b before merging | pass | `phases.md` Step 2a references Step 5.1b; test T1 |
| aggressive + merge_partial with open Depends on #N pauses instead of merging | pass | Step 2a `blocked_by_dependency` stop semantics; test T2 |
| error-messages.md replaced with two mode-gated variants; no unconditional partial merge text | pass | tests T3.1–T3.2 |
| No text scoping dependency gate to PASS-reviewed PRs only | pass | Step 5.2 rewrite; test T4 |