### PR TITLE
refactor(conformance): close GitHub-driver gaps — Docs lines and rate-budget prechecks (#197)

### DIFF
--- a/skills/auto-pilot/SKILL.md
+++ b/skills/auto-pilot/SKILL.md
@@ -64,6 +64,20 @@ Before starting the loop, verify the environment. On failure, output the exact e
    - `issue-pr-review`
 6. Confirm clean working tree: `git status --porcelain`
 7. Confirm on default branch: `git rev-parse --abbrev-ref HEAD`
+8. **Check the rate budget** (driver rule 4, `references/docs/platform-github.md` ~12): auto-pilot processes many issues in a loop, each fanning out resolver and review subagents that make their own `gh`/API calls. Before starting the loop, confirm enough budget remains:
+
+   ```bash
+   gh api rate_limit --jq '.rate.remaining'
+   ```
+
+   **Threshold:** if `remaining` is below **200**, stop and print the `✗ Insufficient API rate budget` error from `references/error-messages.md` — the loop would exhaust the budget partway through and strand issues in a half-resolved state. Between 200 and 500, warn with the `⚠` variant but continue. At or above 500, proceed silently.
+9. **Confirm push/merge permission** (driver `references/docs/platform-github.md` ~22-23): check the caller's repository permission:
+
+   ```bash
+   gh repo view --json viewerPermission
+   ```
+
+   If `viewerPermission` is `ADMIN`, `MAINTAIN`, or `WRITE`, the caller can push and merge — proceed normally. If it is `READ`, `TRIAGE`, or `NONE`, the caller cannot merge PRs. Rather than fail, **downgrade to no-merge mode**: print the `⚠ Insufficient merge permission — running in no-merge mode` line from `references/error-messages.md`, then run the full triage/resolve/review loop but skip Phase 5 (merge), leaving every PR open for a maintainer to merge. This is consistent with auto-pilot's always-proceed philosophy: leave PRs open rather than failing.
 
 ### Skill dependency precheck
 
@@ -329,7 +343,8 @@ On final stop, the **Final Summary** table (above) lists each iteration's issue,
 
 - **Empty backlog** — loop exits with a green "no work remaining" notice, no error.
 - **Critical issue unresolvable** — loop halts and hands control back to the user with the exact error output.
-- **Merge permission missing** — auto-merge is skipped, PR is left open, loop moves on.
+- **Merge permission missing** — detected upfront by the preflight `viewerPermission` check (Prerequisite 9); auto-pilot downgrades to no-merge mode, runs the full loop, and leaves every PR open for a maintainer. If permission is lost mid-run, auto-merge is skipped for that PR and the loop moves on.
+- **Rate budget too low** — the preflight rate-budget check (Prerequisite 8) stops before the loop starts when `remaining` is below the threshold, rather than stranding issues half-resolved.
 - **Duplicate detection** — if triage marks an issue "already fixed", it is closed with a comment and the loop picks the next one.
 - **Follow-up issue creation fails** — the PR is still merged so progress is never blocked; a warning is printed.
 

--- a/skills/auto-pilot/references/error-messages.md
+++ b/skills/auto-pilot/references/error-messages.md
@@ -55,6 +55,34 @@ All errors follow the rich error format: what went wrong + fix command + docs li
 **Trigger:** `git rev-parse --abbrev-ref HEAD` returns a branch that is not `main` or `master`.
 **Action:** Auto-switch with `git checkout {default_branch} && git pull --rebase origin {default_branch}`. Non-fatal — auto-pilot continues.
 
+### Insufficient API rate budget (preflight)
+```
+✗ Insufficient GitHub API rate budget for auto-pilot
+
+  Remaining: {remaining} calls — below the safe threshold of 200.
+  The loop resolves many issues, each fanning out subagents that make
+  their own API calls; running now would strand issues half-resolved.
+
+  To fix:  wait for the budget to reset, then re-run /auto-pilot
+  Check:   gh api rate_limit --jq '.rate.remaining'
+  Docs:    https://github.com/luongnv89/idd/blob/main/docs/platform-github.md
+```
+**Trigger:** Preflight step 8 finds `gh api rate_limit --jq '.rate.remaining'` below 200 before the loop starts. Fatal — auto-pilot stops.
+
+**Low-budget warning (non-fatal):** when `remaining` is between 200 and 500, print the same block with a `⚠` symbol and the line `Proceeding — budget may run low; the loop will skip merges if it hits the limit.` instead of stopping.
+
+### Insufficient merge permission (auto-downgrade)
+```
+⚠ Insufficient merge permission — running in no-merge mode
+
+  Your permission on this repo is {viewerPermission} (need WRITE or higher).
+  Auto-pilot will triage, resolve, and review every issue, then leave each
+  PR open for a maintainer to merge. No issues will be blocked.
+  Docs:    https://github.com/luongnv89/idd/blob/main/docs/platform-github.md
+```
+**Trigger:** Preflight step 9 finds `gh repo view --json viewerPermission` is `READ`, `TRIAGE`, or `NONE`.
+**Action:** Downgrade to no-merge mode — run the full loop but skip Phase 5 (merge), leaving all PRs open. Non-fatal — auto-pilot continues.
+
 ## Explicit List Mode
 
 ### Empty issue list

--- a/skills/init-gitissue/references/error-messages.md
+++ b/skills/init-gitissue/references/error-messages.md
@@ -9,6 +9,7 @@ All errors follow the rich error format: what went wrong + fix command + docs li
 ✗ Not a git repository
 
   To fix:  git init && git remote add origin <url>
+  Docs:    https://github.com/luongnv89/idd/blob/main/docs/platform-github.md
 ```
 **Trigger:** `git rev-parse --git-dir` fails.
 
@@ -51,6 +52,7 @@ All errors follow the rich error format: what went wrong + fix command + docs li
 
   To fix:  check file permissions in the repo root
   Check:   do you have write access? ls -la .
+  Docs:    https://github.com/luongnv89/idd/blob/main/docs/config-schema.md
 ```
 **Trigger:** File write to `.gitissue.yml` fails (permission denied, disk full, read-only filesystem).
 
@@ -60,5 +62,6 @@ All errors follow the rich error format: what went wrong + fix command + docs li
 
   To fix:  check permissions: ls -la .
   Check:   is this a read-only mount?
+  Docs:    https://github.com/luongnv89/idd/blob/main/docs/config-schema.md
 ```
 **Trigger:** The repo root directory does not allow file creation.

--- a/skills/issue-pr-review/references/error-messages.md
+++ b/skills/issue-pr-review/references/error-messages.md
@@ -15,6 +15,7 @@ All errors follow the rich format: symbol + description + fix action.
 
   To fix:  cd into your project directory
   Check:   ls -la .git
+  Docs:    https://github.com/luongnv89/idd/blob/main/docs/platform-github.md
 ```
 
 ### GitHub CLI not installed
@@ -26,6 +27,7 @@ All errors follow the rich format: symbol + description + fix action.
 
   To fix:  brew install gh   (macOS)
            https://cli.github.com (other)
+  Docs:    https://cli.github.com
 ```
 
 ### Not authenticated
@@ -36,6 +38,7 @@ All errors follow the rich format: symbol + description + fix action.
 ✗ Not authenticated with GitHub
 
   To fix:  gh auth login
+  Docs:    https://cli.github.com/manual/gh_auth_login
 ```
 
 ---
@@ -51,6 +54,7 @@ All errors follow the rich format: symbol + description + fix action.
 
   To fix:  gh pr list
   Check:   is this the right repository?
+  Docs:    https://github.com/luongnv89/idd/blob/main/docs/platform-github.md
 ```
 
 ### No PR for current branch
@@ -62,6 +66,7 @@ All errors follow the rich format: symbol + description + fix action.
 
   To fix:  gh pr create
   Or:      /issue-pr-review <PR_NUMBER>
+  Docs:    https://github.com/luongnv89/idd/blob/main/docs/platform-github.md
 ```
 
 ### PR already closed/merged
@@ -87,6 +92,7 @@ All errors follow the rich format: symbol + description + fix action.
 
   To fix:  wait and re-run /issue-pr-review {N}
   Check:   gh pr checks {N}
+  Docs:    https://github.com/luongnv89/idd/blob/main/docs/platform-github.md
 ```
 
 ### CI log fetch failed
@@ -98,6 +104,7 @@ All errors follow the rich format: symbol + description + fix action.
 
   To fix:  gh run view {run_id} --log-failed
   Check:   gh run list
+  Docs:    https://cli.github.com/manual/gh_run_view
 ```
 
 ---
@@ -113,6 +120,7 @@ All errors follow the rich format: symbol + description + fix action.
 
   To fix:  check remote access: git remote -v
   Check:   do you have push permission? gh repo view --json viewerPermission
+  Docs:    https://github.com/luongnv89/idd/blob/main/docs/platform-github.md
 ```
 
 ### Merge failed

--- a/skills/issue-triage/SKILL.md
+++ b/skills/issue-triage/SKILL.md
@@ -121,6 +121,13 @@ Before any operation, verify the environment. On failure, output the exact error
 2. Confirm `gh` is installed: `which gh`
 3. Confirm authentication: `gh auth status`
 4. Confirm GitHub remote exists: `git remote -v`
+5. **Check the rate budget** (driver rule 4, `references/docs/platform-github.md`): update mode runs a batch loop that fetches every open issue and fans out one relationship-scanner subagent per batch, each making its own `gh`/API calls. Before that loop, confirm enough budget remains:
+
+   ```bash
+   gh api rate_limit --jq '.rate.remaining'
+   ```
+
+   **Threshold:** if `remaining` is below **100**, stop and print the `✗ Insufficient API rate budget` error from `references/error-messages.md` — the batch loop would exhaust the budget mid-scan and leave a partial triage. Between 100 and 200, warn with the same message's `⚠` variant but continue. At or above 200, proceed silently. (View mode makes no API calls and skips this check entirely.)
 
 ## Repo Sync (recommended)
 

--- a/skills/issue-triage/SKILL.md
+++ b/skills/issue-triage/SKILL.md
@@ -18,8 +18,8 @@ Analyze open GitHub issues to surface dependencies, suggest priorities, identify
 | Invocation | What happens |
 |------------|--------------|
 | `/issue-triage` | Show cached triage from `.gitissue/triage.json`. If no cache exists, automatically run a full analysis and persist. After rendering, suggest an update if repo changes are detected. |
-| `/issue-triage update` | Force a full re-analysis: run Steps 1-9 and overwrite `.gitissue/triage.json` |
-| `/issue-triage --limit N` | Force a full re-analysis with up to N issues |
+| `/issue-triage update` | Force a full re-analysis: run **Prerequisites** (including the rate-budget preflight), then Steps 1-9, and overwrite `.gitissue/triage.json` |
+| `/issue-triage --limit N` | Force a full re-analysis with up to N issues (runs Prerequisites, then Steps 1-9) |
 
 The design principle: **viewing is cheap and instant, updating is deliberate.** Users see their triage report immediately without waiting for GitHub API calls. Updates only happen when the user explicitly requests one or approves a suggestion.
 

--- a/skills/issue-triage/references/error-messages.md
+++ b/skills/issue-triage/references/error-messages.md
@@ -40,6 +40,22 @@ All errors follow the rich error format: what went wrong + fix command + docs li
 
 ## Triage
 
+### Insufficient API rate budget (preflight)
+```
+✗ Insufficient GitHub API rate budget for triage
+
+  Remaining: {remaining} calls — below the safe threshold of 100.
+  The update-mode batch loop fetches every open issue and fans out
+  scanner subagents; running now would exhaust the budget mid-scan.
+
+  To fix:  wait for the budget to reset, then retry
+  Check:   gh api rate_limit --jq '.rate.remaining'
+  Docs:    https://github.com/luongnv89/idd/blob/main/docs/platform-github.md
+```
+**Trigger:** Preflight step 5 finds `gh api rate_limit --jq '.rate.remaining'` below 100 before the update-mode batch loop. Fatal — triage stops.
+
+**Low-budget warning (non-fatal):** when `remaining` is between 100 and 200, print the same block with a `⚠` symbol and the line `Proceeding — budget may run low during the scan.` instead of stopping.
+
 ### No open issues
 ```
 ○ No open issues found. Nothing to triage!

--- a/src/internal-skills/idd-doctor/references/error-messages.md
+++ b/src/internal-skills/idd-doctor/references/error-messages.md
@@ -9,6 +9,7 @@ All errors follow the rich error format: what went wrong + fix command (+ docs l
 ✗ Not a git repository
 
   To fix:  cd into a git repository, or run `git init` first
+  Docs:    https://github.com/luongnv89/idd/blob/main/docs/platform-github.md
 ```
 **Trigger:** `git rev-parse --git-dir` exits non-zero.
 
@@ -18,6 +19,7 @@ All errors follow the rich error format: what went wrong + fix command (+ docs l
 
   To fix:  ensure the working directory is the repo root and is readable
   Check:   ls -la .
+  Docs:    https://github.com/luongnv89/idd/blob/main/docs/platform-github.md
 ```
 **Trigger:** The repo root is unreadable (rare — typically a permission misconfiguration on a shared mount).
 

--- a/src/skills/auto-pilot/SKILL.source.md
+++ b/src/skills/auto-pilot/SKILL.source.md
@@ -64,6 +64,20 @@ Before starting the loop, verify the environment. On failure, output the exact e
    - `issue-pr-review`
 6. Confirm clean working tree: `git status --porcelain`
 7. Confirm on default branch: `git rev-parse --abbrev-ref HEAD`
+8. **Check the rate budget** (driver rule 4, `docs/platform-github.md` ~12): auto-pilot processes many issues in a loop, each fanning out resolver and review subagents that make their own `gh`/API calls. Before starting the loop, confirm enough budget remains:
+
+   ```bash
+   gh api rate_limit --jq '.rate.remaining'
+   ```
+
+   **Threshold:** if `remaining` is below **200**, stop and print the `✗ Insufficient API rate budget` error from `references/error-messages.md` — the loop would exhaust the budget partway through and strand issues in a half-resolved state. Between 200 and 500, warn with the `⚠` variant but continue. At or above 500, proceed silently.
+9. **Confirm push/merge permission** (driver `docs/platform-github.md` ~22-23): check the caller's repository permission:
+
+   ```bash
+   gh repo view --json viewerPermission
+   ```
+
+   If `viewerPermission` is `ADMIN`, `MAINTAIN`, or `WRITE`, the caller can push and merge — proceed normally. If it is `READ`, `TRIAGE`, or `NONE`, the caller cannot merge PRs. Rather than fail, **downgrade to no-merge mode**: print the `⚠ Insufficient merge permission — running in no-merge mode` line from `references/error-messages.md`, then run the full triage/resolve/review loop but skip Phase 5 (merge), leaving every PR open for a maintainer to merge. This is consistent with auto-pilot's always-proceed philosophy: leave PRs open rather than failing.
 
 ### Skill dependency precheck
 
@@ -329,7 +343,8 @@ On final stop, the **Final Summary** table (above) lists each iteration's issue,
 
 - **Empty backlog** — loop exits with a green "no work remaining" notice, no error.
 - **Critical issue unresolvable** — loop halts and hands control back to the user with the exact error output.
-- **Merge permission missing** — auto-merge is skipped, PR is left open, loop moves on.
+- **Merge permission missing** — detected upfront by the preflight `viewerPermission` check (Prerequisite 9); auto-pilot downgrades to no-merge mode, runs the full loop, and leaves every PR open for a maintainer. If permission is lost mid-run, auto-merge is skipped for that PR and the loop moves on.
+- **Rate budget too low** — the preflight rate-budget check (Prerequisite 8) stops before the loop starts when `remaining` is below the threshold, rather than stranding issues half-resolved.
 - **Duplicate detection** — if triage marks an issue "already fixed", it is closed with a comment and the loop picks the next one.
 - **Follow-up issue creation fails** — the PR is still merged so progress is never blocked; a warning is printed.
 

--- a/src/skills/auto-pilot/references/error-messages.md
+++ b/src/skills/auto-pilot/references/error-messages.md
@@ -55,6 +55,34 @@ All errors follow the rich error format: what went wrong + fix command + docs li
 **Trigger:** `git rev-parse --abbrev-ref HEAD` returns a branch that is not `main` or `master`.
 **Action:** Auto-switch with `git checkout {default_branch} && git pull --rebase origin {default_branch}`. Non-fatal — auto-pilot continues.
 
+### Insufficient API rate budget (preflight)
+```
+✗ Insufficient GitHub API rate budget for auto-pilot
+
+  Remaining: {remaining} calls — below the safe threshold of 200.
+  The loop resolves many issues, each fanning out subagents that make
+  their own API calls; running now would strand issues half-resolved.
+
+  To fix:  wait for the budget to reset, then re-run /auto-pilot
+  Check:   gh api rate_limit --jq '.rate.remaining'
+  Docs:    https://github.com/luongnv89/idd/blob/main/docs/platform-github.md
+```
+**Trigger:** Preflight step 8 finds `gh api rate_limit --jq '.rate.remaining'` below 200 before the loop starts. Fatal — auto-pilot stops.
+
+**Low-budget warning (non-fatal):** when `remaining` is between 200 and 500, print the same block with a `⚠` symbol and the line `Proceeding — budget may run low; the loop will skip merges if it hits the limit.` instead of stopping.
+
+### Insufficient merge permission (auto-downgrade)
+```
+⚠ Insufficient merge permission — running in no-merge mode
+
+  Your permission on this repo is {viewerPermission} (need WRITE or higher).
+  Auto-pilot will triage, resolve, and review every issue, then leave each
+  PR open for a maintainer to merge. No issues will be blocked.
+  Docs:    https://github.com/luongnv89/idd/blob/main/docs/platform-github.md
+```
+**Trigger:** Preflight step 9 finds `gh repo view --json viewerPermission` is `READ`, `TRIAGE`, or `NONE`.
+**Action:** Downgrade to no-merge mode — run the full loop but skip Phase 5 (merge), leaving all PRs open. Non-fatal — auto-pilot continues.
+
 ## Explicit List Mode
 
 ### Empty issue list

--- a/src/skills/init-gitissue/references/error-messages.md
+++ b/src/skills/init-gitissue/references/error-messages.md
@@ -9,6 +9,7 @@ All errors follow the rich error format: what went wrong + fix command + docs li
 ✗ Not a git repository
 
   To fix:  git init && git remote add origin <url>
+  Docs:    https://github.com/luongnv89/idd/blob/main/docs/platform-github.md
 ```
 **Trigger:** `git rev-parse --git-dir` fails.
 
@@ -51,6 +52,7 @@ All errors follow the rich error format: what went wrong + fix command + docs li
 
   To fix:  check file permissions in the repo root
   Check:   do you have write access? ls -la .
+  Docs:    https://github.com/luongnv89/idd/blob/main/docs/config-schema.md
 ```
 **Trigger:** File write to `.gitissue.yml` fails (permission denied, disk full, read-only filesystem).
 
@@ -60,5 +62,6 @@ All errors follow the rich error format: what went wrong + fix command + docs li
 
   To fix:  check permissions: ls -la .
   Check:   is this a read-only mount?
+  Docs:    https://github.com/luongnv89/idd/blob/main/docs/config-schema.md
 ```
 **Trigger:** The repo root directory does not allow file creation.

--- a/src/skills/issue-pr-review/references/error-messages.md
+++ b/src/skills/issue-pr-review/references/error-messages.md
@@ -15,6 +15,7 @@ All errors follow the rich format: symbol + description + fix action.
 
   To fix:  cd into your project directory
   Check:   ls -la .git
+  Docs:    https://github.com/luongnv89/idd/blob/main/docs/platform-github.md
 ```
 
 ### GitHub CLI not installed
@@ -26,6 +27,7 @@ All errors follow the rich format: symbol + description + fix action.
 
   To fix:  brew install gh   (macOS)
            https://cli.github.com (other)
+  Docs:    https://cli.github.com
 ```
 
 ### Not authenticated
@@ -36,6 +38,7 @@ All errors follow the rich format: symbol + description + fix action.
 ✗ Not authenticated with GitHub
 
   To fix:  gh auth login
+  Docs:    https://cli.github.com/manual/gh_auth_login
 ```
 
 ---
@@ -51,6 +54,7 @@ All errors follow the rich format: symbol + description + fix action.
 
   To fix:  gh pr list
   Check:   is this the right repository?
+  Docs:    https://github.com/luongnv89/idd/blob/main/docs/platform-github.md
 ```
 
 ### No PR for current branch
@@ -62,6 +66,7 @@ All errors follow the rich format: symbol + description + fix action.
 
   To fix:  gh pr create
   Or:      /issue-pr-review <PR_NUMBER>
+  Docs:    https://github.com/luongnv89/idd/blob/main/docs/platform-github.md
 ```
 
 ### PR already closed/merged
@@ -87,6 +92,7 @@ All errors follow the rich format: symbol + description + fix action.
 
   To fix:  wait and re-run /issue-pr-review {N}
   Check:   gh pr checks {N}
+  Docs:    https://github.com/luongnv89/idd/blob/main/docs/platform-github.md
 ```
 
 ### CI log fetch failed
@@ -98,6 +104,7 @@ All errors follow the rich format: symbol + description + fix action.
 
   To fix:  gh run view {run_id} --log-failed
   Check:   gh run list
+  Docs:    https://cli.github.com/manual/gh_run_view
 ```
 
 ---
@@ -113,6 +120,7 @@ All errors follow the rich format: symbol + description + fix action.
 
   To fix:  check remote access: git remote -v
   Check:   do you have push permission? gh repo view --json viewerPermission
+  Docs:    https://github.com/luongnv89/idd/blob/main/docs/platform-github.md
 ```
 
 ### Merge failed

--- a/src/skills/issue-triage/SKILL.source.md
+++ b/src/skills/issue-triage/SKILL.source.md
@@ -18,8 +18,8 @@ Analyze open GitHub issues to surface dependencies, suggest priorities, identify
 | Invocation | What happens |
 |------------|--------------|
 | `/issue-triage` | Show cached triage from `.gitissue/triage.json`. If no cache exists, automatically run a full analysis and persist. After rendering, suggest an update if repo changes are detected. |
-| `/issue-triage update` | Force a full re-analysis: run Steps 1-9 and overwrite `.gitissue/triage.json` |
-| `/issue-triage --limit N` | Force a full re-analysis with up to N issues |
+| `/issue-triage update` | Force a full re-analysis: run **Prerequisites** (including the rate-budget preflight), then Steps 1-9, and overwrite `.gitissue/triage.json` |
+| `/issue-triage --limit N` | Force a full re-analysis with up to N issues (runs Prerequisites, then Steps 1-9) |
 
 The design principle: **viewing is cheap and instant, updating is deliberate.** Users see their triage report immediately without waiting for GitHub API calls. Updates only happen when the user explicitly requests one or approves a suggestion.
 

--- a/src/skills/issue-triage/SKILL.source.md
+++ b/src/skills/issue-triage/SKILL.source.md
@@ -121,6 +121,13 @@ Before any operation, verify the environment. On failure, output the exact error
 2. Confirm `gh` is installed: `which gh`
 3. Confirm authentication: `gh auth status`
 4. Confirm GitHub remote exists: `git remote -v`
+5. **Check the rate budget** (driver rule 4, `docs/platform-github.md`): update mode runs a batch loop that fetches every open issue and fans out one relationship-scanner subagent per batch, each making its own `gh`/API calls. Before that loop, confirm enough budget remains:
+
+   ```bash
+   gh api rate_limit --jq '.rate.remaining'
+   ```
+
+   **Threshold:** if `remaining` is below **100**, stop and print the `✗ Insufficient API rate budget` error from `references/error-messages.md` — the batch loop would exhaust the budget mid-scan and leave a partial triage. Between 100 and 200, warn with the same message's `⚠` variant but continue. At or above 200, proceed silently. (View mode makes no API calls and skips this check entirely.)
 
 ## Repo Sync (recommended)
 

--- a/src/skills/issue-triage/references/error-messages.md
+++ b/src/skills/issue-triage/references/error-messages.md
@@ -40,6 +40,22 @@ All errors follow the rich error format: what went wrong + fix command + docs li
 
 ## Triage
 
+### Insufficient API rate budget (preflight)
+```
+✗ Insufficient GitHub API rate budget for triage
+
+  Remaining: {remaining} calls — below the safe threshold of 100.
+  The update-mode batch loop fetches every open issue and fans out
+  scanner subagents; running now would exhaust the budget mid-scan.
+
+  To fix:  wait for the budget to reset, then retry
+  Check:   gh api rate_limit --jq '.rate.remaining'
+  Docs:    https://github.com/luongnv89/idd/blob/main/docs/platform-github.md
+```
+**Trigger:** Preflight step 5 finds `gh api rate_limit --jq '.rate.remaining'` below 100 before the update-mode batch loop. Fatal — triage stops.
+
+**Low-budget warning (non-fatal):** when `remaining` is between 100 and 200, print the same block with a `⚠` symbol and the line `Proceeding — budget may run low during the scan.` instead of stopping.
+
 ### No open issues
 ```
 ○ No open issues found. Nothing to triage!


### PR DESCRIPTION
Closes #197

Part of epic #182 (Phase 2 hygiene). Closes three conformance gaps against the GitHub driver contract (`docs/platform-github.md`).

## Gap 1 — Missing `Docs:` lines in error catalogs
Added a `Docs:` line to every error entry that carries a `To fix:` action, matching the rich error format (`✗ what` / `To fix:` / `Docs:`) and URL convention used by the other four skills' catalogs:
- `issue-pr-review/references/error-messages.md` — 8 entries
- `init-gitissue/references/error-messages.md` — 3 entries
- `idd-doctor/references/error-messages.md` — 2 entries (internal skill; source-only)

URLs point at the most relevant real doc per error (`docs/platform-github.md`, `docs/config-schema.md`, or the GitHub CLI manual). Full `https://…` URLs are used (not bare `docs/X.md` tokens) so build.py's transitive-closure scan does not bundle new docs and trip the #195 precheck guard. Informational (`○`), prompt, and `To fix:`-less blocks are intentionally left unchanged.

## Gap 2 — `/issue-triage` rate-budget preflight
Added preflight step 5 before the update-mode batch loop: `gh api rate_limit --jq '.rate.remaining'` with a documented threshold (stop below 100, warn 100–200, proceed at 200+), plus a new rich-format `✗ Insufficient API rate budget` entry in the catalog. View mode makes no API calls and skips the check.

## Gap 3 — `/auto-pilot` rate-budget + push/merge permission
Added two preflight steps (8 and 9):
- **Rate budget** — `gh api rate_limit` with threshold stop below 200, warn 200–500.
- **Push/merge permission** — `gh repo view --json viewerPermission`; when the caller lacks WRITE+ (`READ`/`TRIAGE`/`NONE`), gracefully **downgrades to no-merge mode** with a `⚠` line, running the full loop and leaving PRs open rather than failing (consistent with auto-pilot's always-proceed philosophy). Two new catalog entries added; the existing edge-case bullets updated to match.

Both reference `docs/platform-github.md` (driver rule 4, `viewerPermission`) as the source.

## Build
`./scripts/build.sh` regenerated committed `skills/` alongside the src edits; a fresh rebuild leaves `git diff --exit-code -- skills/` clean, so the CI drift job passes.
