### PR TITLE
chore(design): bundle terminal-style contract for installed skills (#196)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,8 @@ docs/                              # All documentation — single tree (issue #8
 ├── platform-github.md             #
 ├── shared-agent-conventions.md    #
 ├── agent-model-effort.md          #
-├── pre-commit-security.md         # ↑
+├── pre-commit-security.md         #
+├── terminal-style.md              # ↑
 ├── ARCHITECTURE.md                # ↓ Human-only project docs (not bundled
 ├── DEVELOPMENT.md                 #   into skills; readable on the
 ├── decisions/                     #   repo's main branch only)
@@ -73,7 +74,7 @@ docs/                              # All documentation — single tree (issue #8
 
 All documentation lives in top-level `docs/`. Two kinds coexist there:
 
-1. **Runtime docs** — read by skills at execution time. A skill source file references them as bare `docs/X.md` tokens. `scripts/build.py` discovers these references via transitive-closure scan and copies the matching files into each skill's `references/docs/`. To add a runtime doc: drop the new `.md` file at `docs/<name>.md` and reference it from a skill or shared agent — the build picks it up automatically. Today's runtime docs — all 9 bundled by the closure — are: `config-schema.md`, `idd-methodology.md`, `naming-conventions.md`, `sync-conventions.md`, `github-projects-sync.md`, `platform-github.md`, `shared-agent-conventions.md`, `agent-model-effort.md`, `pre-commit-security.md`.
+1. **Runtime docs** — read by skills at execution time. A skill source file references them as bare `docs/X.md` tokens. `scripts/build.py` discovers these references via transitive-closure scan and copies the matching files into each skill's `references/docs/`. To add a runtime doc: drop the new `.md` file at `docs/<name>.md` and reference it from a skill or shared agent — the build picks it up automatically. Today's runtime docs — all 10 bundled by the closure — are: `config-schema.md`, `idd-methodology.md`, `naming-conventions.md`, `sync-conventions.md`, `github-projects-sync.md`, `platform-github.md`, `shared-agent-conventions.md`, `agent-model-effort.md`, `pre-commit-security.md`, `terminal-style.md`.
 2. **Project docs** — read by humans only. Architecture, changelog, dev guide, decision records, experiments, release notes. They are not referenced by any skill, so the build does not bundle them. Place new project docs at `docs/<name>.md` (top-level) or under a topical subdirectory (`docs/decisions/`, `docs/experiments/`, `docs/release-notes/`).
 
 When in doubt: if a skill source needs to read it at runtime, it is a runtime doc and goes at the top level of `docs/`. Otherwise it is a project doc.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2,6 +2,14 @@
 
 The terminal is the interface. Every character of output is a design decision.
 
+The canonical output contract that skills consume at runtime — symbol
+vocabulary, output structure, progress patterns, table/error formats, and the
+confirmation/confidence/first-run/empty-state rules — lives in
+`docs/terminal-style.md` (a bundled runtime doc). This guide is the human-facing
+companion: it repeats that contract for reference and adds the color palette and
+per-command output mockups. When the two overlap, `docs/terminal-style.md` is
+authoritative.
+
 ## Principles
 
 1. **Show, don't dump.** Structured output > raw text. Tables > JSON. Sections > walls of text.
@@ -21,6 +29,7 @@ The terminal is the interface. Every character of output is a design decision.
 | `⚡` | Action / recommendation | — | `⚡ Parallelizable: #12 + #8` |
 | `⚠` | Warning | Yellow | `⚠ Stale: 1 issue (>14d)` |
 | `○` | Info / neutral | — | `○ First run — using defaults` |
+| `⟶` | Next action / leads to | — | `⟶ Spawning resolver subagent...` |
 | `+` | Added field | — | `+ Files: auth.py (high)` |
 | `=` | Preserved field | — | `= Original: preserved` |
 

--- a/docs/terminal-style.md
+++ b/docs/terminal-style.md
@@ -1,0 +1,154 @@
+# Terminal Output Style Contract
+
+The canonical terminal-output contract that gitissue skills consume at runtime:
+the symbol vocabulary, output structure, progress patterns, table and error
+formats, and the behavioral rules for confirmations, confidence, first-run, and
+empty states. This is the single source of truth for skill output.
+
+`DESIGN.md` (repo root) is the human-facing style guide — it adds the color
+palette and per-command output mockups on top of this contract. When the two
+overlap, this document is authoritative for what skills emit.
+
+## Principles
+
+1. **Show, don't dump.** Structured output > raw text. Tables > JSON. Sections > walls of text.
+2. **Transparency builds trust.** Show confidence scores, step progress, and what's happening at each phase. No black boxes.
+3. **Errors are help.** When something fails, show what went wrong + how to fix + where to learn more.
+4. **Warmth in empty states.** "No items found" is not a design. Every empty state has context and a next action.
+5. **Distinctive, not decorative.** Step counters, confidence markers, and semantic symbols give gitissue its own feel — not generic AI slop.
+
+## Symbol Vocabulary
+
+| Symbol | Meaning | Color | Example |
+|--------|---------|-------|---------|
+| `●` | In progress | — | `● Scanning codebase...` |
+| `✓` | Success / complete | Green | `✓ Created issue #42` |
+| `✗` | Failure / error | Red | `✗ Not authenticated` |
+| `◆` | Section header | Bold | `◆ Issue Preview` |
+| `⚡` | Action / recommendation | — | `⚡ Parallelizable: #12 + #8` |
+| `⚠` | Warning | Yellow | `⚠ Stale: 1 issue (>14d)` |
+| `○` | Info / neutral | — | `○ First run — using defaults` |
+| `⟶` | Next action / leads to | — | `⟶ Spawning resolver subagent...` |
+| `+` | Added field | — | `+ Files: auth.py (high)` |
+| `=` | Preserved field | — | `= Original: preserved` |
+
+All symbols carry meaning without color. Never rely on color alone.
+
+`⟶` marks the transition to the next autonomous action in a loop (auto-pilot):
+what the orchestrator is about to do — spawn a subagent, start immediately,
+merge a partial PR. It reads as "leads to".
+
+## Output Structure
+
+Every command follows this hierarchy:
+
+```
+  ● Progress (what's happening now)
+
+  ◆ Section Header
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+    Content (indented 2 spaces)
+    More content
+
+  ✓ Result (what happened)
+    https://url (always on its own line)
+```
+
+Rules:
+- One blank line between sections
+- Two-space indent for content under headers
+- No trailing blank lines
+- URLs always on their own line, in cyan
+- Section separators: `┄` (light dash, not heavy box)
+
+## Progress Patterns
+
+**Multi-step pipeline** (issue-resolver):
+```
+  [0/5] Preflight    ✓ issue #42 open, not yet resolved
+  [1/5] Research     ✓ read 5 files, complexity: medium
+  [2/5] Plan         ● selecting approach...
+```
+
+**Single operation** (issue-creator):
+```
+  ● Scanning codebase...
+```
+
+## Table Format
+
+```
+  #  │ Issue              │ Pri │ Blocks │ Status
+  ───┼────────────────────┼─────┼────────┼───────────
+  1  │ #12 Fix auth       │ P1  │ #15    │ ready
+  2  │ #8  Add pagination │ P2  │ —      │ ready
+```
+
+- Box-drawing characters: `│ ─ ┼`
+- Right-align numbers, left-align text
+- Max width: 80 characters (truncate with `...` if needed)
+- Use `—` for empty cells (not blank)
+
+## Error Format
+
+Errors are the moment users need the most help.
+
+```
+  ✗ Short error description
+
+    To fix:  <actionable command>
+    Docs:    <url to relevant documentation>
+```
+
+Always include: what went wrong, how to fix it, where to learn more.
+
+## Confirmation Prompts
+
+```
+  Apply normalization? [Y/n]
+```
+
+Default option in uppercase. Alternatives in lowercase.
+
+## Confidence Markers
+
+Unique to gitissue. Show honesty about what's inferred:
+
+```
+  + Files:    auth.py (high), config.py (medium)
+  + Criteria: 3 acceptance criteria (medium)
+```
+
+Levels: `high` (direct match), `medium` (keyword inference), `low` (best guess, marked `(needs review)` in the issue).
+
+## First-Run Experience
+
+When no `.gitissue.yml` exists:
+
+```
+  ○ First run — using default config. Run /init-gitissue to customize.
+```
+
+One line, then proceed normally. Non-intrusive.
+
+## Empty States
+
+Every empty state has warmth and a next action:
+
+| Scenario | Output |
+|----------|--------|
+| No files identified | `⚠ Could not identify affected files. Issue created with manual-review flag. Tip: mention specific filenames for better results.` |
+| No open issues (triage) | `○ No open issues found. Nothing to triage! Create issues with /issue-creator to get started.` |
+| Already normalized | `✓ Issue #42 is already normalized (v1, 2026-03-15). No changes needed.` |
+| Issue not found | `✗ Issue #42 not found\n\n  To fix: gh issue list\n  Check: is this the right repository?` |
+
+## GitHub Markdown Rendering
+
+Normalized issues must render cleanly in GitHub's web UI:
+
+- Use standard markdown (no HTML except the invisible marker)
+- Section headers: `## Type`, `## Description`, `## Acceptance Criteria`
+- Code blocks for file paths and technical details
+- Normalization marker: `<!-- gitissue:normalized v1 -->` (invisible in rendered view)
+- Reporter's original text: in a `> Reporter Context` blockquote
+- Confidence markers in parentheses: `(high confidence)`, `(needs review)`

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -15,11 +15,11 @@ docs/decisions/cross-skill-invocation.md — sibling-relative paths only.
 Per issue #81 consolidation, runtime docs live at the top-level docs/
 alongside human-only project docs (ARCHITECTURE.md, DEVELOPMENT.md, etc.).
 The build's transitive-closure scan determines which docs each skill
-needs and bundles only those into the dist outputs. The 9 runtime docs
+needs and bundles only those into the dist outputs. The 10 runtime docs
 bundled by the closure are: config-schema.md, idd-methodology.md,
 naming-conventions.md, sync-conventions.md, github-projects-sync.md,
 platform-github.md, shared-agent-conventions.md, agent-model-effort.md,
-pre-commit-security.md.
+pre-commit-security.md, terminal-style.md.
 """
 
 from __future__ import annotations

--- a/skills/issue-pr-review/SKILL.md
+++ b/skills/issue-pr-review/SKILL.md
@@ -56,6 +56,7 @@ references/docs/github-projects-sync.md
 references/docs/platform-github.md
 references/docs/shared-agent-conventions.md
 references/docs/agent-model-effort.md
+references/docs/terminal-style.md
 ```
 
 
@@ -358,7 +359,7 @@ When `--no-merge` is set (even in auto mode): skip the merge step and report sta
 ## Conventions
 
 - **Platform driver:** all tracker access follows the GitHub driver — `--json` with explicit field selection, never parsed text output; full catalog in references/docs/platform-github.md.
-- **Terminal output:** follow the DESIGN.md vocabulary — `[N/7]` step counter; symbols `●` progress, `✓` success, `✗` failure, `◆` header, `⚠` warning, `○` info; two-space indent, `┄` separators, URLs on their own line, max 80 chars.
+- **Terminal output:** follow the `references/docs/terminal-style.md` vocabulary — `[N/7]` step counter; symbols `●` progress, `✓` success, `✗` failure, `◆` header, `⚠` warning, `○` info; two-space indent, `┄` separators, URLs on their own line, max 80 chars.
 - **Errors:** rich format from `references/error-messages.md` — `✗ Short description` then `  To fix:  <command>`.
 - **Expected output:** a clean review prints the 7-step tracker and a summary — see *Expected Inline Output* in `references/report-templates.md`.
 
@@ -384,4 +385,4 @@ When `--no-merge` is set (even in auto mode): skip the merge step and report sta
 - **`references/docs/sync-conventions.md`** — Stash-first sync convention and recovery
 - **`references/docs/idd-methodology.md`** — IDD durable-analysis fields (traceability check 3)
 - **`references/docs/naming-conventions.md`** — Naming conventions
-- **`DESIGN.md`** — Terminal output style guide
+- **`references/docs/terminal-style.md`** — Terminal output style contract (bundled at build time; the repo-root `DESIGN.md` is the human-facing companion and is not bundled)

--- a/skills/issue-pr-review/references/docs/terminal-style.md
+++ b/skills/issue-pr-review/references/docs/terminal-style.md
@@ -1,0 +1,155 @@
+<!-- Generated from /docs/terminal-style.md. Do not edit. Edit source and run ./scripts/build.sh. -->
+# Terminal Output Style Contract
+
+The canonical terminal-output contract that gitissue skills consume at runtime:
+the symbol vocabulary, output structure, progress patterns, table and error
+formats, and the behavioral rules for confirmations, confidence, first-run, and
+empty states. This is the single source of truth for skill output.
+
+`DESIGN.md` (repo root) is the human-facing style guide — it adds the color
+palette and per-command output mockups on top of this contract. When the two
+overlap, this document is authoritative for what skills emit.
+
+## Principles
+
+1. **Show, don't dump.** Structured output > raw text. Tables > JSON. Sections > walls of text.
+2. **Transparency builds trust.** Show confidence scores, step progress, and what's happening at each phase. No black boxes.
+3. **Errors are help.** When something fails, show what went wrong + how to fix + where to learn more.
+4. **Warmth in empty states.** "No items found" is not a design. Every empty state has context and a next action.
+5. **Distinctive, not decorative.** Step counters, confidence markers, and semantic symbols give gitissue its own feel — not generic AI slop.
+
+## Symbol Vocabulary
+
+| Symbol | Meaning | Color | Example |
+|--------|---------|-------|---------|
+| `●` | In progress | — | `● Scanning codebase...` |
+| `✓` | Success / complete | Green | `✓ Created issue #42` |
+| `✗` | Failure / error | Red | `✗ Not authenticated` |
+| `◆` | Section header | Bold | `◆ Issue Preview` |
+| `⚡` | Action / recommendation | — | `⚡ Parallelizable: #12 + #8` |
+| `⚠` | Warning | Yellow | `⚠ Stale: 1 issue (>14d)` |
+| `○` | Info / neutral | — | `○ First run — using defaults` |
+| `⟶` | Next action / leads to | — | `⟶ Spawning resolver subagent...` |
+| `+` | Added field | — | `+ Files: auth.py (high)` |
+| `=` | Preserved field | — | `= Original: preserved` |
+
+All symbols carry meaning without color. Never rely on color alone.
+
+`⟶` marks the transition to the next autonomous action in a loop (auto-pilot):
+what the orchestrator is about to do — spawn a subagent, start immediately,
+merge a partial PR. It reads as "leads to".
+
+## Output Structure
+
+Every command follows this hierarchy:
+
+```
+  ● Progress (what's happening now)
+
+  ◆ Section Header
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+    Content (indented 2 spaces)
+    More content
+
+  ✓ Result (what happened)
+    https://url (always on its own line)
+```
+
+Rules:
+- One blank line between sections
+- Two-space indent for content under headers
+- No trailing blank lines
+- URLs always on their own line, in cyan
+- Section separators: `┄` (light dash, not heavy box)
+
+## Progress Patterns
+
+**Multi-step pipeline** (issue-resolver):
+```
+  [0/5] Preflight    ✓ issue #42 open, not yet resolved
+  [1/5] Research     ✓ read 5 files, complexity: medium
+  [2/5] Plan         ● selecting approach...
+```
+
+**Single operation** (issue-creator):
+```
+  ● Scanning codebase...
+```
+
+## Table Format
+
+```
+  #  │ Issue              │ Pri │ Blocks │ Status
+  ───┼────────────────────┼─────┼────────┼───────────
+  1  │ #12 Fix auth       │ P1  │ #15    │ ready
+  2  │ #8  Add pagination │ P2  │ —      │ ready
+```
+
+- Box-drawing characters: `│ ─ ┼`
+- Right-align numbers, left-align text
+- Max width: 80 characters (truncate with `...` if needed)
+- Use `—` for empty cells (not blank)
+
+## Error Format
+
+Errors are the moment users need the most help.
+
+```
+  ✗ Short error description
+
+    To fix:  <actionable command>
+    Docs:    <url to relevant documentation>
+```
+
+Always include: what went wrong, how to fix it, where to learn more.
+
+## Confirmation Prompts
+
+```
+  Apply normalization? [Y/n]
+```
+
+Default option in uppercase. Alternatives in lowercase.
+
+## Confidence Markers
+
+Unique to gitissue. Show honesty about what's inferred:
+
+```
+  + Files:    auth.py (high), config.py (medium)
+  + Criteria: 3 acceptance criteria (medium)
+```
+
+Levels: `high` (direct match), `medium` (keyword inference), `low` (best guess, marked `(needs review)` in the issue).
+
+## First-Run Experience
+
+When no `.gitissue.yml` exists:
+
+```
+  ○ First run — using default config. Run /init-gitissue to customize.
+```
+
+One line, then proceed normally. Non-intrusive.
+
+## Empty States
+
+Every empty state has warmth and a next action:
+
+| Scenario | Output |
+|----------|--------|
+| No files identified | `⚠ Could not identify affected files. Issue created with manual-review flag. Tip: mention specific filenames for better results.` |
+| No open issues (triage) | `○ No open issues found. Nothing to triage! Create issues with /issue-creator to get started.` |
+| Already normalized | `✓ Issue #42 is already normalized (v1, 2026-03-15). No changes needed.` |
+| Issue not found | `✗ Issue #42 not found\n\n  To fix: gh issue list\n  Check: is this the right repository?` |
+
+## GitHub Markdown Rendering
+
+Normalized issues must render cleanly in GitHub's web UI:
+
+- Use standard markdown (no HTML except the invisible marker)
+- Section headers: `## Type`, `## Description`, `## Acceptance Criteria`
+- Code blocks for file paths and technical details
+- Normalization marker: `<!-- gitissue:normalized v1 -->` (invisible in rendered view)
+- Reporter's original text: in a `> Reporter Context` blockquote
+- Confidence markers in parentheses: `(high confidence)`, `(needs review)`

--- a/skills/issue-resolver/SKILL.md
+++ b/skills/issue-resolver/SKILL.md
@@ -141,6 +141,7 @@ references/docs/config-schema.md
 references/docs/agent-model-effort.md
 references/docs/shared-agent-conventions.md
 references/docs/platform-github.md
+references/docs/terminal-style.md
 ```
 
 ```
@@ -517,7 +518,7 @@ All tracker access follows the GitHub driver — `--json` with explicit field se
 
 ## Output Conventions
 
-Terminal output follows the DESIGN.md contract — symbols `● ✓ ✗ ◆ ⚡ ⚠ ○`, two-space indent, `┄` separators, URLs on their own line, ≤80 chars, one blank line between sections, static sequential output (no animation), plus the `[N/5]` pipeline step counter. Errors use the rich format from `references/error-messages.md`: `✗ what failed`, then `To fix:  <command>`, then a docs link when applicable.
+Terminal output follows the `references/docs/terminal-style.md` contract — symbols `● ✓ ✗ ◆ ⚡ ⚠ ○`, two-space indent, `┄` separators, URLs on their own line, ≤80 chars, one blank line between sections, static sequential output (no animation), plus the `[N/5]` pipeline step counter. Errors use the rich format from `references/error-messages.md`: `✗ what failed`, then `To fix:  <command>`, then a docs link when applicable.
 
 ## Additional Resources
 
@@ -527,6 +528,6 @@ Authoritative file list for the *Bundled dependency precheck* above:
 
 **References** (`references/`): `pipeline-steps.md` (payloads/phases/fallbacks, Steps 1–4) · `report-templates.md` (PR body, closing summary, expected output) · `bug-verification.md` (reproduction checkpoint, Step 3) · `skill-index.md` (external-skill catalog, Step 3) · `error-messages.md` (error catalog)
 
-**Docs** (`docs/`): `sync-conventions.md` · `naming-conventions.md` · `pre-commit-security.md` · `idd-methodology.md` · `github-projects-sync.md` · `config-schema.md` · `agent-model-effort.md` · `shared-agent-conventions.md` · `platform-github.md`
+**Docs** (`docs/`): `sync-conventions.md` · `naming-conventions.md` · `pre-commit-security.md` · `idd-methodology.md` · `github-projects-sync.md` · `config-schema.md` · `agent-model-effort.md` · `shared-agent-conventions.md` · `platform-github.md` · `terminal-style.md`
 
-**`DESIGN.md`** — terminal output style guide.
+**`references/docs/terminal-style.md`** — terminal output style contract (symbols, output structure, table/error formats), bundled at build time. The repo-root `DESIGN.md` is the human-facing companion (color palette, per-command mockups) and is not bundled.

--- a/skills/issue-resolver/references/docs/terminal-style.md
+++ b/skills/issue-resolver/references/docs/terminal-style.md
@@ -1,0 +1,155 @@
+<!-- Generated from /docs/terminal-style.md. Do not edit. Edit source and run ./scripts/build.sh. -->
+# Terminal Output Style Contract
+
+The canonical terminal-output contract that gitissue skills consume at runtime:
+the symbol vocabulary, output structure, progress patterns, table and error
+formats, and the behavioral rules for confirmations, confidence, first-run, and
+empty states. This is the single source of truth for skill output.
+
+`DESIGN.md` (repo root) is the human-facing style guide — it adds the color
+palette and per-command output mockups on top of this contract. When the two
+overlap, this document is authoritative for what skills emit.
+
+## Principles
+
+1. **Show, don't dump.** Structured output > raw text. Tables > JSON. Sections > walls of text.
+2. **Transparency builds trust.** Show confidence scores, step progress, and what's happening at each phase. No black boxes.
+3. **Errors are help.** When something fails, show what went wrong + how to fix + where to learn more.
+4. **Warmth in empty states.** "No items found" is not a design. Every empty state has context and a next action.
+5. **Distinctive, not decorative.** Step counters, confidence markers, and semantic symbols give gitissue its own feel — not generic AI slop.
+
+## Symbol Vocabulary
+
+| Symbol | Meaning | Color | Example |
+|--------|---------|-------|---------|
+| `●` | In progress | — | `● Scanning codebase...` |
+| `✓` | Success / complete | Green | `✓ Created issue #42` |
+| `✗` | Failure / error | Red | `✗ Not authenticated` |
+| `◆` | Section header | Bold | `◆ Issue Preview` |
+| `⚡` | Action / recommendation | — | `⚡ Parallelizable: #12 + #8` |
+| `⚠` | Warning | Yellow | `⚠ Stale: 1 issue (>14d)` |
+| `○` | Info / neutral | — | `○ First run — using defaults` |
+| `⟶` | Next action / leads to | — | `⟶ Spawning resolver subagent...` |
+| `+` | Added field | — | `+ Files: auth.py (high)` |
+| `=` | Preserved field | — | `= Original: preserved` |
+
+All symbols carry meaning without color. Never rely on color alone.
+
+`⟶` marks the transition to the next autonomous action in a loop (auto-pilot):
+what the orchestrator is about to do — spawn a subagent, start immediately,
+merge a partial PR. It reads as "leads to".
+
+## Output Structure
+
+Every command follows this hierarchy:
+
+```
+  ● Progress (what's happening now)
+
+  ◆ Section Header
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+    Content (indented 2 spaces)
+    More content
+
+  ✓ Result (what happened)
+    https://url (always on its own line)
+```
+
+Rules:
+- One blank line between sections
+- Two-space indent for content under headers
+- No trailing blank lines
+- URLs always on their own line, in cyan
+- Section separators: `┄` (light dash, not heavy box)
+
+## Progress Patterns
+
+**Multi-step pipeline** (issue-resolver):
+```
+  [0/5] Preflight    ✓ issue #42 open, not yet resolved
+  [1/5] Research     ✓ read 5 files, complexity: medium
+  [2/5] Plan         ● selecting approach...
+```
+
+**Single operation** (issue-creator):
+```
+  ● Scanning codebase...
+```
+
+## Table Format
+
+```
+  #  │ Issue              │ Pri │ Blocks │ Status
+  ───┼────────────────────┼─────┼────────┼───────────
+  1  │ #12 Fix auth       │ P1  │ #15    │ ready
+  2  │ #8  Add pagination │ P2  │ —      │ ready
+```
+
+- Box-drawing characters: `│ ─ ┼`
+- Right-align numbers, left-align text
+- Max width: 80 characters (truncate with `...` if needed)
+- Use `—` for empty cells (not blank)
+
+## Error Format
+
+Errors are the moment users need the most help.
+
+```
+  ✗ Short error description
+
+    To fix:  <actionable command>
+    Docs:    <url to relevant documentation>
+```
+
+Always include: what went wrong, how to fix it, where to learn more.
+
+## Confirmation Prompts
+
+```
+  Apply normalization? [Y/n]
+```
+
+Default option in uppercase. Alternatives in lowercase.
+
+## Confidence Markers
+
+Unique to gitissue. Show honesty about what's inferred:
+
+```
+  + Files:    auth.py (high), config.py (medium)
+  + Criteria: 3 acceptance criteria (medium)
+```
+
+Levels: `high` (direct match), `medium` (keyword inference), `low` (best guess, marked `(needs review)` in the issue).
+
+## First-Run Experience
+
+When no `.gitissue.yml` exists:
+
+```
+  ○ First run — using default config. Run /init-gitissue to customize.
+```
+
+One line, then proceed normally. Non-intrusive.
+
+## Empty States
+
+Every empty state has warmth and a next action:
+
+| Scenario | Output |
+|----------|--------|
+| No files identified | `⚠ Could not identify affected files. Issue created with manual-review flag. Tip: mention specific filenames for better results.` |
+| No open issues (triage) | `○ No open issues found. Nothing to triage! Create issues with /issue-creator to get started.` |
+| Already normalized | `✓ Issue #42 is already normalized (v1, 2026-03-15). No changes needed.` |
+| Issue not found | `✗ Issue #42 not found\n\n  To fix: gh issue list\n  Check: is this the right repository?` |
+
+## GitHub Markdown Rendering
+
+Normalized issues must render cleanly in GitHub's web UI:
+
+- Use standard markdown (no HTML except the invisible marker)
+- Section headers: `## Type`, `## Description`, `## Acceptance Criteria`
+- Code blocks for file paths and technical details
+- Normalization marker: `<!-- gitissue:normalized v1 -->` (invisible in rendered view)
+- Reporter's original text: in a `> Reporter Context` blockquote
+- Confidence markers in parentheses: `(high confidence)`, `(needs review)`

--- a/src/skills/issue-pr-review/SKILL.source.md
+++ b/src/skills/issue-pr-review/SKILL.source.md
@@ -56,6 +56,7 @@ references/docs/github-projects-sync.md
 references/docs/platform-github.md
 references/docs/shared-agent-conventions.md
 references/docs/agent-model-effort.md
+references/docs/terminal-style.md
 ```
 
 
@@ -358,7 +359,7 @@ When `--no-merge` is set (even in auto mode): skip the merge step and report sta
 ## Conventions
 
 - **Platform driver:** all tracker access follows the GitHub driver — `--json` with explicit field selection, never parsed text output; full catalog in docs/platform-github.md.
-- **Terminal output:** follow the DESIGN.md vocabulary — `[N/7]` step counter; symbols `●` progress, `✓` success, `✗` failure, `◆` header, `⚠` warning, `○` info; two-space indent, `┄` separators, URLs on their own line, max 80 chars.
+- **Terminal output:** follow the `docs/terminal-style.md` vocabulary — `[N/7]` step counter; symbols `●` progress, `✓` success, `✗` failure, `◆` header, `⚠` warning, `○` info; two-space indent, `┄` separators, URLs on their own line, max 80 chars.
 - **Errors:** rich format from `references/error-messages.md` — `✗ Short description` then `  To fix:  <command>`.
 - **Expected output:** a clean review prints the 7-step tracker and a summary — see *Expected Inline Output* in `references/report-templates.md`.
 
@@ -384,4 +385,4 @@ When `--no-merge` is set (even in auto mode): skip the merge step and report sta
 - **`docs/sync-conventions.md`** — Stash-first sync convention and recovery
 - **`docs/idd-methodology.md`** — IDD durable-analysis fields (traceability check 3)
 - **`docs/naming-conventions.md`** — Naming conventions
-- **`DESIGN.md`** — Terminal output style guide
+- **`docs/terminal-style.md`** — Terminal output style contract (bundled at build time; the repo-root `DESIGN.md` is the human-facing companion and is not bundled)

--- a/src/skills/issue-resolver/SKILL.source.md
+++ b/src/skills/issue-resolver/SKILL.source.md
@@ -141,6 +141,7 @@ references/docs/config-schema.md
 references/docs/agent-model-effort.md
 references/docs/shared-agent-conventions.md
 references/docs/platform-github.md
+references/docs/terminal-style.md
 ```
 
 ```
@@ -517,7 +518,7 @@ All tracker access follows the GitHub driver — `--json` with explicit field se
 
 ## Output Conventions
 
-Terminal output follows the DESIGN.md contract — symbols `● ✓ ✗ ◆ ⚡ ⚠ ○`, two-space indent, `┄` separators, URLs on their own line, ≤80 chars, one blank line between sections, static sequential output (no animation), plus the `[N/5]` pipeline step counter. Errors use the rich format from `references/error-messages.md`: `✗ what failed`, then `To fix:  <command>`, then a docs link when applicable.
+Terminal output follows the `docs/terminal-style.md` contract — symbols `● ✓ ✗ ◆ ⚡ ⚠ ○`, two-space indent, `┄` separators, URLs on their own line, ≤80 chars, one blank line between sections, static sequential output (no animation), plus the `[N/5]` pipeline step counter. Errors use the rich format from `references/error-messages.md`: `✗ what failed`, then `To fix:  <command>`, then a docs link when applicable.
 
 ## Additional Resources
 
@@ -527,6 +528,6 @@ Authoritative file list for the *Bundled dependency precheck* above:
 
 **References** (`references/`): `pipeline-steps.md` (payloads/phases/fallbacks, Steps 1–4) · `report-templates.md` (PR body, closing summary, expected output) · `bug-verification.md` (reproduction checkpoint, Step 3) · `skill-index.md` (external-skill catalog, Step 3) · `error-messages.md` (error catalog)
 
-**Docs** (`docs/`): `sync-conventions.md` · `naming-conventions.md` · `pre-commit-security.md` · `idd-methodology.md` · `github-projects-sync.md` · `config-schema.md` · `agent-model-effort.md` · `shared-agent-conventions.md` · `platform-github.md`
+**Docs** (`docs/`): `sync-conventions.md` · `naming-conventions.md` · `pre-commit-security.md` · `idd-methodology.md` · `github-projects-sync.md` · `config-schema.md` · `agent-model-effort.md` · `shared-agent-conventions.md` · `platform-github.md` · `terminal-style.md`
 
-**`DESIGN.md`** — terminal output style guide.
+**`docs/terminal-style.md`** — terminal output style contract (symbols, output structure, table/error formats), bundled at build time. The repo-root `DESIGN.md` is the human-facing companion (color palette, per-command mockups) and is not bundled.


### PR DESCRIPTION
Closes #196

## Problem
Installed skills referenced repo-root `DESIGN.md`, but `scripts/build.py`'s doc-bundling regex only matches `docs/<name>.md` tokens — so `DESIGN.md` never shipped into the installed bundle. The "see DESIGN.md" pointers in issue-resolver and issue-pr-review dangled in installed copies. Separately, the `⟶` symbol used pervasively in auto-pilot output had no defined home in the symbol vocabulary.

## Change
- **New bundled runtime doc `docs/terminal-style.md`** — the canonical terminal-output contract skills consume. Because it lives at `docs/<name>.md`, `build.py` bundles it into each referencing skill's `references/docs/`.
- **issue-resolver & issue-pr-review** now reference `docs/terminal-style.md`; their installed SKILL.md files resolve to the bundled file — no dangling reference (AC1, AC3).
- **`⟶` added to the symbol vocabulary** in both `docs/terminal-style.md` and `DESIGN.md` (AC2).
- **`DESIGN.md`** kept as the human-facing companion (color palette, mockups); points at the new canonical doc.

## No regressions to already-merged Phase-2 work
- **#195 drift guard**: added `references/docs/terminal-style.md` to both skills' precheck lists — `./scripts/build.sh` exits 0.
- **#193 registry**: updated CLAUDE.md's runtime-doc tree + prose (9 → 10) and `build.py`'s docstring.

## Verification
- `./scripts/build.sh` exit 0; issue-resolver and issue-pr-review flatten with docs=10 (was 9); `terminal-style.md` bundled under both.
- Built SKILL.md files: no dangling reference.
- Tests pass: build-script (19), dependency-closure (27), flattened-self-contained (7), idd-lint (27), determinism (4), coexistence (5), idd-doctor (61).

Part of #182 (Phase 2 — Hygiene & Consistency).