### PR TITLE
chore(build): complete bundled-dependency prechecks and add drift guard (#195)

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -58,6 +58,15 @@ STALE_DOC_URL_RE = re.compile(
     r"https://github\.com/luongnv89/idd/[^\s<>'\"\)]*?/src/docs/([a-z][a-z0-9-]+\.md)"
 )
 
+# Phase E: bundled-dependency precheck drift guard (issue #195). Each skill's
+# "Bundled dependency precheck" section lists the references/ files it expects
+# to be bundled. The build reconstructs the real bundled set and fails if the
+# list drifts. This regex extracts every references/<path> token from the
+# precheck block; it deliberately matches both authoring styles (bulleted
+# `- ` references/… ` — desc` and bare ```text fence, one path per line).
+PRECHECK_HEADING_RE = re.compile(r"^\s{0,3}#{2,4}\s+Bundled dependency precheck\s*$")
+PRECHECK_REF_RE = re.compile(r"(?<![\w/])references/[A-Za-z0-9._/-]+\.[A-Za-z0-9]+")
+
 BANNER_TMPL = (
     "<!-- Generated from /{rel}. Do not edit. "
     "Edit source and run ./scripts/build.sh. -->\n"
@@ -472,6 +481,85 @@ def _check_init_template_schema_parity(src: Path) -> None:
         _abort("init-gitissue template/schema parity failed — " + " | ".join(details))
 
 
+# --- Phase E — Bundled-dependency precheck drift guard (issue #195) ----------
+
+
+def _parse_precheck_refs(skill_source_text: str) -> set[str] | None:
+    """Extract the references/ paths named in a skill's 'Bundled dependency
+    precheck' section.
+
+    Returns a set of references/<path> tokens, or None when the skill has no
+    precheck section (such skills are not policed). The section is bounded from
+    its heading to the next top-level '## ' heading or '---' rule, so inline
+    references/ mentions elsewhere in the skill (e.g. an Additional Resources
+    index or prose) are never captured. Both authoring styles are supported: a
+    bulleted list with trailing descriptions and a bare ```text fence with one
+    path per line.
+    """
+    lines = skill_source_text.splitlines()
+    start = None
+    for i, line in enumerate(lines):
+        if PRECHECK_HEADING_RE.match(line):
+            start = i + 1
+            break
+    if start is None:
+        return None
+    body: list[str] = []
+    for line in lines[start:]:
+        if re.match(r"^\s*##\s", line) or re.match(r"^\s*---\s*$", line):
+            break
+        body.append(line)
+    return set(PRECHECK_REF_RE.findall("\n".join(body)))
+
+
+def _bundled_reference_paths(out_skill_dir: Path) -> set[str]:
+    """Return every bundled references/ file under an emitted skill directory
+    as skill-relative POSIX paths (e.g. 'references/docs/config-schema.md')."""
+    refs_root = out_skill_dir / "references"
+    if not refs_root.is_dir():
+        return set()
+    return {
+        f.relative_to(out_skill_dir).as_posix()
+        for f in _walk_files(refs_root)
+    }
+
+
+def _check_precheck_drift(
+    skill_name: str, skill_source: Path, out_skill_dir: Path
+) -> None:
+    """Fail the build when a skill's bundled-dependency precheck list diverges
+    from the files actually bundled under its references/ tree.
+
+    Scope is references/ only — README.md and templates/ are intentionally not
+    policed here (the precheck may name required templates, but templates are
+    not part of the closure-driven references/ bundle this guard verifies).
+    Skills without a precheck section are skipped.
+    """
+    named = _parse_precheck_refs(_read_text(skill_source))
+    if named is None:
+        return
+    bundled = _bundled_reference_paths(out_skill_dir)
+    missing_from_list = sorted(bundled - named)
+    stale_in_list = sorted(named - bundled)
+    if not missing_from_list and not stale_in_list:
+        return
+    details = []
+    if missing_from_list:
+        details.append(
+            "bundled but not in precheck list: " + ", ".join(missing_from_list)
+        )
+    if stale_in_list:
+        details.append(
+            "in precheck list but not bundled: " + ", ".join(stale_in_list)
+        )
+    _abort(
+        f"bundled-dependency precheck drift in skill '{skill_name}' — "
+        + " | ".join(details)
+        + f" (fix the 'Bundled dependency precheck' list in "
+        f"src/skills/{skill_name}/{SOURCE_SKILL_MD})"
+    )
+
+
 # --- Reference rewriting -----------------------------------------------------
 
 
@@ -708,9 +796,18 @@ def build(out: Path, src: Path, *, verbose: bool = False, no_root_skills: bool =
     all_skill_sources = [(name, src / "skills" / name) for name in public_skills]
     for name in deprecated_distributed:
         all_skill_sources.append((name, src / "deprecated-skills" / name))
+    public_skill_set = set(public_skills)
     for skill_name, skill_root in sorted(all_skill_sources, key=lambda x: x[0]):
         agents, docs = _compute_closure(src, skill_name, skill_root)
-        _emit_flattened_skill(src, skill_root, out_skills / skill_name, agents, docs)
+        out_skill_dir = out_skills / skill_name
+        _emit_flattened_skill(src, skill_root, out_skill_dir, agents, docs)
+        # Issue #195: fail the build if the skill's bundled-dependency precheck
+        # list drifts from the references/ files actually bundled. Policed for
+        # public skills only (deprecated-distributed skills are exempt).
+        if skill_name in public_skill_set:
+            _check_precheck_drift(
+                skill_name, skill_root / SOURCE_SKILL_MD, out_skill_dir
+            )
         if verbose:
             print(f"  ✓ flattened: {skill_name} (agents={len(agents)}, docs={len(docs)})")
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -192,23 +192,28 @@ run_compile() {
   local log_file="" status=0
   if [[ "$BUILD_QUIET" -eq 1 ]]; then
     log_file="$(mktemp "${TMPDIR:-/tmp}/idd-build.XXXXXX")"
+    # Capture status in the else branch: an if with a false condition and no
+    # else returns 0, so `status=$?` after a bare if/then/fi would read the
+    # if's success, not py_invoke's failure (silently swallowing build aborts).
     if py_invoke ${verbose_args[@]+"${verbose_args[@]}"} "${compile_args[@]}" >"$log_file" 2>&1; then
       rm -f "$log_file"
       return 0
+    else
+      status=$?
+      err "compile failed (exit $status)"
+      sed 's/^/  /' "$log_file" >&2
+      rm -f "$log_file"
+      return "$status"
     fi
-    status=$?
-    err "compile failed (exit $status)"
-    sed 's/^/  /' "$log_file" >&2
-    rm -f "$log_file"
-    return "$status"
   fi
 
   if py_invoke ${verbose_args[@]+"${verbose_args[@]}"} "${compile_args[@]}"; then
     return 0
+  else
+    status=$?
+    err "compile failed (exit $status)"
+    return "$status"
   fi
-  status=$?
-  err "compile failed (exit $status)"
-  return "$status"
 }
 
 run_verify() {
@@ -228,27 +233,31 @@ run_verify() {
   local log_file="" status=0
   if [[ "$BUILD_QUIET" -eq 1 ]]; then
     log_file="$(mktemp "${TMPDIR:-/tmp}/idd-verify.XXXXXX")"
+    # Capture status in the else branch (see run_compile): a false if with no
+    # else returns 0, which would mask verify failures otherwise.
     if bash "$VERIFY_SH" "$skills_out" >"$log_file" 2>&1; then
       rm -f "$log_file"
       if [[ "$BUILD_QUIET" -eq 0 ]]; then ok "skills verification passed"; fi
       return 0
+    else
+      status=$?
+      err "skills verification failed"
+      sed 's/^/  /' "$log_file" >&2
+      rm -f "$log_file"
+      err "  skills/ was not updated (previous tree unchanged)"
+      return "$status"
     fi
-    status=$?
-    err "skills verification failed"
-    sed 's/^/  /' "$log_file" >&2
-    rm -f "$log_file"
-    err "  skills/ was not updated (previous tree unchanged)"
-    return "$status"
   fi
 
   if bash "$VERIFY_SH" "$skills_out"; then
     ok "skills verification passed"
     return 0
+  else
+    status=$?
+    err "skills verification failed"
+    err "  skills/ was not updated (previous tree unchanged)"
+    return "$status"
   fi
-  status=$?
-  err "skills verification failed"
-  err "  skills/ was not updated (previous tree unchanged)"
-  return "$status"
 }
 
 run_promote() {

--- a/skills/auto-pilot/SKILL.md
+++ b/skills/auto-pilot/SKILL.md
@@ -85,13 +85,20 @@ Check these files relative to the skill's directory (the dirname of this SKILL.m
 - `references/subagent-prompts.md` — resolver, reviewer, analyzer, batch-resolver subagent prompts
 - `references/preflight.md` — precheck error outputs and branch-sync procedure
 - `references/orchestration.md` — subagent rationale and main-agent task list
-- `references/docs/idd-methodology.md` — IDD methodology (issue dependencies, etc.)
-- `references/docs/sync-conventions.md` — stash-first sync convention and recovery
-- `references/docs/config-schema.md` — configuration schema reference
 - `references/explicit-list-mode.md` — explicit list mode parsing rules and dependency scan
 - `references/run-log.md` — run-log single-writer and batch fan-out contracts
 - `references/summary-format.md` — final-summary outcome table and template
 - `references/configuration.md` — per-key config rationale and edge-case behavior
+- `references/error-messages.md` — complete error catalog with triggers and exact output
+- `references/examples.md` — worked example runs
+- `references/docs/idd-methodology.md` — IDD methodology (issue dependencies, etc.)
+- `references/docs/sync-conventions.md` — stash-first sync convention and recovery
+- `references/docs/config-schema.md` — configuration schema reference
+- `references/docs/naming-conventions.md` — naming conventions
+- `references/docs/github-projects-sync.md` — GitHub Projects status sync reference
+- `references/docs/platform-github.md` — GitHub platform driver reference
+- `references/docs/shared-agent-conventions.md` — shared subagent conventions
+- `references/docs/agent-model-effort.md` — per-agent model and reasoning-effort mapping
 
 If the working tree is dirty, auto-stash before starting; if not on the default
 branch, auto-switch and rebase on a clean tree. Both procedures (the stash-first

--- a/skills/init-gitissue/SKILL.md
+++ b/skills/init-gitissue/SKILL.md
@@ -46,8 +46,7 @@ That is the only prerequisite. This skill does not need `gh` or GitHub authentic
 Verify that this skill's bundled template and reference files are present. If any are missing,
 stop immediately and print:
 
-```
-text
+```text
 ✗ Missing bundled dependency: {missing_file}
 
   To fix:  asm install https://github.com/luongnv89/idd --skill init-gitissue
@@ -59,8 +58,13 @@ text
 Check these files relative to the skill's directory (the dirname of this SKILL.md):
 
 - `templates/gitissue-template.yml` — canonical config template with all schema fields
+- `references/error-messages.md` — complete error catalog with triggers and exact output
+- `references/examples.md` — worked example runs
 - `references/docs/config-schema.md` — full configuration schema
 - `references/docs/naming-conventions.md` — naming conventions (referenced by generated config)
+- `references/docs/idd-methodology.md` — IDD methodology reference
+- `references/docs/github-projects-sync.md` — GitHub Projects status sync reference
+- `references/docs/platform-github.md` — GitHub platform driver reference
 
 ## Configuration Check
 

--- a/skills/issue-analysis/SKILL.md
+++ b/skills/issue-analysis/SKILL.md
@@ -178,9 +178,15 @@ Check these files relative to the skill's directory (the dirname of this SKILL.m
 - `references/agents/synthesizer.md` — Synthesizer subagent prompt (Steps 6-7)
 - `references/subagent-steps.md` — per-step prompts and tool budgets for subagents
 - `references/output-and-persist.md` — terminal report rendering spec and JSON schema
+- `references/error-messages.md` — complete error catalog with triggers and exact output
+- `references/examples.md` — worked example runs
 - `references/docs/sync-conventions.md` — stash-first sync convention and recovery
 - `references/docs/idd-methodology.md` — IDD methodology (durable analysis fields)
 - `references/docs/config-schema.md` — configuration schema reference
+- `references/docs/github-projects-sync.md` — GitHub Projects status sync reference
+- `references/docs/platform-github.md` — GitHub platform driver reference
+- `references/docs/shared-agent-conventions.md` — shared subagent conventions
+- `references/docs/agent-model-effort.md` — per-agent model and reasoning-effort mapping
 
 The steps below include both the subagent delegation path and the inline fallback.
 

--- a/skills/issue-creator/SKILL.md
+++ b/skills/issue-creator/SKILL.md
@@ -115,8 +115,7 @@ If not (e.g., Claude.ai or environments without the Agent tool), execute duplica
 Verify that this skill's bundled agent prompt and template files are present.
 If any are missing, stop immediately and print:
 
-```
-text
+```text
 ✗ Missing bundled dependency: {missing_file}
 
   To fix:  asm install https://github.com/luongnv89/idd --skill issue-creator
@@ -131,13 +130,21 @@ Check these files relative to the skill's directory (the dirname of this SKILL.m
 - `templates/bug.md` — bug issue template
 - `templates/feature.md` — feature request template
 - `templates/improvement.md` — improvement request template
-- `references/docs/naming-conventions.md` — issue title and labeling conventions
-- `references/docs/github-projects-sync.md` — GitHub Projects status sync reference
 - `references/modes.md` — Normalize and Batch mode step specs and error paths
 - `references/model-suggestion.md` — model-suggestion cache lifecycle and mapping
 - `references/image-upload.md` — image upload procedure and failure handling
 - `references/confidence-scoring.md` — confidence levels and per-field determination
 - `references/clarify-intent.md` — Step 3.5 clarify-ambiguous-intent full procedure
+- `references/error-messages.md` — complete error catalog with triggers and exact output
+- `references/examples.md` — worked example runs (create, normalize, batch)
+- `references/docs/naming-conventions.md` — issue title and labeling conventions
+- `references/docs/github-projects-sync.md` — GitHub Projects status sync reference
+- `references/docs/config-schema.md` — configuration schema reference
+- `references/docs/idd-methodology.md` — IDD methodology reference
+- `references/docs/sync-conventions.md` — stash-first sync convention and recovery
+- `references/docs/platform-github.md` — GitHub platform driver reference
+- `references/docs/shared-agent-conventions.md` — shared subagent conventions
+- `references/docs/agent-model-effort.md` — per-agent model and reasoning-effort mapping
 
 ---
 

--- a/skills/issue-pr-review/SKILL.md
+++ b/skills/issue-pr-review/SKILL.md
@@ -52,6 +52,10 @@ references/docs/sync-conventions.md
 references/docs/idd-methodology.md
 references/docs/config-schema.md
 references/docs/naming-conventions.md
+references/docs/github-projects-sync.md
+references/docs/platform-github.md
+references/docs/shared-agent-conventions.md
+references/docs/agent-model-effort.md
 ```
 
 

--- a/skills/issue-resolver/SKILL.md
+++ b/skills/issue-resolver/SKILL.md
@@ -140,6 +140,7 @@ references/docs/github-projects-sync.md
 references/docs/config-schema.md
 references/docs/agent-model-effort.md
 references/docs/shared-agent-conventions.md
+references/docs/platform-github.md
 ```
 
 ```

--- a/skills/issue-triage/SKILL.md
+++ b/skills/issue-triage/SKILL.md
@@ -256,10 +256,15 @@ Check these files relative to the skill's directory (the dirname of this SKILL.m
 - `references/agents/issue-relationship-scanner.md` — Combined dependency + history scanner prompt
 - `references/detection.md` — Confidence-scoring rules and merge logic for detection
 - `references/output-and-persist.md` — Terminal report rendering spec and JSON schema
+- `references/error-messages.md` — complete error catalog with triggers and exact output
+- `references/examples.md` — worked example runs
 - `references/docs/sync-conventions.md` — stash-first sync convention and recovery
 - `references/docs/idd-methodology.md` — IDD methodology (durable analysis fields)
 - `references/docs/github-projects-sync.md` — GitHub Projects status sync reference
 - `references/docs/config-schema.md` — configuration schema reference
+- `references/docs/platform-github.md` — GitHub platform driver reference
+- `references/docs/shared-agent-conventions.md` — shared subagent conventions
+- `references/docs/agent-model-effort.md` — per-agent model and reasoning-effort mapping
 
 ---
 

--- a/src/internal-skills/idd-doctor/SKILL.source.md
+++ b/src/internal-skills/idd-doctor/SKILL.source.md
@@ -61,8 +61,7 @@ Before any check, verify the environment. On failure, output the exact error fro
 Verify that this skill's bundled reference files are present.
 If any are missing, stop immediately and print:
 
-```
-text
+```text
 ✗ Missing bundled dependency: {missing_file}
 
   To fix:  asm install https://github.com/luongnv89/idd --skill idd-doctor

--- a/src/skills/auto-pilot/SKILL.source.md
+++ b/src/skills/auto-pilot/SKILL.source.md
@@ -85,13 +85,20 @@ Check these files relative to the skill's directory (the dirname of this SKILL.m
 - `references/subagent-prompts.md` — resolver, reviewer, analyzer, batch-resolver subagent prompts
 - `references/preflight.md` — precheck error outputs and branch-sync procedure
 - `references/orchestration.md` — subagent rationale and main-agent task list
-- `references/docs/idd-methodology.md` — IDD methodology (issue dependencies, etc.)
-- `references/docs/sync-conventions.md` — stash-first sync convention and recovery
-- `references/docs/config-schema.md` — configuration schema reference
 - `references/explicit-list-mode.md` — explicit list mode parsing rules and dependency scan
 - `references/run-log.md` — run-log single-writer and batch fan-out contracts
 - `references/summary-format.md` — final-summary outcome table and template
 - `references/configuration.md` — per-key config rationale and edge-case behavior
+- `references/error-messages.md` — complete error catalog with triggers and exact output
+- `references/examples.md` — worked example runs
+- `references/docs/idd-methodology.md` — IDD methodology (issue dependencies, etc.)
+- `references/docs/sync-conventions.md` — stash-first sync convention and recovery
+- `references/docs/config-schema.md` — configuration schema reference
+- `references/docs/naming-conventions.md` — naming conventions
+- `references/docs/github-projects-sync.md` — GitHub Projects status sync reference
+- `references/docs/platform-github.md` — GitHub platform driver reference
+- `references/docs/shared-agent-conventions.md` — shared subagent conventions
+- `references/docs/agent-model-effort.md` — per-agent model and reasoning-effort mapping
 
 If the working tree is dirty, auto-stash before starting; if not on the default
 branch, auto-switch and rebase on a clean tree. Both procedures (the stash-first

--- a/src/skills/init-gitissue/SKILL.source.md
+++ b/src/skills/init-gitissue/SKILL.source.md
@@ -46,8 +46,7 @@ That is the only prerequisite. This skill does not need `gh` or GitHub authentic
 Verify that this skill's bundled template and reference files are present. If any are missing,
 stop immediately and print:
 
-```
-text
+```text
 ✗ Missing bundled dependency: {missing_file}
 
   To fix:  asm install https://github.com/luongnv89/idd --skill init-gitissue
@@ -59,8 +58,13 @@ text
 Check these files relative to the skill's directory (the dirname of this SKILL.md):
 
 - `templates/gitissue-template.yml` — canonical config template with all schema fields
+- `references/error-messages.md` — complete error catalog with triggers and exact output
+- `references/examples.md` — worked example runs
 - `references/docs/config-schema.md` — full configuration schema
 - `references/docs/naming-conventions.md` — naming conventions (referenced by generated config)
+- `references/docs/idd-methodology.md` — IDD methodology reference
+- `references/docs/github-projects-sync.md` — GitHub Projects status sync reference
+- `references/docs/platform-github.md` — GitHub platform driver reference
 
 ## Configuration Check
 

--- a/src/skills/issue-analysis/SKILL.source.md
+++ b/src/skills/issue-analysis/SKILL.source.md
@@ -178,9 +178,15 @@ Check these files relative to the skill's directory (the dirname of this SKILL.m
 - `references/agents/synthesizer.md` — Synthesizer subagent prompt (Steps 6-7)
 - `references/subagent-steps.md` — per-step prompts and tool budgets for subagents
 - `references/output-and-persist.md` — terminal report rendering spec and JSON schema
+- `references/error-messages.md` — complete error catalog with triggers and exact output
+- `references/examples.md` — worked example runs
 - `references/docs/sync-conventions.md` — stash-first sync convention and recovery
 - `references/docs/idd-methodology.md` — IDD methodology (durable analysis fields)
 - `references/docs/config-schema.md` — configuration schema reference
+- `references/docs/github-projects-sync.md` — GitHub Projects status sync reference
+- `references/docs/platform-github.md` — GitHub platform driver reference
+- `references/docs/shared-agent-conventions.md` — shared subagent conventions
+- `references/docs/agent-model-effort.md` — per-agent model and reasoning-effort mapping
 
 The steps below include both the subagent delegation path and the inline fallback.
 

--- a/src/skills/issue-creator/SKILL.source.md
+++ b/src/skills/issue-creator/SKILL.source.md
@@ -115,8 +115,7 @@ If not (e.g., Claude.ai or environments without the Agent tool), execute duplica
 Verify that this skill's bundled agent prompt and template files are present.
 If any are missing, stop immediately and print:
 
-```
-text
+```text
 ✗ Missing bundled dependency: {missing_file}
 
   To fix:  asm install https://github.com/luongnv89/idd --skill issue-creator
@@ -131,13 +130,21 @@ Check these files relative to the skill's directory (the dirname of this SKILL.m
 - `templates/bug.md` — bug issue template
 - `templates/feature.md` — feature request template
 - `templates/improvement.md` — improvement request template
-- `references/docs/naming-conventions.md` — issue title and labeling conventions
-- `references/docs/github-projects-sync.md` — GitHub Projects status sync reference
 - `references/modes.md` — Normalize and Batch mode step specs and error paths
 - `references/model-suggestion.md` — model-suggestion cache lifecycle and mapping
 - `references/image-upload.md` — image upload procedure and failure handling
 - `references/confidence-scoring.md` — confidence levels and per-field determination
 - `references/clarify-intent.md` — Step 3.5 clarify-ambiguous-intent full procedure
+- `references/error-messages.md` — complete error catalog with triggers and exact output
+- `references/examples.md` — worked example runs (create, normalize, batch)
+- `references/docs/naming-conventions.md` — issue title and labeling conventions
+- `references/docs/github-projects-sync.md` — GitHub Projects status sync reference
+- `references/docs/config-schema.md` — configuration schema reference
+- `references/docs/idd-methodology.md` — IDD methodology reference
+- `references/docs/sync-conventions.md` — stash-first sync convention and recovery
+- `references/docs/platform-github.md` — GitHub platform driver reference
+- `references/docs/shared-agent-conventions.md` — shared subagent conventions
+- `references/docs/agent-model-effort.md` — per-agent model and reasoning-effort mapping
 
 ---
 

--- a/src/skills/issue-pr-review/SKILL.source.md
+++ b/src/skills/issue-pr-review/SKILL.source.md
@@ -52,6 +52,10 @@ references/docs/sync-conventions.md
 references/docs/idd-methodology.md
 references/docs/config-schema.md
 references/docs/naming-conventions.md
+references/docs/github-projects-sync.md
+references/docs/platform-github.md
+references/docs/shared-agent-conventions.md
+references/docs/agent-model-effort.md
 ```
 
 

--- a/src/skills/issue-resolver/SKILL.source.md
+++ b/src/skills/issue-resolver/SKILL.source.md
@@ -140,6 +140,7 @@ references/docs/github-projects-sync.md
 references/docs/config-schema.md
 references/docs/agent-model-effort.md
 references/docs/shared-agent-conventions.md
+references/docs/platform-github.md
 ```
 
 ```

--- a/src/skills/issue-triage/SKILL.source.md
+++ b/src/skills/issue-triage/SKILL.source.md
@@ -256,10 +256,15 @@ Check these files relative to the skill's directory (the dirname of this SKILL.m
 - `references/agents/issue-relationship-scanner.md` — Combined dependency + history scanner prompt
 - `references/detection.md` — Confidence-scoring rules and merge logic for detection
 - `references/output-and-persist.md` — Terminal report rendering spec and JSON schema
+- `references/error-messages.md` — complete error catalog with triggers and exact output
+- `references/examples.md` — worked example runs
 - `references/docs/sync-conventions.md` — stash-first sync convention and recovery
 - `references/docs/idd-methodology.md` — IDD methodology (durable analysis fields)
 - `references/docs/github-projects-sync.md` — GitHub Projects status sync reference
 - `references/docs/config-schema.md` — configuration schema reference
+- `references/docs/platform-github.md` — GitHub platform driver reference
+- `references/docs/shared-agent-conventions.md` — shared subagent conventions
+- `references/docs/agent-model-effort.md` — per-agent model and reasoning-effort mapping
 
 ---
 


### PR DESCRIPTION
Closes #195

Part of epic #182 (Phase 2 hygiene). Completes every skill's bundled-dependency precheck list, fixes stray literal `text` fence lines, and adds a build-time guard so precheck lists cannot silently drift again.

## Part A — complete the precheck lists
Each skill's *Bundled dependency precheck* list now names every file the build bundles under `references/` (verified against the committed `skills/` tree). Files added across the seven public skills:

- **auto-pilot** (+7): `error-messages.md`, `examples.md`, `docs/{agent-model-effort,github-projects-sync,naming-conventions,platform-github,shared-agent-conventions}.md`
- **init-gitissue** (+5): `error-messages.md`, `examples.md`, `docs/{github-projects-sync,idd-methodology,platform-github}.md`
- **issue-analysis** (+6): `error-messages.md`, `examples.md`, `docs/{agent-model-effort,github-projects-sync,platform-github,shared-agent-conventions}.md`
- **issue-creator** (+8): `error-messages.md`, `examples.md`, `docs/{agent-model-effort,config-schema,idd-methodology,platform-github,shared-agent-conventions,sync-conventions}.md`
- **issue-pr-review** (+4): `docs/{agent-model-effort,github-projects-sync,platform-github,shared-agent-conventions}.md`
- **issue-resolver** (+1): `docs/platform-github.md`
- **issue-triage** (+5): `error-messages.md`, `examples.md`, `docs/{agent-model-effort,platform-github,shared-agent-conventions}.md`

## Part B — fix stray `text` fence lines
In issue-creator, init-gitissue, and idd-doctor the bundled-dependency error block opened with a bare ``` fence followed by a lone `text` line, so a literal `text` would print. The language tag now sits on the opening fence (```` ```text ````), removing the stray line.

## Part C — build-time drift guard
`scripts/build.py` now parses each public skill's precheck list (handles both the bulleted and bare-fence authoring styles, bounded to the precheck section so inline `references/` mentions elsewhere are ignored) and compares it against the `references/` files actually emitted into the skill bundle. Any divergence — a bundled file missing from the list, or a listed file no longer bundled — aborts the build with a message naming the skill and the offending path. Skills without a precheck section are skipped; scope is `references/` only (README.md and `templates/` are not policed here).

**Why this PR also touches `scripts/build.sh`:** the guard aborts `build.py` with a non-zero exit, but `build.sh`'s `run_compile`/`run_verify` used a bare `if cmd; then return 0; fi` followed by `status=$?`. A false `if` with no `else` returns 0, so `status` read the `if`'s success rather than the command's failure — silently swallowing every `build.py` abort (existing Phase E checks included). Each site now captures the status inside an `else` branch, so build failures propagate and `skills/` is not promoted from a failed build. Without this fix the new drift guard could not fail the build (and thus could not fail CI's `drift` job).

## Verification
- `./scripts/build.sh` exits 0 on the corrected lists; `git diff --exit-code -- skills/` is clean (CI `drift` job simulated green).
- Red case: dropping one precheck line makes `./scripts/build.sh` exit 1 with a clear drift message and leaves `skills/` untouched (no partial promote).
- Test suites pass: build-script, build-determinism, dependency-closure, flattened-self-contained, flattened-coexistence, init-template-schema-parity, init-template-doc-urls-{source,dist}, idd-lint, idd-doctor.
- No stray `text` line renders in the affected skills' built output.