### PR TITLE
test(skills): add triage/creator/analysis coverage and align sync-conventions lint doc (#200)

### DIFF
--- a/.github/workflows/dist-check.yml
+++ b/.github/workflows/dist-check.yml
@@ -53,3 +53,12 @@ jobs:
 
       - name: test-build-determinism
         run: bash tests/test-build-determinism.sh
+
+      - name: test-issue-triage
+        run: bash tests/test-issue-triage.sh
+
+      - name: test-issue-creator-modes
+        run: bash tests/test-issue-creator-modes.sh
+
+      - name: test-issue-analysis
+        run: bash tests/test-issue-analysis.sh

--- a/docs/sync-conventions.md
+++ b/docs/sync-conventions.md
@@ -75,7 +75,7 @@ Every IDD skill that performs a sync step MUST:
 
 ## Lint Enforcement
 
-`tests/test-sync-safety.sh` greps `src/skills/**/*.md` and `src/skills/**/references/*.md` for `git pull --rebase` and asserts that each occurrence is preceded (within ~12 lines) by a `git stash` invocation or by a comment that defers to this document. Failing the lint blocks merges. This is the regression guard — without it, future skill edits could silently reintroduce the unsafe form.
+`tests/test-sync-safety.sh` recursively scans every Markdown file under `src/skills/` (both `SKILL.source.md` files and everything under each skill's `references/`). It walks the **fenced code blocks** (```` ``` ````-delimited, e.g. ```` ```bash ````/```` ```sh ````) and checks each one: if a fenced block contains `git pull --rebase`, that **same fenced block** must also contain a preceding `git stash` invocation. There is no line-distance window and no comment escape hatch — the guard is purely per-block. Inline mentions in single backticks and ordinary prose are ignored, because only fenced code blocks are what the skill actually instructs the agent to execute. Failing the lint blocks merges. This is the regression guard — without it, future skill edits could silently reintroduce the unsafe form.
 
 ---
 

--- a/skills/auto-pilot/references/docs/sync-conventions.md
+++ b/skills/auto-pilot/references/docs/sync-conventions.md
@@ -76,7 +76,7 @@ Every IDD skill that performs a sync step MUST:
 
 ## Lint Enforcement
 
-`tests/test-sync-safety.sh` greps `src/skills/**/*.md` and `src/skills/**/references/*.md` for `git pull --rebase` and asserts that each occurrence is preceded (within ~12 lines) by a `git stash` invocation or by a comment that defers to this document. Failing the lint blocks merges. This is the regression guard — without it, future skill edits could silently reintroduce the unsafe form.
+`tests/test-sync-safety.sh` recursively scans every Markdown file under `src/skills/` (both `SKILL.source.md` files and everything under each skill's `references/`). It walks the **fenced code blocks** (```` ``` ````-delimited, e.g. ```` ```bash ````/```` ```sh ````) and checks each one: if a fenced block contains `git pull --rebase`, that **same fenced block** must also contain a preceding `git stash` invocation. There is no line-distance window and no comment escape hatch — the guard is purely per-block. Inline mentions in single backticks and ordinary prose are ignored, because only fenced code blocks are what the skill actually instructs the agent to execute. Failing the lint blocks merges. This is the regression guard — without it, future skill edits could silently reintroduce the unsafe form.
 
 ---
 

--- a/skills/issue-analysis/references/docs/sync-conventions.md
+++ b/skills/issue-analysis/references/docs/sync-conventions.md
@@ -76,7 +76,7 @@ Every IDD skill that performs a sync step MUST:
 
 ## Lint Enforcement
 
-`tests/test-sync-safety.sh` greps `src/skills/**/*.md` and `src/skills/**/references/*.md` for `git pull --rebase` and asserts that each occurrence is preceded (within ~12 lines) by a `git stash` invocation or by a comment that defers to this document. Failing the lint blocks merges. This is the regression guard — without it, future skill edits could silently reintroduce the unsafe form.
+`tests/test-sync-safety.sh` recursively scans every Markdown file under `src/skills/` (both `SKILL.source.md` files and everything under each skill's `references/`). It walks the **fenced code blocks** (```` ``` ````-delimited, e.g. ```` ```bash ````/```` ```sh ````) and checks each one: if a fenced block contains `git pull --rebase`, that **same fenced block** must also contain a preceding `git stash` invocation. There is no line-distance window and no comment escape hatch — the guard is purely per-block. Inline mentions in single backticks and ordinary prose are ignored, because only fenced code blocks are what the skill actually instructs the agent to execute. Failing the lint blocks merges. This is the regression guard — without it, future skill edits could silently reintroduce the unsafe form.
 
 ---
 

--- a/skills/issue-creator/references/docs/sync-conventions.md
+++ b/skills/issue-creator/references/docs/sync-conventions.md
@@ -76,7 +76,7 @@ Every IDD skill that performs a sync step MUST:
 
 ## Lint Enforcement
 
-`tests/test-sync-safety.sh` greps `src/skills/**/*.md` and `src/skills/**/references/*.md` for `git pull --rebase` and asserts that each occurrence is preceded (within ~12 lines) by a `git stash` invocation or by a comment that defers to this document. Failing the lint blocks merges. This is the regression guard — without it, future skill edits could silently reintroduce the unsafe form.
+`tests/test-sync-safety.sh` recursively scans every Markdown file under `src/skills/` (both `SKILL.source.md` files and everything under each skill's `references/`). It walks the **fenced code blocks** (```` ``` ````-delimited, e.g. ```` ```bash ````/```` ```sh ````) and checks each one: if a fenced block contains `git pull --rebase`, that **same fenced block** must also contain a preceding `git stash` invocation. There is no line-distance window and no comment escape hatch — the guard is purely per-block. Inline mentions in single backticks and ordinary prose are ignored, because only fenced code blocks are what the skill actually instructs the agent to execute. Failing the lint blocks merges. This is the regression guard — without it, future skill edits could silently reintroduce the unsafe form.
 
 ---
 

--- a/skills/issue-pr-review/references/docs/sync-conventions.md
+++ b/skills/issue-pr-review/references/docs/sync-conventions.md
@@ -76,7 +76,7 @@ Every IDD skill that performs a sync step MUST:
 
 ## Lint Enforcement
 
-`tests/test-sync-safety.sh` greps `src/skills/**/*.md` and `src/skills/**/references/*.md` for `git pull --rebase` and asserts that each occurrence is preceded (within ~12 lines) by a `git stash` invocation or by a comment that defers to this document. Failing the lint blocks merges. This is the regression guard — without it, future skill edits could silently reintroduce the unsafe form.
+`tests/test-sync-safety.sh` recursively scans every Markdown file under `src/skills/` (both `SKILL.source.md` files and everything under each skill's `references/`). It walks the **fenced code blocks** (```` ``` ````-delimited, e.g. ```` ```bash ````/```` ```sh ````) and checks each one: if a fenced block contains `git pull --rebase`, that **same fenced block** must also contain a preceding `git stash` invocation. There is no line-distance window and no comment escape hatch — the guard is purely per-block. Inline mentions in single backticks and ordinary prose are ignored, because only fenced code blocks are what the skill actually instructs the agent to execute. Failing the lint blocks merges. This is the regression guard — without it, future skill edits could silently reintroduce the unsafe form.
 
 ---
 

--- a/skills/issue-resolver/references/docs/sync-conventions.md
+++ b/skills/issue-resolver/references/docs/sync-conventions.md
@@ -76,7 +76,7 @@ Every IDD skill that performs a sync step MUST:
 
 ## Lint Enforcement
 
-`tests/test-sync-safety.sh` greps `src/skills/**/*.md` and `src/skills/**/references/*.md` for `git pull --rebase` and asserts that each occurrence is preceded (within ~12 lines) by a `git stash` invocation or by a comment that defers to this document. Failing the lint blocks merges. This is the regression guard — without it, future skill edits could silently reintroduce the unsafe form.
+`tests/test-sync-safety.sh` recursively scans every Markdown file under `src/skills/` (both `SKILL.source.md` files and everything under each skill's `references/`). It walks the **fenced code blocks** (```` ``` ````-delimited, e.g. ```` ```bash ````/```` ```sh ````) and checks each one: if a fenced block contains `git pull --rebase`, that **same fenced block** must also contain a preceding `git stash` invocation. There is no line-distance window and no comment escape hatch — the guard is purely per-block. Inline mentions in single backticks and ordinary prose are ignored, because only fenced code blocks are what the skill actually instructs the agent to execute. Failing the lint blocks merges. This is the regression guard — without it, future skill edits could silently reintroduce the unsafe form.
 
 ---
 

--- a/skills/issue-triage/references/docs/sync-conventions.md
+++ b/skills/issue-triage/references/docs/sync-conventions.md
@@ -76,7 +76,7 @@ Every IDD skill that performs a sync step MUST:
 
 ## Lint Enforcement
 
-`tests/test-sync-safety.sh` greps `src/skills/**/*.md` and `src/skills/**/references/*.md` for `git pull --rebase` and asserts that each occurrence is preceded (within ~12 lines) by a `git stash` invocation or by a comment that defers to this document. Failing the lint blocks merges. This is the regression guard — without it, future skill edits could silently reintroduce the unsafe form.
+`tests/test-sync-safety.sh` recursively scans every Markdown file under `src/skills/` (both `SKILL.source.md` files and everything under each skill's `references/`). It walks the **fenced code blocks** (```` ``` ````-delimited, e.g. ```` ```bash ````/```` ```sh ````) and checks each one: if a fenced block contains `git pull --rebase`, that **same fenced block** must also contain a preceding `git stash` invocation. There is no line-distance window and no comment escape hatch — the guard is purely per-block. Inline mentions in single backticks and ordinary prose are ignored, because only fenced code blocks are what the skill actually instructs the agent to execute. Failing the lint blocks merges. This is the regression guard — without it, future skill edits could silently reintroduce the unsafe form.
 
 ---
 

--- a/tests/test-issue-analysis.sh
+++ b/tests/test-issue-analysis.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# test-issue-analysis.sh — Validate the /issue-analysis persisted JSON schema
+# and view-mode contract (issue #200, epic #182 Phase 2).
+#
+# This is a documentation/contract test in the same style as
+# tests/test-runs-jsonl.sh: it greps the authored src/ sources
+# (SKILL.source.md + references/output-and-persist.md) and asserts the
+# documented `.gitissue/analysis-<N>.json` schema is internally consistent and
+# that the view-mode prerequisites match the corrected contract (#207
+# corrected the analysis JSON `summary` key placement and the view-mode
+# prerequisites). It does NOT call the GitHub API or run the skill (no network).
+#
+# Usage: bash tests/test-issue-analysis.sh
+# Returns: exit 0 if all tests pass, exit 1 on any failure.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0
+FAIL=0
+
+pass() {
+  echo "  ✓ $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "  ✗ $1"
+  FAIL=$((FAIL + 1))
+}
+
+has() {
+  # $1 = file, $2 = pattern, $3 = label
+  if grep -qF -e "$2" "$1" 2>/dev/null; then
+    pass "$3"
+  else
+    fail "$3 (missing: '$2' in ${1#$REPO_ROOT/})"
+  fi
+}
+
+echo "◆ /issue-analysis analysis-<N>.json Tests (issue #200)"
+echo "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄"
+
+SKILL="$REPO_ROOT/src/skills/issue-analysis/SKILL.source.md"
+PERSIST="$REPO_ROOT/src/skills/issue-analysis/references/output-and-persist.md"
+
+# --- T1: both sources exist -------------------------------------------------
+if [ -f "$SKILL" ]; then
+  pass "T1: issue-analysis SKILL.source.md exists"
+else
+  fail "T1: issue-analysis SKILL.source.md missing"
+fi
+if [ -f "$PERSIST" ]; then
+  pass "T1: output-and-persist.md reference exists"
+else
+  fail "T1: output-and-persist.md reference missing"
+fi
+
+# --- T2: canonical persistence target (per-issue filename) ------------------
+# Both the SKILL and its persist reference name the same per-issue output file.
+has "$SKILL"   ".gitissue/analysis-" "T2: SKILL persists to .gitissue/analysis-<N>.json"
+has "$PERSIST" ".gitissue/analysis-" "T2: persist reference names .gitissue/analysis-<N>.json"
+
+# --- T3: top-level schema keys ----------------------------------------------
+# These live in the schema body + field-reference table (stable contract; not
+# illustrative values, so #201 example churn does not touch them).
+for key in version timestamp source issue research_status extraction \
+           affected_files analysis options recommended_option \
+           overall_complexity overall_risk history cross_references \
+           scan_stats git_state decision_record; do
+  has "$PERSIST" "$key" "T3: schema names top-level key '$key'"
+done
+
+# --- T4: analysis.summary key (#207 corrected the summary key) --------------
+# The one-paragraph analysis summary lives under `analysis.summary`. Assert
+# both the SKILL (which lifts analysis.summary into the decision record) and
+# the schema field table define it, so the corrected key placement is pinned.
+has "$PERSIST" "analysis.summary" "T4: schema field table defines analysis.summary"
+has "$PERSIST" "One-paragraph analysis summary" "T4: schema documents the analysis.summary field"
+# The SKILL owns the decision-record lift that reads analysis.summary; the
+# field itself is defined in the persist reference (#207 corrected its
+# placement there). Assert the SKILL names the `analysis` structure and the
+# `root_cause` field it lifts FROM analysis.summary — the stable cross-skill
+# contract — rather than re-stating the dotted field path.
+has "$SKILL"   "root_cause"       "T4: SKILL documents the root_cause lift (from analysis.summary)"
+has "$SKILL"   "\`analysis\`"      "T4: SKILL names the analysis result structure"
+
+# --- T5: decision_record contract (stable five labels) ----------------------
+# The five core decision-record fields are string-matched downstream, so their
+# names are a stable cross-skill contract. Assert all five in both sources.
+for dr in root_cause options_considered options_rejected \
+          selected_option residual_risk; do
+  has "$PERSIST" "$dr" "T5: schema defines decision_record.$dr"
+  has "$SKILL"   "$dr" "T5: SKILL names decision_record field '$dr'"
+done
+
+# --- T6: git_state pins the analysis to a commit ----------------------------
+for gs in branch commit_sha commit_sha_short captured_at; do
+  has "$PERSIST" "$gs" "T6: schema defines git_state.$gs"
+done
+has "$SKILL" "git_state" "T6: SKILL documents git_state pinning"
+
+# --- T7: view-mode prerequisites (#207 corrected the view-mode contract) ----
+# View mode reads ONLY the local cached JSON — no gh, no API calls, no writes.
+# These are the corrected prerequisites the test must pin.
+has "$SKILL" "view"                  "T7: SKILL documents view mode"
+has "$SKILL" "no gh required"        "T7: view mode needs only local file access (no gh)"
+has "$SKILL" "skip the entire analysis pipeline" "T7: view mode skips the analysis pipeline"
+has "$SKILL" "never writes"          "T7: view mode never writes to the file"
+has "$SKILL" "makes API calls"       "T7: view mode makes no API calls"
+# View mode re-reads the cached per-issue JSON.
+has "$SKILL" "cached analysis"       "T7: view mode renders the cached analysis"
+
+# --- T8: full analysis overwrites the cache silently ------------------------
+has "$SKILL" "overwrite it silently" "T8: a fresh full analysis overwrites the cache silently"
+
+echo ""
+echo "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄"
+echo "  Results: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+else
+  echo "  ✓ All tests passed"
+  exit 0
+fi

--- a/tests/test-issue-creator-modes.sh
+++ b/tests/test-issue-creator-modes.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# test-issue-creator-modes.sh — Validate the /issue-creator normalize, batch,
+# and dry-run mode surfaces (issue #200, epic #182 Phase 2).
+#
+# This is a documentation/contract test in the same style as
+# tests/test-runs-jsonl.sh: it greps the authored src/ sources
+# (SKILL.source.md + references/modes.md) and asserts the documented behavior
+# of the Normalize, Batch, and dry-run surfaces is present and consistent. It
+# does NOT call the GitHub API or run the skill (no network).
+#
+# Scope note: the existing tests/test-issue-creator-confidence-191.sh already
+# covers the confidence-marker placeholders and confidence-scoring.md — this
+# suite covers the MODE surfaces it does not (invocation table, normalize
+# safety steps, batch pipeline, dry-run stop). Batch mode gained optional epic
+# support in #198 (`--parent`, `Part of #{parent}`, parent checklist); a few
+# assertions confirm that surface exists but stay on STABLE documented
+# behavior — no illustrative example values that #201 may churn.
+#
+# Usage: bash tests/test-issue-creator-modes.sh
+# Returns: exit 0 if all tests pass, exit 1 on any failure.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0
+FAIL=0
+
+pass() {
+  echo "  ✓ $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "  ✗ $1"
+  FAIL=$((FAIL + 1))
+}
+
+has() {
+  # $1 = file, $2 = pattern, $3 = label
+  if grep -qF -e "$2" "$1" 2>/dev/null; then
+    pass "$3"
+  else
+    fail "$3 (missing: '$2' in ${1#$REPO_ROOT/})"
+  fi
+}
+
+echo "◆ /issue-creator mode surfaces Tests (issue #200)"
+echo "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄"
+
+SKILL="$REPO_ROOT/src/skills/issue-creator/SKILL.source.md"
+MODES="$REPO_ROOT/src/skills/issue-creator/references/modes.md"
+
+# --- T1: both sources exist -------------------------------------------------
+if [ -f "$SKILL" ]; then
+  pass "T1: issue-creator SKILL.source.md exists"
+else
+  fail "T1: issue-creator SKILL.source.md missing"
+fi
+if [ -f "$MODES" ]; then
+  pass "T1: references/modes.md exists"
+else
+  fail "T1: references/modes.md missing"
+fi
+
+# --- T2: the three modes are declared ---------------------------------------
+# The SKILL front-matter/body names Create, Normalize, and Batch.
+has "$SKILL" "Create"    "T2: SKILL declares Create mode"
+has "$SKILL" "Normalize" "T2: SKILL declares Normalize mode"
+has "$SKILL" "Batch"     "T2: SKILL declares Batch mode"
+
+# --- T3: mode-detection / invocation table ----------------------------------
+# A bare number → Normalize; multi-item text → Batch; a number is NEVER a
+# parent (that guards the #198 epic surface against mis-routing).
+has "$SKILL" "/issue-creator <N>"             "T3: invocation table has bare-N normalize"
+has "$SKILL" "/issue-creator <N> --dry-run"   "T3: invocation table has --dry-run preview"
+has "$SKILL" "argument is a number → Normalize" "T3: mode detection routes a number to Normalize"
+
+# --- T4: Normalize mode documented behavior (modes.md) ----------------------
+# Idempotency marker, security-label skip, backup-before-edit safety, and the
+# normalized marker are the stable documented contract of Normalize mode.
+has "$MODES" "gitissue:normalized v1"          "T4: normalize checks/writes the normalized marker"
+has "$MODES" "already normalized"              "T4: normalize is idempotent (already-normalized skip)"
+has "$MODES" "security label"                  "T4: normalize skips security-labeled issues"
+has "$MODES" "Backup Original Body"            "T4: normalize backs up the original body before edit"
+has "$MODES" "Reporter Context"                "T4: normalize preserves original text in Reporter Context"
+
+# --- T5: dry-run surface -----------------------------------------------------
+# --dry-run (or the [Y/n/dry-run] prompt selection) previews and stops without
+# applying any change. This is the documented no-mutation guarantee.
+has "$SKILL" "--dry-run"                        "T5: SKILL documents the --dry-run flag"
+has "$MODES" "Dry Run Check"                    "T5: modes.md has a Dry Run Check step"
+has "$MODES" "Dry run complete. No changes applied." "T5: dry-run stops with no changes applied"
+
+# --- T6: Batch mode pipeline (modes.md) -------------------------------------
+# Detect items → preview → duplicate check → approval → create sequentially,
+# with per-item success/failure tracking. Stable documented pipeline.
+has "$MODES" "Batch Create"                     "T6: modes.md documents Batch Create mode"
+has "$MODES" "Detect Items"                     "T6: batch detects distinct items"
+has "$MODES" "Preview Table"                    "T6: batch previews parsed items before creating"
+has "$MODES" "Duplicate Check"                  "T6: batch runs a duplicate check"
+has "$MODES" "fall through to single Create mode" "T6: single-item batch falls back to Create"
+has "$MODES" "Partial failure"                  "T6: batch tracks per-item partial failure"
+
+# --- T7: Batch epic surface (#198 — additive, do not over-assert values) ----
+# Confirm the epic-binding surface EXISTS without pinning illustrative numbers.
+has "$SKILL" "--parent <N>"                     "T7: SKILL documents the --parent epic flag"
+has "$MODES" "Part of #{parent}"                "T7: batch appends the Part of #{parent} child marker"
+has "$MODES" "Epic Binding"                     "T7: modes.md has the optional Epic Binding step"
+# Additive guarantee: a batch without --parent behaves as before.
+has "$MODES" "without a parent"                 "T7: epic step is skipped when no parent is bound"
+
+# --- T8: reporter-text-as-untrusted-data boundary ---------------------------
+# Normalize/Batch treat issue bodies + pasted docs as data, never instructions.
+has "$SKILL" "untrusted data"                   "T8: SKILL declares reporter text is untrusted data"
+
+echo ""
+echo "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄"
+echo "  Results: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+else
+  echo "  ✓ All tests passed"
+  exit 0
+fi

--- a/tests/test-issue-triage.sh
+++ b/tests/test-issue-triage.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# test-issue-triage.sh — Validate the /issue-triage persisted triage.json schema
+# and view-mode contract (issue #200, epic #182 Phase 2).
+#
+# This is a documentation/contract test in the same style as
+# tests/test-runs-jsonl.sh and tests/test-projects-sync.sh: it greps the
+# authored src/ sources (SKILL.source.md + references/) and asserts the skill's
+# documented triage.json schema is internally consistent — the persisted JSON
+# keys and the status enum must agree across the SKILL source, its
+# output-and-persist reference, and the field-reference table. It does NOT call
+# the GitHub API or run the skill (no network).
+#
+# The review (#200 AC1) flagged a schema-contradiction; #205 corrected the
+# triage.json `summary` key and the status enum. These assertions pin the
+# CORRECTED, internally-consistent contract so a future divergence fails here.
+#
+# Usage: bash tests/test-issue-triage.sh
+# Returns: exit 0 if all tests pass, exit 1 on any failure.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0
+FAIL=0
+
+pass() {
+  echo "  ✓ $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "  ✗ $1"
+  FAIL=$((FAIL + 1))
+}
+
+# grep helper: assert a fixed-string pattern exists in a file.
+# -e guards patterns that begin with '-' from being parsed as grep options.
+has() {
+  # $1 = file, $2 = pattern, $3 = label
+  if grep -qF -e "$2" "$1" 2>/dev/null; then
+    pass "$3"
+  else
+    fail "$3 (missing: '$2' in ${1#$REPO_ROOT/})"
+  fi
+}
+
+# assert a pattern is ABSENT from a file.
+lacks() {
+  # $1 = file, $2 = pattern, $3 = label
+  if grep -qF -e "$2" "$1" 2>/dev/null; then
+    fail "$3 (unexpected: '$2' in ${1#$REPO_ROOT/})"
+  else
+    pass "$3"
+  fi
+}
+
+echo "◆ /issue-triage triage.json schema Tests (issue #200)"
+echo "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄"
+
+SKILL="$REPO_ROOT/src/skills/issue-triage/SKILL.source.md"
+PERSIST="$REPO_ROOT/src/skills/issue-triage/references/output-and-persist.md"
+
+# --- T1: both sources exist -------------------------------------------------
+if [ -f "$SKILL" ]; then
+  pass "T1: issue-triage SKILL.source.md exists"
+else
+  fail "T1: issue-triage SKILL.source.md missing"
+fi
+if [ -f "$PERSIST" ]; then
+  pass "T1: output-and-persist.md reference exists"
+else
+  fail "T1: output-and-persist.md reference missing"
+fi
+
+# --- T2: canonical persistence target -------------------------------------
+# Both the SKILL and its persist reference name the same output file.
+has "$SKILL"   ".gitissue/triage.json" "T2: SKILL persists to .gitissue/triage.json"
+has "$PERSIST" ".gitissue/triage.json" "T2: persist reference names .gitissue/triage.json"
+
+# --- T3: top-level keys consistent between SKILL and schema ----------------
+# The SKILL Step 9 line enumerates the top-level keys; the persist reference
+# defines the JSON body + field-reference table. Assert the SAME key set is
+# named in BOTH places, so a future divergence fails here (not a
+# word-appears-somewhere pass).
+for key in version updated source analyzed_count issues summary history; do
+  has "$SKILL"   "$key" "T3: SKILL names top-level key '$key'"
+  has "$PERSIST" "$key" "T3: schema names top-level key '$key'"
+done
+
+# --- T4: summary sub-keys consistent (#205 corrected the `summary` key) -----
+# These are the persisted `summary.*` fields. Grep the unquoted tokens — they
+# appear both in the SKILL Step 9 summary-key list and in the schema body +
+# field table. Assert the same sub-key set in both sources.
+for subkey in parallel_groups stale_count stale_threshold_days \
+              potentially_fixed_count suggested_order circular_deps; do
+  has "$SKILL"   "$subkey" "T4: SKILL names summary sub-key '$subkey'"
+  has "$PERSIST" "$subkey" "T4: schema names summary sub-key '$subkey'"
+done
+
+# --- T5: per-issue keys defined in the schema -------------------------------
+# issues[] entry keys — these live in the schema body + field-reference table.
+for ikey in number title type priority blocks blocked_by status \
+            stale_days labels affected_files updated_at potentially_fixed_by; do
+  has "$PERSIST" "$ikey" "T5: schema defines issues[].$ikey"
+done
+
+# --- T6: status enum internally consistent ----------------------------------
+# The AUTHORITATIVE quoted status enum lives in the schema field-reference
+# table (issues[].status). Assert all four states are named there as quoted
+# JSON values. The SKILL Step 5 writes DISPLAY forms (e.g. `blocked #N`,
+# `stale (Nd)`), so assert the SKILL names the SAME four bare state words —
+# never grep the quoted "stale" against the SKILL (it isn't there).
+for state in ready blocked stale maybe-fixed; do
+  has "$PERSIST" "\"$state\"" "T6: schema status enum includes quoted \"$state\""
+  has "$SKILL"   "$state"     "T6: SKILL Step 5 status list names '$state'"
+done
+
+# --- T7: single consistent `summary` key (no drift back to a renamed key) ---
+# #205 corrected the persisted key to `summary`. Guard against a regression to
+# a differently-named container (e.g. `stats`/`summary_block`) by asserting the
+# schema body carries the `"summary"` object key exactly.
+has "$PERSIST" "\"summary\"" "T7: schema body uses the corrected \"summary\" object key"
+
+# --- T8: view-mode / cache contract -----------------------------------------
+# Default view mode renders the cached JSON; full re-analysis only on
+# `/issue-triage update`. This is the documented read/write boundary.
+has "$SKILL" "view mode"           "T8: SKILL documents default view mode"
+has "$SKILL" "/issue-triage update" "T8: SKILL documents update-only re-analysis"
+
+# --- T9: overwrite semantics (history is one entry per run) -----------------
+has "$PERSIST" "overwrites the entire file" "T9: full re-triage overwrites the file"
+
+echo ""
+echo "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄"
+echo "  Results: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+else
+  echo "  ✓ All tests passed"
+  exit 0
+fi


### PR DESCRIPTION
Closes #200

Part of epic #182 (Phase 2). Adds test coverage for three previously-untested skill surfaces and fixes one doc-vs-script mismatch, per the 2026-07-09 conformance review (roadmap item 13).

## What changed

**AC1 — `tests/test-issue-triage.sh` (new, 54 assertions).**
Contract test guarding the persisted `.gitissue/triage.json` schema. Asserts the top-level keys (`version`, `updated`, `source`, `analyzed_count`, `issues[]`, `summary`, `history[]`) and the `summary.*` sub-keys are named consistently in BOTH the SKILL source and its `output-and-persist.md` reference, that the `issues[].*` keys are defined, and that the `status` enum (`ready`/`blocked`/`stale`/`maybe-fixed`) is internally consistent — the corrected contract per #205 (quoted JSON values in the schema field table; the SKILL Step 5 list names the same four bare state words, since it writes display forms like `blocked #N`).

**AC2 — `tests/test-issue-creator-modes.sh` (new, 27 assertions).**
Exercises the Normalize, Batch, and dry-run mode surfaces (invocation table, normalize idempotency + security-skip + backup-before-edit, dry-run no-mutation stop, batch detect→preview→dedup→approval→per-item-failure pipeline). Confirms the #198 epic surface (`--parent`, `Part of #{parent}`, additive-when-no-parent) exists without pinning illustrative values. Complements the existing `test-issue-creator-confidence-191.sh` (no overlap — that suite covers confidence markers).

**AC3 — `tests/test-issue-analysis.sh` (new, 47 assertions).**
Guards the `.gitissue/analysis-<N>.json` persistence schema (top-level keys, `git_state.*`, `decision_record.*` five stable labels, `analysis.summary` field) and the corrected view-mode contract per #207 (reads only the local cached JSON, needs no `gh`, skips the pipeline, never writes, makes no API calls).

**AC4 — `docs/sync-conventions.md` Lint Enforcement paragraph rewritten.**
The old text promised a "~12 lines window OR a comment that defers to this document." `tests/test-sync-safety.sh` actually walks fenced code blocks and requires a preceding `git stash` in the SAME fenced block — no line window, no comment escape hatch, inline/prose ignored. The paragraph now describes exactly that. Script unchanged (doc fixed to match script, per the review's stated fix).

## Test & build status

- All three new suites run GREEN against the current tree (exit 0). `test-sync-safety.sh` still passes after the doc edit.
- Wired all three into `.github/workflows/dist-check.yml`.
- `sync-conventions.md` is a bundled runtime doc, so `./scripts/build.sh` regenerated the 6 `skills/**/references/docs/sync-conventions.md` copies — those are committed. `git diff --exit-code -- skills/` is clean vs the committed build.

These are documentation/contract tests (grep `src/` sources, no network, no live GitHub API) in the same style as `test-runs-jsonl.sh`. Assertions target stable schema/contract properties, not illustrative example values that #201 will churn.
