### PR TITLE
fix(resolver): guard security-labeled issues in Step 0d (#186)

### DIFF
--- a/skills/issue-resolver/README.md
+++ b/skills/issue-resolver/README.md
@@ -4,7 +4,7 @@
 
 ## Intent-Code Boundary
 
-`/issue-resolver` respects the intent-code boundary. The **issue body** owns durable intent: the problem statement, reporter context, and acceptance criteria. The resolver scans the **current codebase** during Research (Step 1) to discover affected files, dependencies, and constraints — it never trusts the issue body for predicted file lists or implementation hints. The atomic PR captures *how* the change was made; the linked issue captures *why* it mattered. If the issue body lacks structure (e.g., no acceptance criteria), the resolver runs `/issue-creator` first to normalize it without inventing technical detail. See `references/docs/idd-methodology.md` for the full boundary contract.
+`/issue-resolver` respects the intent-code boundary. The **issue body** owns durable intent: the problem statement, reporter context, and acceptance criteria. The resolver scans the **current codebase** during Research (Step 1) to discover affected files, dependencies, and constraints — it never trusts the issue body for predicted file lists or implementation hints. The atomic PR captures *how* the change was made; the linked issue captures *why* it mattered. If the issue body lacks structure (e.g., no acceptance criteria) and `issue.auto_normalize` is enabled, Step 0d normalizes it inline (same structure-only rules as `/issue-creator` Normalize) without inventing technical detail. Security-labeled issues are not rewritten without explicit operator confirmation (SPEC §1.4). See `references/docs/idd-methodology.md` for the full boundary contract.
 
 ## Highlights
 

--- a/skills/issue-resolver/SKILL.md
+++ b/skills/issue-resolver/SKILL.md
@@ -218,7 +218,22 @@ Stop.
 
 ### 0d — Auto-normalize
 
-If `issue.auto_normalize` is true and not already normalized (no `<!-- gitissue:normalized v1 -->` marker): classify issue type, generate normalized body, add marker, post a backup comment with the original body, update the issue via `gh issue edit`, then re-fetch. If normalization fails, warn and continue with the original body.
+If `issue.auto_normalize` is true and not already normalized (no `<!-- gitissue:normalized v1 -->` marker):
+
+1. **Security label check (SPEC §1.4)** — before any rewrite, scan issue labels for `security`, `CVE`, or `vulnerability` (case-insensitive). If any match:
+   - **Auto mode (`--auto` / `IDD_AUTO_MODE=1`):** print the skip warning below and continue preflight **without** rewriting the issue body.
+   - **Interactive mode:** print the warning and ask for explicit operator confirmation. Default is **no** — do not rewrite unless the operator clearly confirms (e.g. `y` / `yes`). If declined, continue without normalization.
+
+   ```
+   ⚠ Issue #N has a security label ({label}). Skipping auto-normalization.
+     Rewriting security-sensitive issues requires explicit operator confirmation (SPEC §1.4).
+
+     To normalize first: /issue-creator N   (or /issue-creator N --force after review)
+   ```
+
+   Use the first matching label name for `{label}` in the warning line.
+
+2. **Normalize inline** — when no security label blocks (or interactive operator confirmed): classify issue type, generate normalized body, add marker, post a backup comment with the original body, update the issue via `gh issue edit`, then re-fetch. This is the same structure-only flow as `/issue-creator` Normalize mode (`references/modes.md` in the issue-creator skill); the resolver does **not** invoke `/issue-creator` as a subprocess — it performs Step 0d inline. If normalization fails, warn and continue with the original body (see `references/error-messages.md`).
 
 ### 0e — Workspace (interactive only)
 

--- a/skills/issue-resolver/references/error-messages.md
+++ b/skills/issue-resolver/references/error-messages.md
@@ -218,6 +218,15 @@ All errors follow the rich error format: what went wrong + fix command + docs li
 
 ## Auto-normalize
 
+### Security-labeled issue (skip)
+```
+⚠ Issue #N has a security label ({label}). Skipping auto-normalization.
+  Rewriting security-sensitive issues requires explicit operator confirmation (SPEC §1.4).
+
+  To normalize first: /issue-creator N   (or /issue-creator N --force after review)
+```
+**Trigger:** Step 0d finds a `security`, `CVE`, or `vulnerability` label (case-insensitive) and the operator has not confirmed a rewrite (auto mode always skips; interactive defaults to skip). Non-fatal — the pipeline continues with the original issue body.
+
 ### Auto-normalization failed
 ```
 ⚠ Auto-normalization failed for issue #N — proceeding without normalization.

--- a/src/skills/issue-resolver/README.md
+++ b/src/skills/issue-resolver/README.md
@@ -4,7 +4,7 @@
 
 ## Intent-Code Boundary
 
-`/issue-resolver` respects the intent-code boundary. The **issue body** owns durable intent: the problem statement, reporter context, and acceptance criteria. The resolver scans the **current codebase** during Research (Step 1) to discover affected files, dependencies, and constraints — it never trusts the issue body for predicted file lists or implementation hints. The atomic PR captures *how* the change was made; the linked issue captures *why* it mattered. If the issue body lacks structure (e.g., no acceptance criteria), the resolver runs `/issue-creator` first to normalize it without inventing technical detail. See `docs/idd-methodology.md` for the full boundary contract.
+`/issue-resolver` respects the intent-code boundary. The **issue body** owns durable intent: the problem statement, reporter context, and acceptance criteria. The resolver scans the **current codebase** during Research (Step 1) to discover affected files, dependencies, and constraints — it never trusts the issue body for predicted file lists or implementation hints. The atomic PR captures *how* the change was made; the linked issue captures *why* it mattered. If the issue body lacks structure (e.g., no acceptance criteria) and `issue.auto_normalize` is enabled, Step 0d normalizes it inline (same structure-only rules as `/issue-creator` Normalize) without inventing technical detail. Security-labeled issues are not rewritten without explicit operator confirmation (SPEC §1.4). See `docs/idd-methodology.md` for the full boundary contract.
 
 ## Highlights
 

--- a/src/skills/issue-resolver/SKILL.source.md
+++ b/src/skills/issue-resolver/SKILL.source.md
@@ -218,7 +218,22 @@ Stop.
 
 ### 0d — Auto-normalize
 
-If `issue.auto_normalize` is true and not already normalized (no `<!-- gitissue:normalized v1 -->` marker): classify issue type, generate normalized body, add marker, post a backup comment with the original body, update the issue via `gh issue edit`, then re-fetch. If normalization fails, warn and continue with the original body.
+If `issue.auto_normalize` is true and not already normalized (no `<!-- gitissue:normalized v1 -->` marker):
+
+1. **Security label check (SPEC §1.4)** — before any rewrite, scan issue labels for `security`, `CVE`, or `vulnerability` (case-insensitive). If any match:
+   - **Auto mode (`--auto` / `IDD_AUTO_MODE=1`):** print the skip warning below and continue preflight **without** rewriting the issue body.
+   - **Interactive mode:** print the warning and ask for explicit operator confirmation. Default is **no** — do not rewrite unless the operator clearly confirms (e.g. `y` / `yes`). If declined, continue without normalization.
+
+   ```
+   ⚠ Issue #N has a security label ({label}). Skipping auto-normalization.
+     Rewriting security-sensitive issues requires explicit operator confirmation (SPEC §1.4).
+
+     To normalize first: /issue-creator N   (or /issue-creator N --force after review)
+   ```
+
+   Use the first matching label name for `{label}` in the warning line.
+
+2. **Normalize inline** — when no security label blocks (or interactive operator confirmed): classify issue type, generate normalized body, add marker, post a backup comment with the original body, update the issue via `gh issue edit`, then re-fetch. This is the same structure-only flow as `/issue-creator` Normalize mode (`references/modes.md` in the issue-creator skill); the resolver does **not** invoke `/issue-creator` as a subprocess — it performs Step 0d inline. If normalization fails, warn and continue with the original body (see `references/error-messages.md`).
 
 ### 0e — Workspace (interactive only)
 

--- a/src/skills/issue-resolver/references/error-messages.md
+++ b/src/skills/issue-resolver/references/error-messages.md
@@ -218,6 +218,15 @@ All errors follow the rich error format: what went wrong + fix command + docs li
 
 ## Auto-normalize
 
+### Security-labeled issue (skip)
+```
+⚠ Issue #N has a security label ({label}). Skipping auto-normalization.
+  Rewriting security-sensitive issues requires explicit operator confirmation (SPEC §1.4).
+
+  To normalize first: /issue-creator N   (or /issue-creator N --force after review)
+```
+**Trigger:** Step 0d finds a `security`, `CVE`, or `vulnerability` label (case-insensitive) and the operator has not confirmed a rewrite (auto mode always skips; interactive defaults to skip). Non-fatal — the pipeline continues with the original issue body.
+
 ### Auto-normalization failed
 ```
 ⚠ Auto-normalization failed for issue #N — proceeding without normalization.

--- a/tests/test-issue-resolver-0d-security.sh
+++ b/tests/test-issue-resolver-0d-security.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# test-issue-resolver-0d-security.sh — Validate resolver Step 0d security guard (issue #186)
+#
+# Acceptance criteria:
+#  - Step 0d checks security/CVE/vulnerability labels before rewrite
+#  - Auto mode skips with ⚠; interactive asks for explicit confirmation
+#  - README no longer claims resolver runs /issue-creator first
+#
+# Usage: bash tests/test-issue-resolver-0d-security.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0
+FAIL=0
+
+pass() { echo "  ✓ $1"; PASS=$((PASS + 1)); }
+fail() { echo "  ✗ $1"; FAIL=$((FAIL + 1)); }
+
+echo "◆ Issue-Resolver Step 0d Security Guard Tests (issue #186)"
+echo "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄"
+
+SKILL="$REPO_ROOT/src/skills/issue-resolver/SKILL.source.md"
+README="$REPO_ROOT/src/skills/issue-resolver/README.md"
+ERRORS="$REPO_ROOT/src/skills/issue-resolver/references/error-messages.md"
+
+if [ ! -f "$SKILL" ]; then
+  fail "SKILL.source.md missing"
+  exit 1
+fi
+
+if grep -qE 'Security label check \(SPEC §1\.4\)' "$SKILL"; then
+  pass "T1.1: Step 0d documents SPEC §1.4 security label check"
+else
+  fail "T1.1: Step 0d missing SPEC §1.4 security label check"
+fi
+
+if grep -qE 'security.*CVE.*vulnerability|CVE.*vulnerability' "$SKILL"; then
+  pass "T1.2: Step 0d lists security/CVE/vulnerability labels"
+else
+  fail "T1.2: Step 0d missing security/CVE/vulnerability label list"
+fi
+
+if grep -qE 'case-insensitive' "$SKILL"; then
+  pass "T1.3: Step 0d documents case-insensitive label match"
+else
+  fail "T1.3: Step 0d missing case-insensitive note"
+fi
+
+if grep -qE 'Auto mode.*--auto.*IDD_AUTO_MODE' "$SKILL" && grep -q 'Skipping auto-normalization' "$SKILL"; then
+  pass "T1.4: Step 0d auto mode skips normalization with warning"
+else
+  fail "T1.4: Step 0d auto-mode skip behavior incomplete"
+fi
+
+if grep -qE 'Interactive mode.*explicit operator confirmation' "$SKILL"; then
+  pass "T1.5: Step 0d interactive mode requires explicit confirmation"
+else
+  fail "T1.5: Step 0d interactive confirmation missing"
+fi
+
+if grep -qE 'does \*\*not\*\* invoke `/issue-creator`' "$SKILL"; then
+  pass "T1.6: Step 0d clarifies inline normalize vs /issue-creator subprocess"
+else
+  fail "T1.6: Step 0d missing inline vs /issue-creator clarification"
+fi
+
+if grep -qE '^### Security-labeled issue \(skip\)' "$ERRORS"; then
+  pass "T2.1: error-messages.md defines security skip warning"
+else
+  fail "T2.1: error-messages.md missing security skip section"
+fi
+
+if grep -q 'runs `/issue-creator` first' "$README"; then
+  fail "T3.1: README still claims resolver runs /issue-creator first"
+else
+  pass "T3.1: README corrected — no false /issue-creator-first claim"
+fi
+
+if grep -q 'Step 0d normalizes it inline' "$README"; then
+  pass "T3.2: README documents Step 0d inline normalization"
+else
+  fail "T3.2: README missing Step 0d inline normalization text"
+fi
+
+echo ""
+if [ "$FAIL" -gt 0 ]; then
+  echo "  ✗ Step 0d security guard tests failed ($PASS passed, $FAIL failed)"
+  exit 1
+fi
+echo "  ✓ All Step 0d security guard checks passed ($PASS)"


### PR DESCRIPTION
Closes #186

## Summary

Adds SPEC §1.4 security-label guard to `/issue-resolver` Step 0d auto-normalize and corrects resolver README wording about inline normalization vs `/issue-creator`.

## Approach

Option 2 — balanced: document the guard in Step 0d (matching `/issue-creator` label set), add error-messages template, fix README, add regression test.

## Decision Record

- **Root cause:** Step 0d rewrote issue bodies when `issue.auto_normalize` is true with no check for security/CVE/vulnerability labels; `/issue-creator` already had this guard but the resolver's inline copy omitted it.
- **Options considered:** Route 0d through `/issue-creator`; inline guard only; disable auto_normalize for security issues globally.
- **Options rejected:** Subprocess routing — heavier and out of scope for a doc/skills-only fix; global config change — does not meet SPEC operator-confirmation requirement.
- **Selected option:** Inline guard in Step 0d with auto skip + interactive confirm, aligned with issue-creator `modes.md`.
- **Residual risk:** Operators must still follow the skill text at runtime; no executable enforcement in this repo (skills-only).

Analyzed at: `fix/186-guard-security-resolver-0d @ 8d0e511` (2026-07-09)

## Changes

| File | Change |
|------|--------|
| `src/skills/issue-resolver/SKILL.source.md` | Step 0d security label check + inline normalize clarification |
| `src/skills/issue-resolver/README.md` | Correct intent-code boundary text |
| `src/skills/issue-resolver/references/error-messages.md` | Security skip warning template |
| `skills/issue-resolver/*` | Built install surface |
| `tests/test-issue-resolver-0d-security.sh` | Regression tests for #186 AC |

## Test Results

- Unit tests: 0 (N/A — skills-only)
- Integration tests: 1 passed (`tests/test-issue-resolver-0d-security.sh`)
- Build: passed (`./scripts/build.sh`)
- QA cycles: 0

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Step 0d checks security/CVE/vulnerability labels; auto skips with ⚠; interactive asks | pass | `SKILL.source.md` Step 0d §1; `error-messages.md` |
| Security-labeled un-normalized issues never rewritten without explicit confirmation | pass | Auto always skips; interactive default no |
| README no longer claims resolver runs `/issue-creator` first | pass | `README.md` + test T3.1 |