### PR TITLE
docs(registries): refresh CLAUDE.md and skills.md to match src/ (#193)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,10 @@ src/
 │       ├── synthesizer.md         # Analysis + implementation options
 │       ├── implementer.md         # Code + tests implementation
 │       ├── code-reviewer.md       # Confidence-based code review
+│       ├── fixer.md               # Targeted fixes for review/test/CI/AC failures
 │       ├── duplicate-detector.md  # Issue dedup scoring
-│       └── issue-relationship-scanner.md  # File deps + already-fixed detection
+│       ├── issue-relationship-scanner.md  # File deps + already-fixed detection
+│       └── ui-reviewer.md         # UI/UX + screenshot accessibility review
 │
 ├── skills/
 │   ├── auto-pilot/         # /auto-pilot — triage, resolve, review, merge loop
@@ -48,26 +50,30 @@ src/
 │       ├── SKILL.source.md
 │       └── references/
 │
+CHANGELOG.md                       # Project changelog (repo root, not under docs/)
+
 docs/                              # All documentation — single tree (issue #81)
 ├── config-schema.md               # ↓ Runtime docs (skills reference these via
 ├── idd-methodology.md             #   bare `docs/X.md` tokens; build.py
 ├── naming-conventions.md          #   bundles them into each skill's
 ├── sync-conventions.md            #   references/docs/ at build time)
 ├── github-projects-sync.md        #
-├── platform-github.md             # ↑
+├── platform-github.md             #
+├── shared-agent-conventions.md    #
+├── agent-model-effort.md          #
+├── pre-commit-security.md         # ↑
 ├── ARCHITECTURE.md                # ↓ Human-only project docs (not bundled
-├── CHANGELOG.md                   #   into skills; readable on the
-├── DEVELOPMENT.md                 #   repo's main branch only)
-├── decisions/                     # ↑
-├── experiments/
-└── release-notes/
+├── DEVELOPMENT.md                 #   into skills; readable on the
+├── decisions/                     #   repo's main branch only)
+├── experiments/                   #
+└── release-notes/                 # ↑
 ```
 
 ### Docs placement rule
 
 All documentation lives in top-level `docs/`. Two kinds coexist there:
 
-1. **Runtime docs** — read by skills at execution time. A skill source file references them as bare `docs/X.md` tokens. `scripts/build.py` discovers these references via transitive-closure scan and copies the matching files into each skill's `references/docs/`. To add a runtime doc: drop the new `.md` file at `docs/<name>.md` and reference it from a skill or shared agent — the build picks it up automatically. Today's runtime docs include: `config-schema.md`, `idd-methodology.md`, `naming-conventions.md`, `sync-conventions.md`, `github-projects-sync.md`, `platform-github.md`.
+1. **Runtime docs** — read by skills at execution time. A skill source file references them as bare `docs/X.md` tokens. `scripts/build.py` discovers these references via transitive-closure scan and copies the matching files into each skill's `references/docs/`. To add a runtime doc: drop the new `.md` file at `docs/<name>.md` and reference it from a skill or shared agent — the build picks it up automatically. Today's runtime docs — all 9 bundled by the closure — are: `config-schema.md`, `idd-methodology.md`, `naming-conventions.md`, `sync-conventions.md`, `github-projects-sync.md`, `platform-github.md`, `shared-agent-conventions.md`, `agent-model-effort.md`, `pre-commit-security.md`.
 2. **Project docs** — read by humans only. Architecture, changelog, dev guide, decision records, experiments, release notes. They are not referenced by any skill, so the build does not bundle them. Place new project docs at `docs/<name>.md` (top-level) or under a topical subdirectory (`docs/decisions/`, `docs/experiments/`, `docs/release-notes/`).
 
 When in doubt: if a skill source needs to read it at runtime, it is a runtime doc and goes at the top level of `docs/`. Otherwise it is a project doc.
@@ -89,7 +95,7 @@ When in doubt: if a skill source needs to read it at runtime, it is a runtime do
 
 ### Issue Templates
 - Normalization marker: `<!-- gitissue:normalized v1 -->`
-- Standard sections: Type, Context, Description, Acceptance Criteria, Technical Notes, Metadata
+- Standard sections (SPEC §1.1): Type, Description, Screenshots, Acceptance Criteria, Metadata
 - Reporter's original text preserved in `> Reporter Context` blockquote
 - Confidence markers: `(high confidence)`, `(needs review)`
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,6 +1,6 @@
 # gitissue Skills Reference
 
-This page documents every skill shipped by gitissue / IDD, what each skill does, and the supported input forms. Skills are invoked as slash commands in an agent session.
+This page documents every public skill shipped by gitissue / IDD, what each skill does, and the supported input forms. Skills are invoked as slash commands in an agent session. One skill — `/idd-doctor` — is **repo-internal**: it lives in `src/internal-skills/`, is excluded from the built `skills/` and `dist/` surface (see `docs/ARCHITECTURE.md`), and is not distributed for external install.
 
 ## Quick map
 
@@ -13,7 +13,7 @@ This page documents every skill shipped by gitissue / IDD, what each skill does,
 | `/issue-resolver` | Resolve one issue and open an atomic PR | Issue number, optional `--auto` |
 | `/issue-pr-review` | Review a PR, run tests/CI, fix issues in cycles | PR number or current branch PR, optional modes |
 | `/auto-pilot` | Fully autonomous backlog loop | Optional issue list, limit, dry-run, skip |
-| `/idd-doctor` | Read-only IDD repository health check | No arguments |
+| `/idd-doctor` (repo-internal) | Read-only IDD repository health check | No arguments |
 
 ## Shared conventions
 
@@ -63,6 +63,7 @@ Creates structured, intent-focused GitHub issues. It preserves reporter context 
 | `/issue-creator <N>` | Normalize | Rewrites existing issue #N into the standard template. |
 | `/issue-creator <N> --dry-run` | Preview | Shows the normalization preview without applying it. |
 | `/issue-creator <N> --force` | Force normalize | Normalizes even when the issue has security-sensitive labels. |
+| `/issue-creator … --refresh-model-data` | Refresh cache | Force-refreshes the skill-level model-data cache before proceeding (combines with any mode when model suggestion is enabled). |
 | `/issue-creator <multi-item text>` | Batch | Extracts multiple issues from one input and creates them sequentially. |
 | `/issue-creator <image path> [text]` | Screenshot/image issue | Reads visual context, uploads the image to GitHub, embeds it in the issue body, and creates a structured issue. |
 
@@ -134,6 +135,7 @@ Resolves one GitHub issue end-to-end and creates an atomic PR.
 |---|---|---|
 | `/issue-resolver <N>` | Interactive | Resolves issue #N, asks the user to pick an implementation plan, implements, tests, and opens a PR. |
 | `/issue-resolver <N> --auto` | Auto-pilot | Resolves issue #N autonomously with no user prompts. |
+| `/issue-resolver <N> --no-run-log` | Modifier | Suppresses the resolver's own `.gitissue/runs.jsonl` append and returns telemetry to the caller instead. Orthogonal to `--auto`; passed only by `/auto-pilot`, which is the single writer of the run-log line. |
 
 ### Pipeline summary
 
@@ -230,9 +232,11 @@ The loop pauses for critical unresolved review failures and dependency-blocked P
 
 ---
 
-## `/idd-doctor`
+## `/idd-doctor` (repo-internal)
 
 Runs a read-only health check for this IDD repository. It does not modify files, comments, issues, or PRs.
+
+`/idd-doctor` is a **repo-internal** skill: it lives in `src/internal-skills/`, is excluded from the built `skills/` and `dist/` distribution surface (per `docs/ARCHITECTURE.md`), and has no external install command. It is intended to run from a clone of this repository.
 
 ### Input options
 
@@ -247,7 +251,9 @@ Runs a read-only health check for this IDD repository. It does not modify files,
 | Stale skill claims in issue-creator docs | `FAIL` on drift |
 | Forbidden issue-template fields | `FAIL` on forbidden fields |
 | Missing `autopilot.mode` when `.gitissue.yml` exists | `FAIL` |
-| Repository squash-merge default | `WARN` when not squash-only or when unavailable |
+| Repository squash-merge default | `WARN` when not squash-only; skipped (`○`) when `gh` is absent or unauthenticated |
+
+After the four gating checks, the doctor prints one **informational, non-gating** section — a *run-log summary* over the last N runs (default 50) recorded in `.gitissue/runs.jsonl`. It reports resolve rate, median QA cycles, and common skip reasons, and never affects the PASS/WARN/FAIL result. When no runs are recorded, it degrades gracefully to a single `○` line.
 
 ### Requirements
 

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -13,7 +13,7 @@ Implements the (A-fail, B-fail, C-1) ADR row from
 docs/decisions/cross-skill-invocation.md — sibling-relative paths only.
 
 Per issue #81 consolidation, runtime docs live at the top-level docs/
-alongside human-only project docs (ARCHITECTURE.md, CHANGELOG.md, etc.).
+alongside human-only project docs (ARCHITECTURE.md, DEVELOPMENT.md, etc.).
 The build's transitive-closure scan determines which docs each skill
 needs and bundles only those into the dist outputs. The 9 runtime docs
 bundled by the closure are: config-schema.md, idd-methodology.md,

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -12,12 +12,14 @@ The build is byte-deterministic per refactor-plan-v10.md §4.1.
 Implements the (A-fail, B-fail, C-1) ADR row from
 docs/decisions/cross-skill-invocation.md — sibling-relative paths only.
 
-Per issue #81 consolidation, runtime docs (config-schema.md,
-idd-methodology.md, naming-conventions.md, sync-conventions.md,
-github-projects-sync.md) live at the top-level docs/ alongside
-human-only project docs (ARCHITECTURE.md, CHANGELOG.md, etc.). The
-build's transitive-closure scan determines which docs each skill needs
-and bundles only those into the dist outputs.
+Per issue #81 consolidation, runtime docs live at the top-level docs/
+alongside human-only project docs (ARCHITECTURE.md, CHANGELOG.md, etc.).
+The build's transitive-closure scan determines which docs each skill
+needs and bundles only those into the dist outputs. The 9 runtime docs
+bundled by the closure are: config-schema.md, idd-methodology.md,
+naming-conventions.md, sync-conventions.md, github-projects-sync.md,
+platform-github.md, shared-agent-conventions.md, agent-model-effort.md,
+pre-commit-security.md.
 """
 
 from __future__ import annotations

--- a/src/internal-skills/idd-doctor/README.md
+++ b/src/internal-skills/idd-doctor/README.md
@@ -36,17 +36,7 @@ All four checks always run — a fail in Check 1 does not skip Checks 2-4. The o
 
 ## Installation
 
-Install via [npx (Vercel)](https://www.npmjs.com/package/skills):
-
-```bash
-npx skills add https://github.com/luongnv89/idd --skill idd-doctor
-```
-
-Or via [agent-skill-manager (asm)](https://www.npmjs.com/package/agent-skill-manager):
-
-```bash
-asm install https://github.com/luongnv89/idd --skill idd-doctor
-```
+`/idd-doctor` is a **repo-internal** skill. It lives in `src/internal-skills/` and is intentionally excluded from the built `skills/` and `dist/` distribution surface (see [`docs/ARCHITECTURE.md`](../../../docs/ARCHITECTURE.md)), so there is no external `npx` or `asm` install command. Run it from a clone of this repository — the agent discovers it in place under `src/internal-skills/idd-doctor/`.
 
 ## Usage
 


### PR DESCRIPTION
Closes #193

Refreshes the project registries that had drifted from `src/` reality, so CLAUDE.md, `scripts/build.py`, and `docs/skills.md` describe what the build actually bundles and what the intent-code-boundary work left in place.

## Changes

### CLAUDE.md
- **Shared-agent registry**: now lists all 8 agents — added `fixer.md` and `ui-reviewer.md` (both registered in `scripts/build.py`'s `AGENT_DESCRIPTIONS`).
- **Runtime-doc list** (fixed in both the architecture tree *and* the "Docs placement rule" prose): now lists all 9 docs the transitive-closure scan bundles — added `shared-agent-conventions.md`, `agent-model-effort.md`, `pre-commit-security.md`.
- **Standard issue sections**: updated to SPEC §1.1 — `Type, Description, Screenshots, Acceptance Criteria, Metadata`. Removed the stale `Context` and `Technical Notes` (which idd-doctor Check 2 actively FAILs on).
- **CHANGELOG path**: moved `CHANGELOG.md` out of the `docs/` block to repo root in the tree (that is where the file lives).

### scripts/build.py
- Module docstring now enumerates all 9 bundled runtime docs (was 5).

### docs/skills.md
- Documents `--refresh-model-data` (`/issue-creator`) and `--no-run-log` (`/issue-resolver`) in their input-option tables.
- Documents the doctor's implemented **run-log summary** as informational / non-gating.
- Merge-strategy check row: the gh-absent case is now labeled **skipped (`○`)**, not WARN — matching the SKILL and idd-doctor README.
- Marks `/idd-doctor` as **repo-internal** (intro, quick map, and section header).

### src/internal-skills/idd-doctor/README.md
- Replaced the external `npx`/`asm` Installation section with a repo-internal note, consistent with `docs/ARCHITECTURE.md` excluding internal skills from the built `skills/` and `dist/` surface. (Both external installers discover only the generated `skills/` surface, so neither could install an internal skill.)

## Verification
All 3 acceptance criteria verified programmatically against the edited files:
- The 9 bundled runtime docs confirmed as the definitive set via the union of `skills/*/references/docs/` in the committed tree (matches `scripts/build.py`'s regexes over `src/` and the transitive closure of the docs themselves).
- All 8 shared agents confirmed present in `src/shared/agents/` and `AGENT_DESCRIPTIONS`.
- Templates confirmed to use exactly the SPEC §1.1 sections.

Docs/source-only change — nothing under `dist/` touched.

Part of #182 (Phase 2 hygiene).
