### PR TITLE
fix(auto-pilot): ignore cross-repo refs in dependency merge gate (#192)

### DIFF
--- a/scripts/dependency_gate_parse.py
+++ b/scripts/dependency_gate_parse.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Parse local issue numbers from SPEC §2 dependency markers in an issue body.
+
+Cross-repo references (org/repo#N) MUST be ignored per SPEC §2.
+Used by tests and referenced from auto-pilot phases.md Step 5.1b.
+"""
+
+from __future__ import annotations
+
+import re
+
+MARKER_RE = re.compile(r"(?i)\b(?:depends\s+on|blocked\s+by)\b")
+CROSS_REPO_TOKEN_RE = re.compile(r"\S+/\S+#\d+")
+BARE_ISSUE_RE = re.compile(r"(?<![\w/])#(\d+)")
+
+
+def extract_dependency_issue_numbers(body: str) -> list[int]:
+    """Return unique local issue numbers from Depends on / Blocked by lines."""
+    found: list[int] = []
+    seen: set[int] = set()
+    for line in body.splitlines():
+        if not MARKER_RE.search(line):
+            continue
+        local_segment = CROSS_REPO_TOKEN_RE.sub("", line)
+        for match in BARE_ISSUE_RE.finditer(local_segment):
+            number = int(match.group(1))
+            if number not in seen:
+                seen.add(number)
+                found.append(number)
+    return found
+
+
+def main() -> None:
+    import sys
+
+    body = sys.stdin.read()
+    for n in extract_dependency_issue_numbers(body):
+        print(n)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/idd-lint.py
+++ b/scripts/idd-lint.py
@@ -45,7 +45,9 @@ MARKER_RE = re.compile(r"<!--\s*gitissue:normalized\s+v(\d+)\s*-->")
 SECTION_RE = re.compile(r"^## +(.+?)\s*$")
 CONFIDENCE_RE = re.compile(r"\((?:high|medium) confidence\)|\(needs review\)")
 CHECKBOX_RE = re.compile(r"^\s*[-*] \[[ xX]\] \S", re.MULTILINE)
-DEP_MARKER_RE = re.compile(r"\b(?:depends on|blocked by):?\s*(#\d+(?:\s*,\s*#\d+)*)", re.IGNORECASE)
+DEP_MARKER_RE = re.compile(r"(?i)\b(?:depends on|blocked by)\b")
+CROSS_REPO_TOKEN_RE = re.compile(r"\S+/\S+#\d+")
+BARE_ISSUE_RE = re.compile(r"(?<![\w/])#(\d+)")
 PART_MARKER_RE = re.compile(r"\bpart of:?\s*(#\d+)", re.IGNORECASE)
 
 ISSUE_TYPES = ("bug", "feature", "improvement")
@@ -199,10 +201,18 @@ def lint_issue(body: str) -> list[Finding]:
             else:
                 findings.append(err("I07", f"metadata missing {label} line (§1.1)"))
 
-    # I08 — dependency markers (informational, §2)
+    # I08 — dependency markers (informational, §2; cross-repo ignored)
     deps: list[str] = []
-    for m in DEP_MARKER_RE.finditer(body):
-        deps.extend(re.findall(r"#\d+", m.group(1)))
+    seen_dep: set[str] = set()
+    for line in body.splitlines():
+        if not DEP_MARKER_RE.search(line):
+            continue
+        local_segment = CROSS_REPO_TOKEN_RE.sub("", line)
+        for m in BARE_ISSUE_RE.finditer(local_segment):
+            ref = f"#{m.group(1)}"
+            if ref not in seen_dep:
+                seen_dep.add(ref)
+                deps.append(ref)
     if deps:
         findings.append(info("I08", f"dependency markers found: {', '.join(deps)} (§2)"))
 

--- a/skills/auto-pilot/references/phases.md
+++ b/skills/auto-pilot/references/phases.md
@@ -416,7 +416,12 @@ Blocked by: #15, #20
 This depends on #8
 ```
 
-Use a regex equivalent to `(?im)\b(?:depends\s+on|blocked\s+by)\b[^\n]*?#(\d+)` and capture every numeric reference on the matching line (handle comma lists like `#12, #15`). Cross-repo references (`org/repo#N`) are explicitly out of scope — match only bare `#N`. If no markers are found, the gate is satisfied; proceed to Step 5.2.
+For each line that matches `(?im)\b(?:depends\s+on|blocked\s+by)\b`, collect **local** issue numbers only (SPEC §2 MUST-ignore for cross-repo):
+
+1. **Strip cross-repo tokens** on that line — remove every `\S+/\S+#\d+` match (e.g. `acme/lib#15`) so its trailing digits are never captured.
+2. **Capture bare refs** on the remainder with a negative lookbehind guard: `(?<![\w/])#(\d+)` — this matches `#12` and comma lists (`#12, #15`) but not the `#15` inside `acme/lib#15` if a token was missed.
+
+Example: `Blocked by: acme/lib#15, #12` → gate on **#12 only**. `Depends on #12, #15` → gate on **#12** and **#15**. The reference implementation is `scripts/dependency_gate_parse.py` (`extract_dependency_issue_numbers`). If no local markers remain, the gate is satisfied; proceed to Step 5.2.
 
 **Cycle guard:** If issue A's body references its own number (`#A`), log a warning and skip the gate (treat as satisfied). The auto-pilot must not pause forever on a self-referential cycle. Multi-hop cycles (A → B → A) are not detected here — they would require traversing each dependency's body, which is out of scope for the per-merge gate; the fail-safe is that any genuinely-cyclic issue set will eventually surface as `blocked_by_dependency` and require user intervention regardless. The check is:
 

--- a/src/skills/auto-pilot/references/phases.md
+++ b/src/skills/auto-pilot/references/phases.md
@@ -416,7 +416,12 @@ Blocked by: #15, #20
 This depends on #8
 ```
 
-Use a regex equivalent to `(?im)\b(?:depends\s+on|blocked\s+by)\b[^\n]*?#(\d+)` and capture every numeric reference on the matching line (handle comma lists like `#12, #15`). Cross-repo references (`org/repo#N`) are explicitly out of scope — match only bare `#N`. If no markers are found, the gate is satisfied; proceed to Step 5.2.
+For each line that matches `(?im)\b(?:depends\s+on|blocked\s+by)\b`, collect **local** issue numbers only (SPEC §2 MUST-ignore for cross-repo):
+
+1. **Strip cross-repo tokens** on that line — remove every `\S+/\S+#\d+` match (e.g. `acme/lib#15`) so its trailing digits are never captured.
+2. **Capture bare refs** on the remainder with a negative lookbehind guard: `(?<![\w/])#(\d+)` — this matches `#12` and comma lists (`#12, #15`) but not the `#15` inside `acme/lib#15` if a token was missed.
+
+Example: `Blocked by: acme/lib#15, #12` → gate on **#12 only**. `Depends on #12, #15` → gate on **#12** and **#15**. The reference implementation is `scripts/dependency_gate_parse.py` (`extract_dependency_issue_numbers`). If no local markers remain, the gate is satisfied; proceed to Step 5.2.
 
 **Cycle guard:** If issue A's body references its own number (`#A`), log a warning and skip the gate (treat as satisfied). The auto-pilot must not pause forever on a self-referential cycle. Multi-hop cycles (A → B → A) are not detected here — they would require traversing each dependency's body, which is out of scope for the per-merge gate; the fail-safe is that any genuinely-cyclic issue set will eventually surface as `blocked_by_dependency` and require user intervention regardless. The check is:
 

--- a/tests/test-autopilot-dependency-cross-repo-192.sh
+++ b/tests/test-autopilot-dependency-cross-repo-192.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# test-autopilot-dependency-cross-repo-192.sh — Issue #192 acceptance checks
+#
+# Usage: bash tests/test-autopilot-dependency-cross-repo-192.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0
+FAIL=0
+
+pass() { echo "  ✓ $1"; PASS=$((PASS + 1)); }
+fail() { echo "  ✗ $1"; FAIL=$((FAIL + 1)); }
+
+echo "◆ Auto-Pilot dependency gate cross-repo exclusion (issue #192)"
+echo "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄"
+
+PHASES="$REPO_ROOT/src/skills/auto-pilot/references/phases.md"
+PARSE="$REPO_ROOT/scripts/dependency_gate_parse.py"
+
+if grep -qE 'Strip cross-repo tokens' "$PHASES" \
+   && grep -qF '(?<![\w/])#(\d+)' "$PHASES"; then
+  pass "T1: phases.md documents strip + bare-ref guard (not capture-all #digits)"
+else
+  fail "T1: phases.md missing cross-repo exclusion mechanism"
+fi
+
+if grep -qE 'acme/lib#15' "$PHASES" && grep -qE '#12 only' "$PHASES"; then
+  pass "T1.1: phases.md includes cross-repo vs local example"
+else
+  fail "T1.1: phases.md missing worked example for acme/lib#15"
+fi
+
+if [ ! -f "$PARSE" ]; then
+  fail "T2: scripts/dependency_gate_parse.py missing"
+else
+  pass "T2: reference parser script present"
+fi
+
+run_parse() {
+  printf '%s' "$1" | python3 "$PARSE" | tr '\n' ' ' | sed 's/ $//'
+}
+
+out="$(run_parse 'Blocked by: acme/lib#15')"
+if [ -z "$out" ]; then
+  pass "T3: cross-repo-only line yields no local deps"
+else
+  fail "T3: expected empty deps, got: $out"
+fi
+
+out="$(run_parse 'Depends on #12, #15')"
+if [ "$out" = "12 15" ]; then
+  pass "T3.1: multi bare-ref line gates #12 and #15"
+else
+  fail "T3.1: expected '12 15', got '$out'"
+fi
+
+out="$(run_parse $'Blocked by: acme/lib#15, #12')"
+if [ "$out" = "12" ]; then
+  pass "T3.2: mixed line ignores cross-repo, keeps #12"
+else
+  fail "T3.2: expected '12', got '$out'"
+fi
+
+echo ""
+echo "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄"
+echo "  Result: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
Closes #192

## Summary

Documents and implements SPEC §2 cross-repo exclusion for auto-pilot Step 5.1b dependency capture so `Blocked by: acme/lib#15` does not gate on local #15.

## Approach

Strip `\S+/\S+#\d+` tokens per marker line, then capture bare refs with `(?<![\w/])#(\d+)`. Added `scripts/dependency_gate_parse.py` as reference implementation and aligned `idd-lint` I08 parsing.

## Decision Record

- **Root cause:** phases.md instructed `#(\d+)` on the full marker line, which captures digits inside cross-repo tokens.
- **Options considered:** bare-ref guard only; strip-then-capture; documentation-only
- **Options rejected:** doc-only — no executable regression
- **Selected option:** strip + bare-ref guard + parser + tests
- **Residual risk:** LLM executors must follow updated phases.md; parser is normative for tests

Analyzed at: `fix/192-ignore-cross-repo-dependency-refs` (2026-07-09)

## Changes

| File | Change |
|------|--------|
| `src/skills/auto-pilot/references/phases.md` | Step 5.1b exclusion algorithm + examples |
| `scripts/dependency_gate_parse.py` | Reference `extract_dependency_issue_numbers` |
| `scripts/idd-lint.py` | I08 ignores cross-repo refs |
| `tests/test-autopilot-dependency-cross-repo-192.sh` | AC regression |

## Test Results

- Unit tests: 0
- Integration tests: 6 passed (`test-autopilot-dependency-cross-repo-192.sh`), 28 passed (`test-autopilot-dependency-gate.sh`)
- E2e tests: skipped
- Build: passed (`./scripts/build.sh`)
- QA cycles: 0

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Cross-repo refs ignored (`acme/lib#15` does not gate #15) | pass | parser + T3/T3.2 |
| Bare local refs still gate (`Depends on #12, #15`) | pass | T3.1 |
| phases.md documents exclusion mechanism | pass | T1, strip + `(?<![\w/])#(\d+)` |