### PR TITLE
docs(conformance): align examples with canonical templates and clean stale artifacts (#201)

### DIFF
--- a/docs/decisions/cross-skill-invocation.md
+++ b/docs/decisions/cross-skill-invocation.md
@@ -8,9 +8,12 @@
 
 ## Context
 
-The build emits two distribution outputs from one source tree:
-`dist/skills/` (flattened, harness-agnostic) and `dist/plugin/` (Claude Code
-plugin layout). For each cross-skill, shared-agent, and runtime-doc reference
+At the time of this decision the build emitted two distribution outputs from
+one source tree: `dist/skills/` (flattened, harness-agnostic) and
+`dist/plugin/` (Claude Code plugin layout). The `dist/plugin/` output was later
+retired (see the Re-validation log) and the build now emits only the flattened
+`dist/skills/`; the plugin column below is preserved as the historical record
+of the decision. For each cross-skill, shared-agent, and runtime-doc reference
 the build chooses a rendering form. The form depends on which of three
 runtime behaviors actually work in subagent prompts (A, B, C — see plan §6.0
 and the experiment procedure in
@@ -172,8 +175,11 @@ aborts only when the *same* reference type appears in two forms within
 
 - `build.py` (#56) implements exactly the rendering forms in the table above.
   The `${CLAUDE_PLUGIN_ROOT}` form is not used anywhere in skill text.
-- `tests/test-plugin-reference-rendering.sh` (#58) verifies the chosen forms
-  and rejects same-reference-type mixing per §4 Phase E.
+- `tests/test-plugin-reference-rendering.sh` (#58) originally verified the
+  chosen forms and rejected same-reference-type mixing per §4 Phase E. That
+  test was removed together with the `dist/plugin/` output (see the
+  Re-validation log); the flattened-form invariants it covered are now
+  exercised by the standalone build tests.
 - `tests/test-autopilot-portability.sh` (#53) verifies that the
   `{{skill:name}}` tokens in `auto-pilot` are rewritten to the chosen forms
   in both distribution outputs.
@@ -212,3 +218,4 @@ aborts only when the *same* reference type appears in two forms within
 | Date | Triggering change | Outcome | Action taken |
 |------|-------------------|---------|--------------|
 | 2026-04-28 | Initial — first run for #52 | A-fail, B-fail, C-1 | Build implements row (A-fail, B-fail, C-1) per the table above |
+| 2026-07-10 | `dist/plugin/` build output and `tests/test-plugin-reference-rendering.sh` removed (epic #182 conformance cleanup) | Decision unaffected | Re-validated: plugin/ output and test-plugin-reference-rendering.sh no longer exist; the (A-fail, B-fail, C-1) decision and the flattened `dist/skills/` rendering forms stand. Present-tense references to the removed artifacts were past-tensed; the plugin column is retained as historical record. |

--- a/skills/auto-pilot/README.md
+++ b/skills/auto-pilot/README.md
@@ -67,7 +67,15 @@ When something fails, the auto-pilot skips and continues rather than stopping. A
 
 | Path | Description |
 |---|---|
+| `references/orchestration.md` | Loop orchestration and the top-level control flow |
+| `references/phases.md` | Full per-phase specification for each iteration |
+| `references/preflight.md` | Environment and rate-budget preflight checks |
+| `references/configuration.md` | Auto-pilot config options and merge-mode matrix |
+| `references/explicit-list-mode.md` | Explicit `--issues` list mode: validation, analysis, batching |
 | `references/subagent-prompts.md` | Exact prompts for resolver, reviewer, analyzer, and batch-resolver subagents |
+| `references/summary-format.md` | Final summary template and the six iteration outcomes |
+| `references/run-log.md` | `.gitissue/runs.jsonl` run-log schema and single-writer rules |
+| `references/examples.md` | Full example sessions and edge-case scenarios |
 | `references/error-messages.md` | Complete error catalog with triggers and autonomous recovery actions |
 
 ## Output

--- a/skills/auto-pilot/references/examples.md
+++ b/skills/auto-pilot/references/examples.md
@@ -54,26 +54,34 @@ Detailed example runs and edge-case behaviors referenced from SKILL.md.
 
 ✓ Iteration 1/3 complete
   Issue:    #12 — Fix auth redirect loop
-  PR:       #45 — merged ✓
+  PR:       #45
+  Outcome:  merged
+  Duration: 4m 05s
   ────────────────────────────────────
   Remaining: 4 eligible issues
 
 ● [Iteration 2/3] Triaging open issues...
   ...
 
-◆ Auto-Pilot Summary
-┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
-  Status:      limit reached
-  Iterations:  3/3
-  Duration:    12m 30s
+◆ Auto-Pilot Summary — 3/3 iterations
+┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
 
-  Resolved:
-  ✓ #12 — Fix auth redirect loop      →  PR #45 merged
-  ✓ #8  — Add pagination to API       →  PR #46 merged
-  ✓ #15 — Refactor middleware          →  PR #47 merged
+  Iteration 1:       ✓ merged                — #12 Fix auth redirect loop → PR #45
+  Iteration 2:       ✓ merged                — #8 Add pagination to API → PR #46
+  Iteration 3:       ✓ merged                — #15 Refactor middleware → PR #47
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+  merged:                  3
+  left_open:               0
+  partial_followup:        0
+  blocked_by_dependency:   0
+  failed:                  0
+  skipped:                 0
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+  Result:                  LIMIT REACHED
+  Mode:                    balanced
 
-  Remaining:   5 open issues
-  Next action: /auto-pilot to continue
+  Remaining:               5 open issues
+  Next action:             /auto-pilot to continue
 ```
 
 ---
@@ -143,7 +151,9 @@ Detailed example runs and edge-case behaviors referenced from SKILL.md.
 
 ✓ Issue 1/3 complete
   Issue:    #12 — Refactor auth middleware
-  PR:       #50 — merged ✓
+  PR:       #50
+  Outcome:  merged
+  Duration: 3m 20s
   ────────────────────────────────────
   Remaining: 2 issues in list
 
@@ -164,25 +174,33 @@ Detailed example runs and edge-case behaviors referenced from SKILL.md.
 
 ✓ Issue 2/3 complete (2 issues resolved via batch)
   Issues:   #5 — Fix login crash on mobile, #8 — Add dark mode toggle
-  PR:       #51 — merged ✓
+  PR:       #51
+  Outcome:  merged
+  Duration: 2m 50s
   ────────────────────────────────────
   Remaining: 0 issues in list
 
 ○ [Issue 3/3] #8 — already resolved in batch with #5
 
-◆ Auto-Pilot Summary
-┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
-  Status:      completed
-  Iterations:  2/3 (1 batch saved an iteration)
-  Duration:    6m 10s
-  Mode:        explicit list (analyzed + optimized)
+◆ Auto-Pilot Summary — 2/3 iterations (batch mode)
+┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+  Analysis: ✓ pass (3 issues, 1 batch groups)
 
-  Resolved:
-  ✓ #12 — Refactor auth middleware      →  PR #50 merged
-  ✓ #5  — Fix login crash on mobile    →  PR #51 merged (batch: +#8)
-  ✓ #8  — Add dark mode toggle          →  PR #51 merged (batched with #5)
+  Iteration 1:       ✓ merged                — #12 Refactor auth middleware → PR #50
+  Iteration 2:       ✓ merged                — #5 Fix login crash on mobile → PR #51 (batch: +#8)
+  Iteration 3:       ○ skipped               — #8 Add dark mode toggle (already resolved in batch)
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+  merged:                  2
+  left_open:               0
+  partial_followup:        0
+  blocked_by_dependency:   0
+  failed:                  0
+  skipped:                 1
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+  Result:                  COMPLETED
+  Mode:                    balanced
 
-  Next action: all requested issues resolved!
+  Next action:             all requested issues resolved!
 ```
 
 ---

--- a/skills/auto-pilot/references/examples.md
+++ b/skills/auto-pilot/references/examples.md
@@ -200,7 +200,8 @@ Detailed example runs and edge-case behaviors referenced from SKILL.md.
   Result:                  COMPLETED
   Mode:                    balanced
 
-  Next action:             all requested issues resolved!
+  Remaining:               0 open issues
+  Next action:             /auto-pilot to continue
 ```
 
 ---

--- a/skills/init-gitissue/README.md
+++ b/skills/init-gitissue/README.md
@@ -54,7 +54,9 @@ asm install https://github.com/luongnv89/idd --skill init-gitissue
 
 | Path | Description |
 |---|---|
+| `references/examples.md` | Full example outputs for typical detection and merge scenarios |
 | `references/error-messages.md` | Error catalog for missing git repo, existing config, and detection failures |
+| `templates/gitissue-template.yml` | Annotated `.gitissue.yml` template the skill fills in and writes |
 
 ## Output
 

--- a/skills/init-gitissue/SKILL.md
+++ b/skills/init-gitissue/SKILL.md
@@ -359,15 +359,21 @@ Terminal output follows the DESIGN.md contract — symbols `● ✓ ✗ ◆ ⚡ 
 After a successful run, the repo root contains a `.gitissue.yml` file and the terminal prints:
 
 ```
-  ✓ Wrote .gitissue.yml (24 lines)
+◆ Init Gitissue — setup complete
+┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
 
-  Detected:
-    language:    TypeScript
-    framework:   Next.js
-    test_runner: vitest
-    repo_size:   medium (42 files)
+  Git repo:          ✓ pass
+  Language:          ✓ TypeScript (from package.json)
+  Framework:         ✓ Next.js
+  Test runner:       ✓ vitest
+  Templates:         ✓ .github/ISSUE_TEMPLATE/ (3 templates)
+  Repo size:         ✓ medium (42 files)
+  Config:            ✓ generated .gitissue.yml (163 lines)
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+  Result:            DONE
 
-  Run /auto-pilot to start the loop, or /issue-creator to file a first issue.
+  Config: .gitissue.yml
+  Next action: /issue-creator to create your first issue
 ```
 
 ## Edge Cases

--- a/skills/init-gitissue/references/examples.md
+++ b/skills/init-gitissue/references/examples.md
@@ -19,20 +19,21 @@ Full example outputs for the three typical scenarios.
 6. Report:
 
 ```
-  ● Scanning repository...
-    Language:    TypeScript (detected from package.json)
-    Framework:   Next.js
-    Test runner: Jest
-    Templates:   .github/ISSUE_TEMPLATE/ found (3 templates)
-    Repo size:   medium (342 files)
+◆ Init Gitissue — setup complete
+┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
 
-  ◆ Configuration
-  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
-    Generated .gitissue.yml with project-specific defaults
+  Git repo:          ✓ pass
+  Language:          ✓ TypeScript (from package.json)
+  Framework:         ✓ Next.js
+  Test runner:       ✓ Jest
+  Templates:         ✓ .github/ISSUE_TEMPLATE/ (3 templates)
+  Repo size:         ✓ medium (342 files)
+  Config:            ✓ generated .gitissue.yml
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+  Result:            DONE
 
-  ✓ Setup complete
-    Config: .gitissue.yml
-    Run /issue-creator to create your first issue
+  Config: .gitissue.yml
+  Next action: /issue-creator to create your first issue
 ```
 
 ## Example: Minimal Python project
@@ -56,19 +57,21 @@ Full example outputs for the three typical scenarios.
   ○ Could not detect test runner. Setting resolve.auto_test: false.
     Tip: configure your test command in .gitissue.yml after setup.
 
-  ● Scanning repository...
-    Language:    Python (detected from requirements.txt)
-    Test runner: none
-    Templates:   none found
-    Repo size:   small (47 files)
+◆ Init Gitissue — setup complete
+┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
 
-  ◆ Configuration
-  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
-    Generated .gitissue.yml with project-specific defaults
+  Git repo:          ✓ pass
+  Language:          ✓ Python (from requirements.txt)
+  Framework:         ○ skip (not detected)
+  Test runner:       ○ skip (not detected)
+  Templates:         ○ skip (none found)
+  Repo size:         ✓ small (47 files)
+  Config:            ✓ generated .gitissue.yml
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+  Result:            DONE
 
-  ✓ Setup complete
-    Config: .gitissue.yml
-    Run /issue-creator to create your first issue
+  Config: .gitissue.yml
+  Next action: /issue-creator to create your first issue
 ```
 
 ## Example: Config already exists (merge)
@@ -82,21 +85,21 @@ Full example outputs for the three typical scenarios.
 5. Report:
 
 ```
-  ● Scanning repository...
-    Language:    Go (detected from go.mod)
-    Framework:   Gin
-    Test runner: Go test
-    Templates:   none found
-    Repo size:   large (1847 files)
+◆ Init Gitissue — setup complete
+┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
 
-  ◆ Configuration
-  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
-    Merged new fields into existing .gitissue.yml
-    3 new fields added, 8 existing values preserved
+  Git repo:          ✓ pass
+  Language:          ✓ Go (from go.mod)
+  Framework:         ✓ Gin
+  Test runner:       ✓ Go test
+  Templates:         ○ skip (none found)
+  Repo size:         ✓ large (1847 files)
+  Config:            ✓ merged .gitissue.yml (3 new fields, 8 preserved)
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+  Result:            DONE
 
-  ✓ Setup complete
-    Config: .gitissue.yml
-    Run /issue-creator to create your first issue
+  Config: .gitissue.yml
+  Next action: /issue-creator to create your first issue
 ```
 
 ---

--- a/skills/issue-analysis/references/examples.md
+++ b/skills/issue-analysis/references/examples.md
@@ -113,10 +113,23 @@ Full example runs (happy path, view mode, closed issue), extracted from SKILL.md
 
   ✓ Analysis saved to .gitissue/analysis-42.json
 
-  ✓ Done — analysis of issue #42: Fix mobile auth ...
-    Complexity: S │ Risk: Low
-    Recommended: Option 1 — Minimal fix
-    Saved: .gitissue/analysis-42.json
+◆ Issue Analysis: #42 — Fix mobile auth redirect loop
+┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+
+  Fetch:             ✓ pass (issue loaded)
+  Extract targets:   ✓ pass (6 keywords, 2 file refs)
+  Research:          ✓ pass (14 files scanned)
+  Git history:       ✓ pass (3 related commits)
+  Cross-references:  ✓ pass (1 related issue)
+  Root cause:        ✓ pass
+  Options:           ✓ pass (3 approaches proposed)
+  Report:            ✓ pass
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+  Result:            DONE
+
+  Complexity: S │ Risk: Low
+  Recommended: Option 1 — Minimal fix
+  Saved: .gitissue/analysis-42.json
 ```
 
 ---

--- a/skills/issue-creator/references/examples.md
+++ b/skills/issue-creator/references/examples.md
@@ -17,7 +17,7 @@ Here are the items from our sprint planning:
 3. Duplicates → none found
 4. Approval:
    ```
-   ● Scanning codebase...
+   ● Parsing input...
      Found 3 items in input
 
    ◆ Batch Preview

--- a/skills/issue-pr-review/README.md
+++ b/skills/issue-pr-review/README.md
@@ -71,7 +71,12 @@ asm install https://github.com/luongnv89/idd --skill issue-pr-review
 
 | Path | Description |
 |---|---|
-| `references/error-messages.md` | Error catalog for auth failures, dirty trees, CI timeouts, and merge conflicts |
+| `references/review-loop-mechanics.md` | Review-fix cycle mechanics and the up-to-3-cycle loop |
+| `references/prepass-tests-ci-mechanics.md` | Pre-pass lint/format/test and CI check mechanics |
+| `references/verification-checks.md` | Verification checks the reviewer runs against the diff |
+| `references/ui-review-mechanics.md` | UI-review mechanics for front-end changes |
+| `references/report-templates.md` | Per-cycle and final report templates |
+| `references/error-messages.md` | Error catalog for prerequisite (git, gh CLI, auth), PR, CI, and fix (push, merge) failures, each with a Docs link |
 
 ## Output
 

--- a/skills/issue-resolver/README.md
+++ b/skills/issue-resolver/README.md
@@ -62,6 +62,10 @@ asm install https://github.com/luongnv89/idd --skill issue-resolver
 
 | Path | Description |
 |---|---|
+| `references/pipeline-steps.md` | Full step-by-step specification of the 6-step resolve pipeline |
+| `references/bug-verification.md` | Post-fix bug-verification checkpoint and reproduction capture |
+| `references/report-templates.md` | PR body and terminal report templates |
+| `references/skill-index.md` | Progressive-disclosure index of the skill's reference files |
 | `references/error-messages.md` | Complete error catalog with triggers and exact output for every failure scenario |
 
 ## Output

--- a/skills/issue-triage/SKILL.md
+++ b/skills/issue-triage/SKILL.md
@@ -448,14 +448,16 @@ See `references/docs/github-projects-sync.md` for the shared reference on how ot
 A cached view renders instantly from `.gitissue/triage.json`:
 
 ```
-  ◆ Triage Snapshot — 12 open issues
-  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
-  │ Rank │ Issue │ Title                           │ Status       │
-  ├──────┼───────┼─────────────────────────────────┼──────────────┤
-  │  1   │ #42   │ Fix mobile auth redirect loop   │ ready        │
-  │  2   │ #15   │ Add dark mode toggle            │ ready        │
-  │  3   │ #31   │ Cover auth in unit tests        │ blocked-by #8│
-  ...
+  ◆ Issue Triage
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+  #  │ Issue              │ Pri │ Blocks │ Status
+  ───┼────────────────────┼─────┼────────┼───────────
+  1  │ #12 Fix auth       │ P1  │ #15    │ ready
+  2  │ #8  Add pagination │ P2  │ —      │ ready
+  3  │ #15 Refactor DB    │ P2  │ —      │ blocked #12
+  4  │ #3  Old UI bug     │ P3  │ —      │ stale (28d)
+
+  ○  Suggested order: #12 → #8 → #15 → #3
 
   ● Suggestion: git history shows 3 new commits since last triage.
     Run /issue-triage update to refresh.

--- a/skills/issue-triage/references/output-and-persist.md
+++ b/skills/issue-triage/references/output-and-persist.md
@@ -35,7 +35,7 @@ After the table, output summary recommendations:
   ⚡ Parallelizable: #12 + #8 (independent)
   ⚠  Stale: 1 issue (>14 days inactive)
   ◆  Maybe fixed: 1 issue may already be resolved
-  ○  Suggested order: #12 → #15 → #8 → #3
+  ○  Suggested order: #12 → #8 → #15 → #3
 ```
 
 - **Parallelizable**: List groups of issues that can be worked on simultaneously. If multiple groups exist, show each on its own line. If no parallelizable issues, omit this line.
@@ -118,7 +118,7 @@ After Step 8 (terminal output is always shown regardless of persistence success)
     "stale_count": 1,
     "stale_threshold_days": 14,
     "potentially_fixed_count": 0,
-    "suggested_order": [12, 8, 3, 15],
+    "suggested_order": [12, 8, 15, 3],
     "circular_deps": []
   },
   "history": [

--- a/src/skills/auto-pilot/README.md
+++ b/src/skills/auto-pilot/README.md
@@ -67,7 +67,15 @@ When something fails, the auto-pilot skips and continues rather than stopping. A
 
 | Path | Description |
 |---|---|
+| `references/orchestration.md` | Loop orchestration and the top-level control flow |
+| `references/phases.md` | Full per-phase specification for each iteration |
+| `references/preflight.md` | Environment and rate-budget preflight checks |
+| `references/configuration.md` | Auto-pilot config options and merge-mode matrix |
+| `references/explicit-list-mode.md` | Explicit `--issues` list mode: validation, analysis, batching |
 | `references/subagent-prompts.md` | Exact prompts for resolver, reviewer, analyzer, and batch-resolver subagents |
+| `references/summary-format.md` | Final summary template and the six iteration outcomes |
+| `references/run-log.md` | `.gitissue/runs.jsonl` run-log schema and single-writer rules |
+| `references/examples.md` | Full example sessions and edge-case scenarios |
 | `references/error-messages.md` | Complete error catalog with triggers and autonomous recovery actions |
 
 ## Output

--- a/src/skills/auto-pilot/references/examples.md
+++ b/src/skills/auto-pilot/references/examples.md
@@ -54,26 +54,34 @@ Detailed example runs and edge-case behaviors referenced from SKILL.md.
 
 ✓ Iteration 1/3 complete
   Issue:    #12 — Fix auth redirect loop
-  PR:       #45 — merged ✓
+  PR:       #45
+  Outcome:  merged
+  Duration: 4m 05s
   ────────────────────────────────────
   Remaining: 4 eligible issues
 
 ● [Iteration 2/3] Triaging open issues...
   ...
 
-◆ Auto-Pilot Summary
-┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
-  Status:      limit reached
-  Iterations:  3/3
-  Duration:    12m 30s
+◆ Auto-Pilot Summary — 3/3 iterations
+┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
 
-  Resolved:
-  ✓ #12 — Fix auth redirect loop      →  PR #45 merged
-  ✓ #8  — Add pagination to API       →  PR #46 merged
-  ✓ #15 — Refactor middleware          →  PR #47 merged
+  Iteration 1:       ✓ merged                — #12 Fix auth redirect loop → PR #45
+  Iteration 2:       ✓ merged                — #8 Add pagination to API → PR #46
+  Iteration 3:       ✓ merged                — #15 Refactor middleware → PR #47
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+  merged:                  3
+  left_open:               0
+  partial_followup:        0
+  blocked_by_dependency:   0
+  failed:                  0
+  skipped:                 0
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+  Result:                  LIMIT REACHED
+  Mode:                    balanced
 
-  Remaining:   5 open issues
-  Next action: /auto-pilot to continue
+  Remaining:               5 open issues
+  Next action:             /auto-pilot to continue
 ```
 
 ---
@@ -143,7 +151,9 @@ Detailed example runs and edge-case behaviors referenced from SKILL.md.
 
 ✓ Issue 1/3 complete
   Issue:    #12 — Refactor auth middleware
-  PR:       #50 — merged ✓
+  PR:       #50
+  Outcome:  merged
+  Duration: 3m 20s
   ────────────────────────────────────
   Remaining: 2 issues in list
 
@@ -164,25 +174,33 @@ Detailed example runs and edge-case behaviors referenced from SKILL.md.
 
 ✓ Issue 2/3 complete (2 issues resolved via batch)
   Issues:   #5 — Fix login crash on mobile, #8 — Add dark mode toggle
-  PR:       #51 — merged ✓
+  PR:       #51
+  Outcome:  merged
+  Duration: 2m 50s
   ────────────────────────────────────
   Remaining: 0 issues in list
 
 ○ [Issue 3/3] #8 — already resolved in batch with #5
 
-◆ Auto-Pilot Summary
-┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
-  Status:      completed
-  Iterations:  2/3 (1 batch saved an iteration)
-  Duration:    6m 10s
-  Mode:        explicit list (analyzed + optimized)
+◆ Auto-Pilot Summary — 2/3 iterations (batch mode)
+┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+  Analysis: ✓ pass (3 issues, 1 batch groups)
 
-  Resolved:
-  ✓ #12 — Refactor auth middleware      →  PR #50 merged
-  ✓ #5  — Fix login crash on mobile    →  PR #51 merged (batch: +#8)
-  ✓ #8  — Add dark mode toggle          →  PR #51 merged (batched with #5)
+  Iteration 1:       ✓ merged                — #12 Refactor auth middleware → PR #50
+  Iteration 2:       ✓ merged                — #5 Fix login crash on mobile → PR #51 (batch: +#8)
+  Iteration 3:       ○ skipped               — #8 Add dark mode toggle (already resolved in batch)
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+  merged:                  2
+  left_open:               0
+  partial_followup:        0
+  blocked_by_dependency:   0
+  failed:                  0
+  skipped:                 1
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+  Result:                  COMPLETED
+  Mode:                    balanced
 
-  Next action: all requested issues resolved!
+  Next action:             all requested issues resolved!
 ```
 
 ---

--- a/src/skills/auto-pilot/references/examples.md
+++ b/src/skills/auto-pilot/references/examples.md
@@ -200,7 +200,8 @@ Detailed example runs and edge-case behaviors referenced from SKILL.md.
   Result:                  COMPLETED
   Mode:                    balanced
 
-  Next action:             all requested issues resolved!
+  Remaining:               0 open issues
+  Next action:             /auto-pilot to continue
 ```
 
 ---

--- a/src/skills/init-gitissue/README.md
+++ b/src/skills/init-gitissue/README.md
@@ -54,7 +54,9 @@ asm install https://github.com/luongnv89/idd --skill init-gitissue
 
 | Path | Description |
 |---|---|
+| `references/examples.md` | Full example outputs for typical detection and merge scenarios |
 | `references/error-messages.md` | Error catalog for missing git repo, existing config, and detection failures |
+| `templates/gitissue-template.yml` | Annotated `.gitissue.yml` template the skill fills in and writes |
 
 ## Output
 

--- a/src/skills/init-gitissue/SKILL.source.md
+++ b/src/skills/init-gitissue/SKILL.source.md
@@ -359,15 +359,21 @@ Terminal output follows the DESIGN.md contract — symbols `● ✓ ✗ ◆ ⚡ 
 After a successful run, the repo root contains a `.gitissue.yml` file and the terminal prints:
 
 ```
-  ✓ Wrote .gitissue.yml (24 lines)
+◆ Init Gitissue — setup complete
+┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
 
-  Detected:
-    language:    TypeScript
-    framework:   Next.js
-    test_runner: vitest
-    repo_size:   medium (42 files)
+  Git repo:          ✓ pass
+  Language:          ✓ TypeScript (from package.json)
+  Framework:         ✓ Next.js
+  Test runner:       ✓ vitest
+  Templates:         ✓ .github/ISSUE_TEMPLATE/ (3 templates)
+  Repo size:         ✓ medium (42 files)
+  Config:            ✓ generated .gitissue.yml (163 lines)
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+  Result:            DONE
 
-  Run /auto-pilot to start the loop, or /issue-creator to file a first issue.
+  Config: .gitissue.yml
+  Next action: /issue-creator to create your first issue
 ```
 
 ## Edge Cases

--- a/src/skills/init-gitissue/references/examples.md
+++ b/src/skills/init-gitissue/references/examples.md
@@ -19,20 +19,21 @@ Full example outputs for the three typical scenarios.
 6. Report:
 
 ```
-  ● Scanning repository...
-    Language:    TypeScript (detected from package.json)
-    Framework:   Next.js
-    Test runner: Jest
-    Templates:   .github/ISSUE_TEMPLATE/ found (3 templates)
-    Repo size:   medium (342 files)
+◆ Init Gitissue — setup complete
+┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
 
-  ◆ Configuration
-  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
-    Generated .gitissue.yml with project-specific defaults
+  Git repo:          ✓ pass
+  Language:          ✓ TypeScript (from package.json)
+  Framework:         ✓ Next.js
+  Test runner:       ✓ Jest
+  Templates:         ✓ .github/ISSUE_TEMPLATE/ (3 templates)
+  Repo size:         ✓ medium (342 files)
+  Config:            ✓ generated .gitissue.yml
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+  Result:            DONE
 
-  ✓ Setup complete
-    Config: .gitissue.yml
-    Run /issue-creator to create your first issue
+  Config: .gitissue.yml
+  Next action: /issue-creator to create your first issue
 ```
 
 ## Example: Minimal Python project
@@ -56,19 +57,21 @@ Full example outputs for the three typical scenarios.
   ○ Could not detect test runner. Setting resolve.auto_test: false.
     Tip: configure your test command in .gitissue.yml after setup.
 
-  ● Scanning repository...
-    Language:    Python (detected from requirements.txt)
-    Test runner: none
-    Templates:   none found
-    Repo size:   small (47 files)
+◆ Init Gitissue — setup complete
+┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
 
-  ◆ Configuration
-  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
-    Generated .gitissue.yml with project-specific defaults
+  Git repo:          ✓ pass
+  Language:          ✓ Python (from requirements.txt)
+  Framework:         ○ skip (not detected)
+  Test runner:       ○ skip (not detected)
+  Templates:         ○ skip (none found)
+  Repo size:         ✓ small (47 files)
+  Config:            ✓ generated .gitissue.yml
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+  Result:            DONE
 
-  ✓ Setup complete
-    Config: .gitissue.yml
-    Run /issue-creator to create your first issue
+  Config: .gitissue.yml
+  Next action: /issue-creator to create your first issue
 ```
 
 ## Example: Config already exists (merge)
@@ -82,21 +85,21 @@ Full example outputs for the three typical scenarios.
 5. Report:
 
 ```
-  ● Scanning repository...
-    Language:    Go (detected from go.mod)
-    Framework:   Gin
-    Test runner: Go test
-    Templates:   none found
-    Repo size:   large (1847 files)
+◆ Init Gitissue — setup complete
+┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
 
-  ◆ Configuration
-  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
-    Merged new fields into existing .gitissue.yml
-    3 new fields added, 8 existing values preserved
+  Git repo:          ✓ pass
+  Language:          ✓ Go (from go.mod)
+  Framework:         ✓ Gin
+  Test runner:       ✓ Go test
+  Templates:         ○ skip (none found)
+  Repo size:         ✓ large (1847 files)
+  Config:            ✓ merged .gitissue.yml (3 new fields, 8 preserved)
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+  Result:            DONE
 
-  ✓ Setup complete
-    Config: .gitissue.yml
-    Run /issue-creator to create your first issue
+  Config: .gitissue.yml
+  Next action: /issue-creator to create your first issue
 ```
 
 ---

--- a/src/skills/issue-analysis/references/examples.md
+++ b/src/skills/issue-analysis/references/examples.md
@@ -113,10 +113,23 @@ Full example runs (happy path, view mode, closed issue), extracted from SKILL.md
 
   ✓ Analysis saved to .gitissue/analysis-42.json
 
-  ✓ Done — analysis of issue #42: Fix mobile auth ...
-    Complexity: S │ Risk: Low
-    Recommended: Option 1 — Minimal fix
-    Saved: .gitissue/analysis-42.json
+◆ Issue Analysis: #42 — Fix mobile auth redirect loop
+┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+
+  Fetch:             ✓ pass (issue loaded)
+  Extract targets:   ✓ pass (6 keywords, 2 file refs)
+  Research:          ✓ pass (14 files scanned)
+  Git history:       ✓ pass (3 related commits)
+  Cross-references:  ✓ pass (1 related issue)
+  Root cause:        ✓ pass
+  Options:           ✓ pass (3 approaches proposed)
+  Report:            ✓ pass
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+  Result:            DONE
+
+  Complexity: S │ Risk: Low
+  Recommended: Option 1 — Minimal fix
+  Saved: .gitissue/analysis-42.json
 ```
 
 ---

--- a/src/skills/issue-creator/references/examples.md
+++ b/src/skills/issue-creator/references/examples.md
@@ -17,7 +17,7 @@ Here are the items from our sprint planning:
 3. Duplicates → none found
 4. Approval:
    ```
-   ● Scanning codebase...
+   ● Parsing input...
      Found 3 items in input
 
    ◆ Batch Preview

--- a/src/skills/issue-pr-review/README.md
+++ b/src/skills/issue-pr-review/README.md
@@ -71,7 +71,12 @@ asm install https://github.com/luongnv89/idd --skill issue-pr-review
 
 | Path | Description |
 |---|---|
-| `references/error-messages.md` | Error catalog for auth failures, dirty trees, CI timeouts, and merge conflicts |
+| `references/review-loop-mechanics.md` | Review-fix cycle mechanics and the up-to-3-cycle loop |
+| `references/prepass-tests-ci-mechanics.md` | Pre-pass lint/format/test and CI check mechanics |
+| `references/verification-checks.md` | Verification checks the reviewer runs against the diff |
+| `references/ui-review-mechanics.md` | UI-review mechanics for front-end changes |
+| `references/report-templates.md` | Per-cycle and final report templates |
+| `references/error-messages.md` | Error catalog for prerequisite (git, gh CLI, auth), PR, CI, and fix (push, merge) failures, each with a Docs link |
 
 ## Output
 

--- a/src/skills/issue-resolver/README.md
+++ b/src/skills/issue-resolver/README.md
@@ -62,6 +62,10 @@ asm install https://github.com/luongnv89/idd --skill issue-resolver
 
 | Path | Description |
 |---|---|
+| `references/pipeline-steps.md` | Full step-by-step specification of the 6-step resolve pipeline |
+| `references/bug-verification.md` | Post-fix bug-verification checkpoint and reproduction capture |
+| `references/report-templates.md` | PR body and terminal report templates |
+| `references/skill-index.md` | Progressive-disclosure index of the skill's reference files |
 | `references/error-messages.md` | Complete error catalog with triggers and exact output for every failure scenario |
 
 ## Output

--- a/src/skills/issue-triage/SKILL.source.md
+++ b/src/skills/issue-triage/SKILL.source.md
@@ -448,14 +448,16 @@ See `docs/github-projects-sync.md` for the shared reference on how other skills 
 A cached view renders instantly from `.gitissue/triage.json`:
 
 ```
-  ◆ Triage Snapshot — 12 open issues
-  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
-  │ Rank │ Issue │ Title                           │ Status       │
-  ├──────┼───────┼─────────────────────────────────┼──────────────┤
-  │  1   │ #42   │ Fix mobile auth redirect loop   │ ready        │
-  │  2   │ #15   │ Add dark mode toggle            │ ready        │
-  │  3   │ #31   │ Cover auth in unit tests        │ blocked-by #8│
-  ...
+  ◆ Issue Triage
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+  #  │ Issue              │ Pri │ Blocks │ Status
+  ───┼────────────────────┼─────┼────────┼───────────
+  1  │ #12 Fix auth       │ P1  │ #15    │ ready
+  2  │ #8  Add pagination │ P2  │ —      │ ready
+  3  │ #15 Refactor DB    │ P2  │ —      │ blocked #12
+  4  │ #3  Old UI bug     │ P3  │ —      │ stale (28d)
+
+  ○  Suggested order: #12 → #8 → #15 → #3
 
   ● Suggestion: git history shows 3 new commits since last triage.
     Run /issue-triage update to refresh.

--- a/src/skills/issue-triage/references/output-and-persist.md
+++ b/src/skills/issue-triage/references/output-and-persist.md
@@ -35,7 +35,7 @@ After the table, output summary recommendations:
   ⚡ Parallelizable: #12 + #8 (independent)
   ⚠  Stale: 1 issue (>14 days inactive)
   ◆  Maybe fixed: 1 issue may already be resolved
-  ○  Suggested order: #12 → #15 → #8 → #3
+  ○  Suggested order: #12 → #8 → #15 → #3
 ```
 
 - **Parallelizable**: List groups of issues that can be worked on simultaneously. If multiple groups exist, show each on its own line. If no parallelizable issues, omit this line.
@@ -118,7 +118,7 @@ After Step 8 (terminal output is always shown regardless of persistence success)
     "stale_count": 1,
     "stale_threshold_days": 14,
     "potentially_fixed_count": 0,
-    "suggested_order": [12, 8, 3, 15],
+    "suggested_order": [12, 8, 15, 3],
     "circular_deps": []
   },
   "history": [


### PR DESCRIPTION
Closes #201

Aligns example outputs with each skill's canonical template/spec, cleans stale ADR references, and syncs README Resources tables. Last issue of epic #182 Phase 2.

## Example alignment (AC1)
- **issue-creator** batch example: `● Scanning codebase...` → `● Parsing input...` to match `references/modes.md`.
- **issue-triage**: unified the execution order to **12 → 8 → 15 → 3** across the table, the summary line, and the `triage.json` `suggested_order` array (order is dependency-consistent: #15 is blocked by #12). Also realigned the SKILL `Expected Output` snapshot with the Step 8 column format.
- **auto-pilot**: regenerated both `◆ Auto-Pilot Summary` example blocks from `references/summary-format.md` (per-iteration outcome rows + count block + Result/Mode footer; batch block uses the `(batch mode)` + `Analysis:` layout), and added the `Outcome:` / `Duration:` lines to the iteration reports to match the SKILL spec.
- **init-gitissue**: all three success-output sites now use the canonical Step 4 `◆ Init Gitissue — setup complete` checklist form. Fixed the implausible `(24 lines)` to the real template length (**163 lines**).
- **issue-analysis**: replaced the divergent `✓ Done —` example line with the canonical **Final Report** block.

## Stale artifacts (AC2)
- **cross-skill-invocation ADR**: past-tensed the two present-tense claims that `dist/plugin/` and `tests/test-plugin-reference-rendering.sh` still exist (both removed), and appended a dated **2026-07-10** re-validation log entry. The decision matrix's plugin column is preserved as historical record (decision unaffected).
- **stale `dist/`**: rebuilt via `./scripts/build.sh`; `dist/` is gitignored and now contains no `plugin/` (working-tree cleanup only — no PR diff).

## README Resources tables (AC3)
Synced `issue-resolver`, `issue-pr-review`, `auto-pilot`, and `init-gitissue` README Resources tables to the reference/template files actually shipped in each skill's `references/`/`templates/`.

## Build & tests
- `./scripts/build.sh` exits 0; `git diff --exit-code -- skills/` clean. Regenerated `skills/` committed alongside `src/` edits.
- #200 tests all green: `test-issue-triage.sh` (54), `test-issue-creator-modes.sh` (27), `test-issue-analysis.sh` (47). Full suite: 31/32 pass; the sole failure (`test-landing-structure.sh` T4) is pre-existing on `main` and unrelated to this change (touches no landing files).
