### PR TITLE
refactor(skills): omit subagent_type in spawn snippets (#194)

### DIFF
--- a/skills/issue-pr-review/SKILL.md
+++ b/skills/issue-pr-review/SKILL.md
@@ -194,7 +194,7 @@ If tests fail here, continue to the review loop — failures are picked up in St
 
 ### Reviewer agents and cycle reuse
 
-Read `references/agents/code-reviewer.md` for the reviewer prompt and `references/agents/fixer.md` for the fix-cycle prompt. Both spawn with `subagent_type="general-purpose"` (NOT a custom `code-reviewer`/`fixer` type). Pass the reviewer `branch_name`, `base_branch`, `pr_context` (PR title + body), and `diff_command` (`gh pr diff {N}`). Pass `review.confidence_threshold` (default 80) as the minimum confidence for code-reviewer findings; ui-reviewer keeps its 75 floor.
+Read `references/agents/code-reviewer.md` for the reviewer prompt and `references/agents/fixer.md` for the fix-cycle prompt. Both spawn with the default general-purpose agent (do NOT set `subagent_type`; not a custom `code-reviewer`/`fixer` type). Pass the reviewer `branch_name`, `base_branch`, `pr_context` (PR title + body), and `diff_command` (`gh pr diff {N}`). Pass `review.confidence_threshold` (default 80) as the minimum confidence for code-reviewer findings; ui-reviewer keeps its 75 floor.
 
 To minimize tokens, the loop **reuses the same reviewer across cycles**: cycle 1 cold-starts; cycles 2+ re-message it via `SendMessage` to re-review the updated diff; after the fixer reports zero fixable issues, one **fresh** confirmation reviewer does an unbiased final check. The exact spawn calls, the `SendMessage` re-review prompt, and the token-trade rationale live in `references/review-loop-mechanics.md`.
 

--- a/skills/issue-pr-review/references/review-loop-mechanics.md
+++ b/skills/issue-pr-review/references/review-loop-mechanics.md
@@ -22,7 +22,7 @@ Spawn a new reviewer agent (cold start):
 Agent(
   description="reviewer — review PR #N",
   prompt=<code-reviewer.md prompt with {variables} replaced>,
-  subagent_type="general-purpose"  # NOT "code-reviewer"
+  # do NOT set subagent_type — default general-purpose agent, not a custom "code-reviewer" type
 )
 ```
 
@@ -52,7 +52,7 @@ After the fix cycle reports zero fixable issues, spawn a **fresh** confirmation 
 Agent(
   description="reviewer — confirmation review for PR #N",
   prompt=<code-reviewer.md prompt with {variables} replaced>,
-  subagent_type="general-purpose"  # NOT "code-reviewer"
+  # do NOT set subagent_type — default general-purpose agent, not a custom "code-reviewer" type
 )
 ```
 
@@ -75,7 +75,7 @@ Delegate fixes to the fixer subagent instead of applying code changes in the mai
 Agent(
   description="fixer — fix PR #N review issues",
   prompt=<fixer.md prompt with {variables} replaced>,
-  subagent_type="general-purpose"  # NOT "fixer"
+  # do NOT set subagent_type — default general-purpose agent, not a custom "fixer" type
 )
 ```
 

--- a/skills/issue-pr-review/references/ui-review-mechanics.md
+++ b/skills/issue-pr-review/references/ui-review-mechanics.md
@@ -43,7 +43,7 @@ When detection returns `ui: detected`, spawn the `ui-reviewer` subagent in **cod
 Agent(
   description="ui-reviewer — UI/UX code review for PR #{N}",
   prompt=<ui-reviewer.md prompt with mode=code, {variables} replaced>,
-  subagent_type="general-purpose"
+  # do NOT set subagent_type — default general-purpose agent, not a custom "ui-reviewer" type
 )
 ```
 

--- a/skills/issue-resolver/SKILL.md
+++ b/skills/issue-resolver/SKILL.md
@@ -88,13 +88,13 @@ confidence scale, `gh --json`, autonomous operation) live once in
 
 ### Spawning a subagent (canonical pattern)
 
-Every step below spawns with the same shape — only role, description, and prompt file change. `subagent_type` is **always** `"general-purpose"` (never the agent's own name — none are registered agent types):
+Every step below spawns with the same shape — only role, description, and prompt file change. **Do NOT set `subagent_type`** — always use the default general-purpose agent (never the agent's own name — none are registered agent types):
 
 ```python
 Agent(
   description="{role} — {action} issue #N",
   prompt=<{agent-file}.md prompt with {variables} replaced>,
-  subagent_type="general-purpose"  # NEVER the agent's own name (e.g. NOT "code-reviewer")
+  # do NOT set subagent_type — default general-purpose agent, never a custom type (e.g. NOT "code-reviewer")
 )
 ```
 

--- a/skills/issue-resolver/references/pipeline-steps.md
+++ b/skills/issue-resolver/references/pipeline-steps.md
@@ -519,7 +519,7 @@ When `ui: detected`, spawn the `ui-reviewer` subagent in **code** mode (see `ref
 Agent(
   description="ui-reviewer — UI/UX code review (#N)",
   prompt=<ui-reviewer.md prompt with mode=code, {variables} replaced>,
-  subagent_type="general-purpose"
+  # do NOT set subagent_type — default general-purpose agent, not a custom "ui-reviewer" type
 )
 ```
 

--- a/src/skills/issue-pr-review/SKILL.source.md
+++ b/src/skills/issue-pr-review/SKILL.source.md
@@ -194,7 +194,7 @@ If tests fail here, continue to the review loop — failures are picked up in St
 
 ### Reviewer agents and cycle reuse
 
-Read `shared/agents/code-reviewer.md` for the reviewer prompt and `shared/agents/fixer.md` for the fix-cycle prompt. Both spawn with `subagent_type="general-purpose"` (NOT a custom `code-reviewer`/`fixer` type). Pass the reviewer `branch_name`, `base_branch`, `pr_context` (PR title + body), and `diff_command` (`gh pr diff {N}`). Pass `review.confidence_threshold` (default 80) as the minimum confidence for code-reviewer findings; ui-reviewer keeps its 75 floor.
+Read `shared/agents/code-reviewer.md` for the reviewer prompt and `shared/agents/fixer.md` for the fix-cycle prompt. Both spawn with the default general-purpose agent (do NOT set `subagent_type`; not a custom `code-reviewer`/`fixer` type). Pass the reviewer `branch_name`, `base_branch`, `pr_context` (PR title + body), and `diff_command` (`gh pr diff {N}`). Pass `review.confidence_threshold` (default 80) as the minimum confidence for code-reviewer findings; ui-reviewer keeps its 75 floor.
 
 To minimize tokens, the loop **reuses the same reviewer across cycles**: cycle 1 cold-starts; cycles 2+ re-message it via `SendMessage` to re-review the updated diff; after the fixer reports zero fixable issues, one **fresh** confirmation reviewer does an unbiased final check. The exact spawn calls, the `SendMessage` re-review prompt, and the token-trade rationale live in `references/review-loop-mechanics.md`.
 

--- a/src/skills/issue-pr-review/references/review-loop-mechanics.md
+++ b/src/skills/issue-pr-review/references/review-loop-mechanics.md
@@ -22,7 +22,7 @@ Spawn a new reviewer agent (cold start):
 Agent(
   description="reviewer — review PR #N",
   prompt=<code-reviewer.md prompt with {variables} replaced>,
-  subagent_type="general-purpose"  # NOT "code-reviewer"
+  # do NOT set subagent_type — default general-purpose agent, not a custom "code-reviewer" type
 )
 ```
 
@@ -52,7 +52,7 @@ After the fix cycle reports zero fixable issues, spawn a **fresh** confirmation 
 Agent(
   description="reviewer — confirmation review for PR #N",
   prompt=<code-reviewer.md prompt with {variables} replaced>,
-  subagent_type="general-purpose"  # NOT "code-reviewer"
+  # do NOT set subagent_type — default general-purpose agent, not a custom "code-reviewer" type
 )
 ```
 
@@ -75,7 +75,7 @@ Delegate fixes to the fixer subagent instead of applying code changes in the mai
 Agent(
   description="fixer — fix PR #N review issues",
   prompt=<fixer.md prompt with {variables} replaced>,
-  subagent_type="general-purpose"  # NOT "fixer"
+  # do NOT set subagent_type — default general-purpose agent, not a custom "fixer" type
 )
 ```
 

--- a/src/skills/issue-pr-review/references/ui-review-mechanics.md
+++ b/src/skills/issue-pr-review/references/ui-review-mechanics.md
@@ -43,7 +43,7 @@ When detection returns `ui: detected`, spawn the `ui-reviewer` subagent in **cod
 Agent(
   description="ui-reviewer — UI/UX code review for PR #{N}",
   prompt=<ui-reviewer.md prompt with mode=code, {variables} replaced>,
-  subagent_type="general-purpose"
+  # do NOT set subagent_type — default general-purpose agent, not a custom "ui-reviewer" type
 )
 ```
 

--- a/src/skills/issue-resolver/SKILL.source.md
+++ b/src/skills/issue-resolver/SKILL.source.md
@@ -88,13 +88,13 @@ confidence scale, `gh --json`, autonomous operation) live once in
 
 ### Spawning a subagent (canonical pattern)
 
-Every step below spawns with the same shape — only role, description, and prompt file change. `subagent_type` is **always** `"general-purpose"` (never the agent's own name — none are registered agent types):
+Every step below spawns with the same shape — only role, description, and prompt file change. **Do NOT set `subagent_type`** — always use the default general-purpose agent (never the agent's own name — none are registered agent types):
 
 ```python
 Agent(
   description="{role} — {action} issue #N",
   prompt=<{agent-file}.md prompt with {variables} replaced>,
-  subagent_type="general-purpose"  # NEVER the agent's own name (e.g. NOT "code-reviewer")
+  # do NOT set subagent_type — default general-purpose agent, never a custom type (e.g. NOT "code-reviewer")
 )
 ```
 

--- a/src/skills/issue-resolver/references/pipeline-steps.md
+++ b/src/skills/issue-resolver/references/pipeline-steps.md
@@ -519,7 +519,7 @@ When `ui: detected`, spawn the `ui-reviewer` subagent in **code** mode (see `sha
 Agent(
   description="ui-reviewer — UI/UX code review (#N)",
   prompt=<ui-reviewer.md prompt with mode=code, {variables} replaced>,
-  subagent_type="general-purpose"
+  # do NOT set subagent_type — default general-purpose agent, not a custom "ui-reviewer" type
 )
 ```
 


### PR DESCRIPTION
Closes #194

## Summary

Settles the `subagent_type` spawn convention repo-wide. The convention doc (`docs/shared-agent-conventions.md:42`) and CLAUDE.md both mandate the **default general-purpose agent** with **no** `subagent_type` parameter, but several spawn snippets contradicted this by mandating `subagent_type="general-purpose"` explicitly.

This PR adopts the simpler of the two options the issue offers: **omit the parameter** in every spawn snippet, leaving the convention doc and CLAUDE.md unchanged as the single source of truth.

## Changes

Replaced the contradicting `subagent_type="general-purpose"` instruction with a `# do NOT set subagent_type` note in each `Agent()` call, **preserving the embedded warnings** (never a custom `code-reviewer` / `fixer` / `ui-reviewer` type). The two prose sentences were rewritten (not deleted) to state "do NOT set `subagent_type`".

8 occurrences across 5 files:

- `src/skills/issue-resolver/SKILL.source.md` — prose + code snippet
- `src/skills/issue-resolver/references/pipeline-steps.md` — ui-reviewer snippet
- `src/skills/issue-pr-review/SKILL.source.md` — prose
- `src/skills/issue-pr-review/references/review-loop-mechanics.md` — reviewer, confirmation reviewer, fixer snippets
- `src/skills/issue-pr-review/references/ui-review-mechanics.md` — ui-reviewer snippet

The auto-pilot files (`phases.md`, `subagent-prompts.md`) already said "do NOT set / omit" and were left unchanged — they were never contradictions.

## Acceptance criteria

- [x] One spawn convention is stated in `docs/shared-agent-conventions.md` and CLAUDE.md, and the two agree (both untouched; both say "do not set it")
- [x] Every spawn snippet in issue-resolver and issue-pr-review sources conforms (no remaining contradicting `subagent_type` usage in `src/`)

## Verification

`grep -rn 'subagent_type="general-purpose"' src/` → **0 matches**. All remaining `subagent_type` mentions in `src/` are "do NOT set / omit / never" statements.
