### PR TITLE
chore(design): repoint remaining skills' DESIGN.md refs to terminal-style (#232)

### DIFF
--- a/docs/github-projects-sync.md
+++ b/docs/github-projects-sync.md
@@ -259,7 +259,7 @@ No status changes. Triage is read-only with respect to the project board. Future
 
 ## Terminal Output
 
-Follow DESIGN.md conventions for all sync output:
+Follow `docs/terminal-style.md` conventions for all sync output:
 
 - `●` when sync is in progress
 - `✓` on success

--- a/skills/auto-pilot/SKILL.md
+++ b/skills/auto-pilot/SKILL.md
@@ -113,6 +113,7 @@ Check these files relative to the skill's directory (the dirname of this SKILL.m
 - `references/docs/platform-github.md` — GitHub platform driver reference
 - `references/docs/shared-agent-conventions.md` — shared subagent conventions
 - `references/docs/agent-model-effort.md` — per-agent model and reasoning-effort mapping
+- `references/docs/terminal-style.md` — terminal output style contract (symbols, output structure, table/error formats)
 
 If the working tree is dirty, auto-stash before starting; if not on the default
 branch, auto-switch and rebase on a clean tree. Both procedures (the stash-first
@@ -318,7 +319,7 @@ All tracker access follows the GitHub driver — `--json` with explicit field se
 
 ## Output Conventions
 
-Terminal output follows the DESIGN.md contract — symbols `● ✓ ✗ ◆ ⚡ ⚠ ○`, two-space indent, `┄` separators, URLs on their own line, ≤80 chars, one blank line between sections, static sequential output (no animation), plus auto-pilot's `[Iteration {i}/{max}]` loop counter and the resolver's inherited `[N/5]` step counter. Errors use the rich format from `references/error-messages.md`: `✗ what failed`, then `To fix:  <command>`, then a docs link when applicable.
+Terminal output follows the `references/docs/terminal-style.md` contract — symbols `● ✓ ✗ ◆ ⚡ ⚠ ○`, two-space indent, `┄` separators, URLs on their own line, ≤80 chars, one blank line between sections, static sequential output (no animation), plus auto-pilot's `[Iteration {i}/{max}]` loop counter and the resolver's inherited `[N/5]` step counter. Errors use the rich format from `references/error-messages.md`: `✗ what failed`, then `To fix:  <command>`, then a docs link when applicable.
 
 ## Prompt Injection Boundary
 
@@ -353,4 +354,4 @@ On final stop, the **Final Summary** table (above) lists each iteration's issue,
 - **`references/subagent-prompts.md`** — resolver, reviewer, analyzer, and batch-resolver prompts (read once at skill start)
 - **`references/error-messages.md`** — full error catalog with triggers and exact output
 - **`references/docs/naming-conventions.md`** — branch, commit, PR, and issue naming
-- **`DESIGN.md`** (repo root) — terminal output style guide; **`references/docs/config-schema.md`** — full configuration schema
+- **`references/docs/terminal-style.md`** — terminal output style contract (bundled at build time; the repo-root `DESIGN.md` is the human-facing companion and is not bundled); **`references/docs/config-schema.md`** — full configuration schema

--- a/skills/auto-pilot/references/docs/github-projects-sync.md
+++ b/skills/auto-pilot/references/docs/github-projects-sync.md
@@ -260,7 +260,7 @@ No status changes. Triage is read-only with respect to the project board. Future
 
 ## Terminal Output
 
-Follow DESIGN.md conventions for all sync output:
+Follow `references/docs/terminal-style.md` conventions for all sync output:
 
 - `●` when sync is in progress
 - `✓` on success

--- a/skills/auto-pilot/references/docs/terminal-style.md
+++ b/skills/auto-pilot/references/docs/terminal-style.md
@@ -1,0 +1,155 @@
+<!-- Generated from /docs/terminal-style.md. Do not edit. Edit source and run ./scripts/build.sh. -->
+# Terminal Output Style Contract
+
+The canonical terminal-output contract that gitissue skills consume at runtime:
+the symbol vocabulary, output structure, progress patterns, table and error
+formats, and the behavioral rules for confirmations, confidence, first-run, and
+empty states. This is the single source of truth for skill output.
+
+`DESIGN.md` (repo root) is the human-facing style guide — it adds the color
+palette and per-command output mockups on top of this contract. When the two
+overlap, this document is authoritative for what skills emit.
+
+## Principles
+
+1. **Show, don't dump.** Structured output > raw text. Tables > JSON. Sections > walls of text.
+2. **Transparency builds trust.** Show confidence scores, step progress, and what's happening at each phase. No black boxes.
+3. **Errors are help.** When something fails, show what went wrong + how to fix + where to learn more.
+4. **Warmth in empty states.** "No items found" is not a design. Every empty state has context and a next action.
+5. **Distinctive, not decorative.** Step counters, confidence markers, and semantic symbols give gitissue its own feel — not generic AI slop.
+
+## Symbol Vocabulary
+
+| Symbol | Meaning | Color | Example |
+|--------|---------|-------|---------|
+| `●` | In progress | — | `● Scanning codebase...` |
+| `✓` | Success / complete | Green | `✓ Created issue #42` |
+| `✗` | Failure / error | Red | `✗ Not authenticated` |
+| `◆` | Section header | Bold | `◆ Issue Preview` |
+| `⚡` | Action / recommendation | — | `⚡ Parallelizable: #12 + #8` |
+| `⚠` | Warning | Yellow | `⚠ Stale: 1 issue (>14d)` |
+| `○` | Info / neutral | — | `○ First run — using defaults` |
+| `⟶` | Next action / leads to | — | `⟶ Spawning resolver subagent...` |
+| `+` | Added field | — | `+ Files: auth.py (high)` |
+| `=` | Preserved field | — | `= Original: preserved` |
+
+All symbols carry meaning without color. Never rely on color alone.
+
+`⟶` marks the transition to the next autonomous action in a loop (auto-pilot):
+what the orchestrator is about to do — spawn a subagent, start immediately,
+merge a partial PR. It reads as "leads to".
+
+## Output Structure
+
+Every command follows this hierarchy:
+
+```
+  ● Progress (what's happening now)
+
+  ◆ Section Header
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+    Content (indented 2 spaces)
+    More content
+
+  ✓ Result (what happened)
+    https://url (always on its own line)
+```
+
+Rules:
+- One blank line between sections
+- Two-space indent for content under headers
+- No trailing blank lines
+- URLs always on their own line, in cyan
+- Section separators: `┄` (light dash, not heavy box)
+
+## Progress Patterns
+
+**Multi-step pipeline** (issue-resolver):
+```
+  [0/5] Preflight    ✓ issue #42 open, not yet resolved
+  [1/5] Research     ✓ read 5 files, complexity: medium
+  [2/5] Plan         ● selecting approach...
+```
+
+**Single operation** (issue-creator):
+```
+  ● Scanning codebase...
+```
+
+## Table Format
+
+```
+  #  │ Issue              │ Pri │ Blocks │ Status
+  ───┼────────────────────┼─────┼────────┼───────────
+  1  │ #12 Fix auth       │ P1  │ #15    │ ready
+  2  │ #8  Add pagination │ P2  │ —      │ ready
+```
+
+- Box-drawing characters: `│ ─ ┼`
+- Right-align numbers, left-align text
+- Max width: 80 characters (truncate with `...` if needed)
+- Use `—` for empty cells (not blank)
+
+## Error Format
+
+Errors are the moment users need the most help.
+
+```
+  ✗ Short error description
+
+    To fix:  <actionable command>
+    Docs:    <url to relevant documentation>
+```
+
+Always include: what went wrong, how to fix it, where to learn more.
+
+## Confirmation Prompts
+
+```
+  Apply normalization? [Y/n]
+```
+
+Default option in uppercase. Alternatives in lowercase.
+
+## Confidence Markers
+
+Unique to gitissue. Show honesty about what's inferred:
+
+```
+  + Files:    auth.py (high), config.py (medium)
+  + Criteria: 3 acceptance criteria (medium)
+```
+
+Levels: `high` (direct match), `medium` (keyword inference), `low` (best guess, marked `(needs review)` in the issue).
+
+## First-Run Experience
+
+When no `.gitissue.yml` exists:
+
+```
+  ○ First run — using default config. Run /init-gitissue to customize.
+```
+
+One line, then proceed normally. Non-intrusive.
+
+## Empty States
+
+Every empty state has warmth and a next action:
+
+| Scenario | Output |
+|----------|--------|
+| No files identified | `⚠ Could not identify affected files. Issue created with manual-review flag. Tip: mention specific filenames for better results.` |
+| No open issues (triage) | `○ No open issues found. Nothing to triage! Create issues with /issue-creator to get started.` |
+| Already normalized | `✓ Issue #42 is already normalized (v1, 2026-03-15). No changes needed.` |
+| Issue not found | `✗ Issue #42 not found\n\n  To fix: gh issue list\n  Check: is this the right repository?` |
+
+## GitHub Markdown Rendering
+
+Normalized issues must render cleanly in GitHub's web UI:
+
+- Use standard markdown (no HTML except the invisible marker)
+- Section headers: `## Type`, `## Description`, `## Acceptance Criteria`
+- Code blocks for file paths and technical details
+- Normalization marker: `<!-- gitissue:normalized v1 -->` (invisible in rendered view)
+- Reporter's original text: in a `> Reporter Context` blockquote
+- Confidence markers in parentheses: `(high confidence)`, `(needs review)`

--- a/skills/init-gitissue/SKILL.md
+++ b/skills/init-gitissue/SKILL.md
@@ -65,6 +65,7 @@ Check these files relative to the skill's directory (the dirname of this SKILL.m
 - `references/docs/idd-methodology.md` — IDD methodology reference
 - `references/docs/github-projects-sync.md` — GitHub Projects status sync reference
 - `references/docs/platform-github.md` — GitHub platform driver reference
+- `references/docs/terminal-style.md` — terminal output style contract (symbols, output structure, table/error formats)
 
 ## Configuration Check
 
@@ -352,7 +353,7 @@ Full example outputs for three scenarios (TypeScript + Next.js project, minimal 
 
 ## Output Conventions
 
-Terminal output follows the DESIGN.md contract — symbols `● ✓ ✗ ◆ ⚡ ⚠ ○`, two-space indent, `┄` separators, URLs on their own line, ≤80 chars, one blank line between sections, static sequential output (no animation). Errors use the rich format from `references/error-messages.md`: `✗ what failed`, then `To fix:  <command>`, then a docs link when applicable.
+Terminal output follows the `references/docs/terminal-style.md` contract — symbols `● ✓ ✗ ◆ ⚡ ⚠ ○`, two-space indent, `┄` separators, URLs on their own line, ≤80 chars, one blank line between sections, static sequential output (no animation). Errors use the rich format from `references/error-messages.md`: `✗ what failed`, then `To fix:  <command>`, then a docs link when applicable.
 
 ## Expected Output
 
@@ -388,4 +389,4 @@ After a successful run, the repo root contains a `.gitissue.yml` file and the te
 - **`references/error-messages.md`** — Complete error catalog with triggers and exact output
 - **`references/docs/naming-conventions.md`** — Branch, commit, PR, and issue naming conventions (referenced by generated config)
 - **`references/docs/config-schema.md`** — Full configuration schema that this skill generates
-- **`DESIGN.md`** — Terminal output style guide (repo root)
+- **`references/docs/terminal-style.md`** — Terminal output style contract (bundled at build time; the repo-root `DESIGN.md` is the human-facing companion and is not bundled)

--- a/skills/init-gitissue/references/docs/github-projects-sync.md
+++ b/skills/init-gitissue/references/docs/github-projects-sync.md
@@ -260,7 +260,7 @@ No status changes. Triage is read-only with respect to the project board. Future
 
 ## Terminal Output
 
-Follow DESIGN.md conventions for all sync output:
+Follow `references/docs/terminal-style.md` conventions for all sync output:
 
 - `●` when sync is in progress
 - `✓` on success

--- a/skills/init-gitissue/references/docs/terminal-style.md
+++ b/skills/init-gitissue/references/docs/terminal-style.md
@@ -1,0 +1,155 @@
+<!-- Generated from /docs/terminal-style.md. Do not edit. Edit source and run ./scripts/build.sh. -->
+# Terminal Output Style Contract
+
+The canonical terminal-output contract that gitissue skills consume at runtime:
+the symbol vocabulary, output structure, progress patterns, table and error
+formats, and the behavioral rules for confirmations, confidence, first-run, and
+empty states. This is the single source of truth for skill output.
+
+`DESIGN.md` (repo root) is the human-facing style guide — it adds the color
+palette and per-command output mockups on top of this contract. When the two
+overlap, this document is authoritative for what skills emit.
+
+## Principles
+
+1. **Show, don't dump.** Structured output > raw text. Tables > JSON. Sections > walls of text.
+2. **Transparency builds trust.** Show confidence scores, step progress, and what's happening at each phase. No black boxes.
+3. **Errors are help.** When something fails, show what went wrong + how to fix + where to learn more.
+4. **Warmth in empty states.** "No items found" is not a design. Every empty state has context and a next action.
+5. **Distinctive, not decorative.** Step counters, confidence markers, and semantic symbols give gitissue its own feel — not generic AI slop.
+
+## Symbol Vocabulary
+
+| Symbol | Meaning | Color | Example |
+|--------|---------|-------|---------|
+| `●` | In progress | — | `● Scanning codebase...` |
+| `✓` | Success / complete | Green | `✓ Created issue #42` |
+| `✗` | Failure / error | Red | `✗ Not authenticated` |
+| `◆` | Section header | Bold | `◆ Issue Preview` |
+| `⚡` | Action / recommendation | — | `⚡ Parallelizable: #12 + #8` |
+| `⚠` | Warning | Yellow | `⚠ Stale: 1 issue (>14d)` |
+| `○` | Info / neutral | — | `○ First run — using defaults` |
+| `⟶` | Next action / leads to | — | `⟶ Spawning resolver subagent...` |
+| `+` | Added field | — | `+ Files: auth.py (high)` |
+| `=` | Preserved field | — | `= Original: preserved` |
+
+All symbols carry meaning without color. Never rely on color alone.
+
+`⟶` marks the transition to the next autonomous action in a loop (auto-pilot):
+what the orchestrator is about to do — spawn a subagent, start immediately,
+merge a partial PR. It reads as "leads to".
+
+## Output Structure
+
+Every command follows this hierarchy:
+
+```
+  ● Progress (what's happening now)
+
+  ◆ Section Header
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+    Content (indented 2 spaces)
+    More content
+
+  ✓ Result (what happened)
+    https://url (always on its own line)
+```
+
+Rules:
+- One blank line between sections
+- Two-space indent for content under headers
+- No trailing blank lines
+- URLs always on their own line, in cyan
+- Section separators: `┄` (light dash, not heavy box)
+
+## Progress Patterns
+
+**Multi-step pipeline** (issue-resolver):
+```
+  [0/5] Preflight    ✓ issue #42 open, not yet resolved
+  [1/5] Research     ✓ read 5 files, complexity: medium
+  [2/5] Plan         ● selecting approach...
+```
+
+**Single operation** (issue-creator):
+```
+  ● Scanning codebase...
+```
+
+## Table Format
+
+```
+  #  │ Issue              │ Pri │ Blocks │ Status
+  ───┼────────────────────┼─────┼────────┼───────────
+  1  │ #12 Fix auth       │ P1  │ #15    │ ready
+  2  │ #8  Add pagination │ P2  │ —      │ ready
+```
+
+- Box-drawing characters: `│ ─ ┼`
+- Right-align numbers, left-align text
+- Max width: 80 characters (truncate with `...` if needed)
+- Use `—` for empty cells (not blank)
+
+## Error Format
+
+Errors are the moment users need the most help.
+
+```
+  ✗ Short error description
+
+    To fix:  <actionable command>
+    Docs:    <url to relevant documentation>
+```
+
+Always include: what went wrong, how to fix it, where to learn more.
+
+## Confirmation Prompts
+
+```
+  Apply normalization? [Y/n]
+```
+
+Default option in uppercase. Alternatives in lowercase.
+
+## Confidence Markers
+
+Unique to gitissue. Show honesty about what's inferred:
+
+```
+  + Files:    auth.py (high), config.py (medium)
+  + Criteria: 3 acceptance criteria (medium)
+```
+
+Levels: `high` (direct match), `medium` (keyword inference), `low` (best guess, marked `(needs review)` in the issue).
+
+## First-Run Experience
+
+When no `.gitissue.yml` exists:
+
+```
+  ○ First run — using default config. Run /init-gitissue to customize.
+```
+
+One line, then proceed normally. Non-intrusive.
+
+## Empty States
+
+Every empty state has warmth and a next action:
+
+| Scenario | Output |
+|----------|--------|
+| No files identified | `⚠ Could not identify affected files. Issue created with manual-review flag. Tip: mention specific filenames for better results.` |
+| No open issues (triage) | `○ No open issues found. Nothing to triage! Create issues with /issue-creator to get started.` |
+| Already normalized | `✓ Issue #42 is already normalized (v1, 2026-03-15). No changes needed.` |
+| Issue not found | `✗ Issue #42 not found\n\n  To fix: gh issue list\n  Check: is this the right repository?` |
+
+## GitHub Markdown Rendering
+
+Normalized issues must render cleanly in GitHub's web UI:
+
+- Use standard markdown (no HTML except the invisible marker)
+- Section headers: `## Type`, `## Description`, `## Acceptance Criteria`
+- Code blocks for file paths and technical details
+- Normalization marker: `<!-- gitissue:normalized v1 -->` (invisible in rendered view)
+- Reporter's original text: in a `> Reporter Context` blockquote
+- Confidence markers in parentheses: `(high confidence)`, `(needs review)`

--- a/skills/issue-analysis/SKILL.md
+++ b/skills/issue-analysis/SKILL.md
@@ -40,7 +40,7 @@ When invoked as `/issue-analysis <N> view`, skip the entire analysis pipeline (S
      Check:   was the file edited manually?
    ```
 5. Compute report age from the `timestamp` field relative to now
-6. Render the full analysis report to terminal using the same DESIGN.md format as Step 6, with a cache header:
+6. Render the full analysis report to terminal using the same `references/docs/terminal-style.md` format as Step 6, with a cache header:
 
 ```
 ◆ Issue Analysis (cached)
@@ -187,6 +187,7 @@ Check these files relative to the skill's directory (the dirname of this SKILL.m
 - `references/docs/platform-github.md` — GitHub platform driver reference
 - `references/docs/shared-agent-conventions.md` — shared subagent conventions
 - `references/docs/agent-model-effort.md` — per-agent model and reasoning-effort mapping
+- `references/docs/terminal-style.md` — terminal output style contract (symbols, output structure, table/error formats)
 
 The steps below include both the subagent delegation path and the inline fallback.
 
@@ -269,7 +270,7 @@ Quick summary:
 ---
 ## Step 8-9 — Output & Persist
 
-Step 8 renders the analysis as a structured terminal report following DESIGN.md conventions; Step 9 persists the same data to `.gitissue/analysis-<N>.json`. Full rendering spec (section layout, color codes, truncation rules) and JSON schema live in `references/output-and-persist.md` — read that file when implementing or debugging either step.
+Step 8 renders the analysis as a structured terminal report following `references/docs/terminal-style.md` conventions; Step 9 persists the same data to `.gitissue/analysis-<N>.json`. Full rendering spec (section layout, color codes, truncation rules) and JSON schema live in `references/output-and-persist.md` — read that file when implementing or debugging either step.
 
 Summary:
 - Terminal report has 8 sections: header, classification, root cause, affected files, options, complexity, risk, recommendation.
@@ -408,12 +409,12 @@ All tracker access follows the GitHub driver — `--json` with explicit field se
 
 ## Output Conventions
 
-Terminal output follows the DESIGN.md contract — symbols `● ✓ ✗ ◆ ⚡ ⚠ ○`, two-space indent, `┄` separators, URLs on their own line, ≤80 chars, one blank line between sections, static sequential output (no animation), plus a `[N/8]` pipeline step counter and `│ ─ ┼` tables (right-align numbers, `—` for empty cells). Errors use the rich format from `references/error-messages.md`: `✗ what failed`, then `To fix:  <command>`, then a docs link when applicable.
+Terminal output follows the `references/docs/terminal-style.md` contract — symbols `● ✓ ✗ ◆ ⚡ ⚠ ○`, two-space indent, `┄` separators, URLs on their own line, ≤80 chars, one blank line between sections, static sequential output (no animation), plus a `[N/8]` pipeline step counter and `│ ─ ┼` tables (right-align numbers, `—` for empty cells). Errors use the rich format from `references/error-messages.md`: `✗ what failed`, then `To fix:  <command>`, then a docs link when applicable.
 
 ## Additional Resources
 
 - **`references/agents/codebase-researcher.md`** — Codebase Researcher subagent prompt (Steps 2-5 delegation)
 - **`references/agents/synthesizer.md`** — Synthesizer subagent prompt (Steps 6-7 delegation)
 - **`references/error-messages.md`** — Complete error catalog with triggers and exact output
-- **`DESIGN.md`** — Terminal output style guide (repo root)
+- **`references/docs/terminal-style.md`** — Terminal output style contract (bundled at build time; the repo-root `DESIGN.md` is the human-facing companion and is not bundled)
 - **`references/docs/config-schema.md`** — Full configuration schema

--- a/skills/issue-analysis/references/docs/github-projects-sync.md
+++ b/skills/issue-analysis/references/docs/github-projects-sync.md
@@ -260,7 +260,7 @@ No status changes. Triage is read-only with respect to the project board. Future
 
 ## Terminal Output
 
-Follow DESIGN.md conventions for all sync output:
+Follow `references/docs/terminal-style.md` conventions for all sync output:
 
 - `●` when sync is in progress
 - `✓` on success

--- a/skills/issue-analysis/references/docs/terminal-style.md
+++ b/skills/issue-analysis/references/docs/terminal-style.md
@@ -1,0 +1,155 @@
+<!-- Generated from /docs/terminal-style.md. Do not edit. Edit source and run ./scripts/build.sh. -->
+# Terminal Output Style Contract
+
+The canonical terminal-output contract that gitissue skills consume at runtime:
+the symbol vocabulary, output structure, progress patterns, table and error
+formats, and the behavioral rules for confirmations, confidence, first-run, and
+empty states. This is the single source of truth for skill output.
+
+`DESIGN.md` (repo root) is the human-facing style guide — it adds the color
+palette and per-command output mockups on top of this contract. When the two
+overlap, this document is authoritative for what skills emit.
+
+## Principles
+
+1. **Show, don't dump.** Structured output > raw text. Tables > JSON. Sections > walls of text.
+2. **Transparency builds trust.** Show confidence scores, step progress, and what's happening at each phase. No black boxes.
+3. **Errors are help.** When something fails, show what went wrong + how to fix + where to learn more.
+4. **Warmth in empty states.** "No items found" is not a design. Every empty state has context and a next action.
+5. **Distinctive, not decorative.** Step counters, confidence markers, and semantic symbols give gitissue its own feel — not generic AI slop.
+
+## Symbol Vocabulary
+
+| Symbol | Meaning | Color | Example |
+|--------|---------|-------|---------|
+| `●` | In progress | — | `● Scanning codebase...` |
+| `✓` | Success / complete | Green | `✓ Created issue #42` |
+| `✗` | Failure / error | Red | `✗ Not authenticated` |
+| `◆` | Section header | Bold | `◆ Issue Preview` |
+| `⚡` | Action / recommendation | — | `⚡ Parallelizable: #12 + #8` |
+| `⚠` | Warning | Yellow | `⚠ Stale: 1 issue (>14d)` |
+| `○` | Info / neutral | — | `○ First run — using defaults` |
+| `⟶` | Next action / leads to | — | `⟶ Spawning resolver subagent...` |
+| `+` | Added field | — | `+ Files: auth.py (high)` |
+| `=` | Preserved field | — | `= Original: preserved` |
+
+All symbols carry meaning without color. Never rely on color alone.
+
+`⟶` marks the transition to the next autonomous action in a loop (auto-pilot):
+what the orchestrator is about to do — spawn a subagent, start immediately,
+merge a partial PR. It reads as "leads to".
+
+## Output Structure
+
+Every command follows this hierarchy:
+
+```
+  ● Progress (what's happening now)
+
+  ◆ Section Header
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+    Content (indented 2 spaces)
+    More content
+
+  ✓ Result (what happened)
+    https://url (always on its own line)
+```
+
+Rules:
+- One blank line between sections
+- Two-space indent for content under headers
+- No trailing blank lines
+- URLs always on their own line, in cyan
+- Section separators: `┄` (light dash, not heavy box)
+
+## Progress Patterns
+
+**Multi-step pipeline** (issue-resolver):
+```
+  [0/5] Preflight    ✓ issue #42 open, not yet resolved
+  [1/5] Research     ✓ read 5 files, complexity: medium
+  [2/5] Plan         ● selecting approach...
+```
+
+**Single operation** (issue-creator):
+```
+  ● Scanning codebase...
+```
+
+## Table Format
+
+```
+  #  │ Issue              │ Pri │ Blocks │ Status
+  ───┼────────────────────┼─────┼────────┼───────────
+  1  │ #12 Fix auth       │ P1  │ #15    │ ready
+  2  │ #8  Add pagination │ P2  │ —      │ ready
+```
+
+- Box-drawing characters: `│ ─ ┼`
+- Right-align numbers, left-align text
+- Max width: 80 characters (truncate with `...` if needed)
+- Use `—` for empty cells (not blank)
+
+## Error Format
+
+Errors are the moment users need the most help.
+
+```
+  ✗ Short error description
+
+    To fix:  <actionable command>
+    Docs:    <url to relevant documentation>
+```
+
+Always include: what went wrong, how to fix it, where to learn more.
+
+## Confirmation Prompts
+
+```
+  Apply normalization? [Y/n]
+```
+
+Default option in uppercase. Alternatives in lowercase.
+
+## Confidence Markers
+
+Unique to gitissue. Show honesty about what's inferred:
+
+```
+  + Files:    auth.py (high), config.py (medium)
+  + Criteria: 3 acceptance criteria (medium)
+```
+
+Levels: `high` (direct match), `medium` (keyword inference), `low` (best guess, marked `(needs review)` in the issue).
+
+## First-Run Experience
+
+When no `.gitissue.yml` exists:
+
+```
+  ○ First run — using default config. Run /init-gitissue to customize.
+```
+
+One line, then proceed normally. Non-intrusive.
+
+## Empty States
+
+Every empty state has warmth and a next action:
+
+| Scenario | Output |
+|----------|--------|
+| No files identified | `⚠ Could not identify affected files. Issue created with manual-review flag. Tip: mention specific filenames for better results.` |
+| No open issues (triage) | `○ No open issues found. Nothing to triage! Create issues with /issue-creator to get started.` |
+| Already normalized | `✓ Issue #42 is already normalized (v1, 2026-03-15). No changes needed.` |
+| Issue not found | `✗ Issue #42 not found\n\n  To fix: gh issue list\n  Check: is this the right repository?` |
+
+## GitHub Markdown Rendering
+
+Normalized issues must render cleanly in GitHub's web UI:
+
+- Use standard markdown (no HTML except the invisible marker)
+- Section headers: `## Type`, `## Description`, `## Acceptance Criteria`
+- Code blocks for file paths and technical details
+- Normalization marker: `<!-- gitissue:normalized v1 -->` (invisible in rendered view)
+- Reporter's original text: in a `> Reporter Context` blockquote
+- Confidence markers in parentheses: `(high confidence)`, `(needs review)`

--- a/skills/issue-analysis/references/output-and-persist.md
+++ b/skills/issue-analysis/references/output-and-persist.md
@@ -5,7 +5,7 @@ Full Step 8 terminal rendering spec and Step 9 JSON persistence schema. SKILL.md
 ## Step 8 — Output (Terminal Report)
 
 
-Display the full analysis following DESIGN.md conventions.
+Display the full analysis following `references/docs/terminal-style.md` conventions.
 
 ### Issue header
 
@@ -60,7 +60,7 @@ Omit categories that have no entries.
     tests/test_auth.py           │ high      │ existing tests
 ```
 
-Table rules (per DESIGN.md): box-drawing characters `│ ─ ┼`, max 80 chars wide, truncate paths with `...` if needed.
+Table rules (per `references/docs/terminal-style.md`): box-drawing characters `│ ─ ┼`, max 80 chars wide, truncate paths with `...` if needed.
 
 ### Git history
 

--- a/skills/issue-creator/SKILL.md
+++ b/skills/issue-creator/SKILL.md
@@ -148,6 +148,7 @@ Check these files relative to the skill's directory (the dirname of this SKILL.m
 - `references/docs/platform-github.md` — GitHub platform driver reference
 - `references/docs/shared-agent-conventions.md` — shared subagent conventions
 - `references/docs/agent-model-effort.md` — per-agent model and reasoning-effort mapping
+- `references/docs/terminal-style.md` — terminal output style contract (symbols, output structure, table/error formats)
 
 ---
 
@@ -346,7 +347,7 @@ All tracker access follows the GitHub driver — `--json` with explicit field se
 
 ## Output Conventions
 
-Terminal output follows the DESIGN.md contract — symbols `● ✓ ✗ ◆ ⚡ ⚠ ○`, two-space indent, `┄` separators, URLs on their own line, ≤80 chars, one blank line between sections, static sequential output (no animation); issue-creator additionally uses `+` (added field) and `=` (preserved field). Errors use the rich format from `references/error-messages.md`: `✗ what failed`, then `To fix:  <command>`, then a docs link when applicable.
+Terminal output follows the `references/docs/terminal-style.md` contract — symbols `● ✓ ✗ ◆ ⚡ ⚠ ○`, two-space indent, `┄` separators, URLs on their own line, ≤80 chars, one blank line between sections, static sequential output (no animation); issue-creator additionally uses `+` (added field) and `=` (preserved field). Errors use the rich format from `references/error-messages.md`: `✗ what failed`, then `To fix:  <command>`, then a docs link when applicable.
 
 ## GitHub Projects Sync
 

--- a/skills/issue-creator/references/docs/github-projects-sync.md
+++ b/skills/issue-creator/references/docs/github-projects-sync.md
@@ -260,7 +260,7 @@ No status changes. Triage is read-only with respect to the project board. Future
 
 ## Terminal Output
 
-Follow DESIGN.md conventions for all sync output:
+Follow `references/docs/terminal-style.md` conventions for all sync output:
 
 - `●` when sync is in progress
 - `✓` on success

--- a/skills/issue-creator/references/docs/terminal-style.md
+++ b/skills/issue-creator/references/docs/terminal-style.md
@@ -1,0 +1,155 @@
+<!-- Generated from /docs/terminal-style.md. Do not edit. Edit source and run ./scripts/build.sh. -->
+# Terminal Output Style Contract
+
+The canonical terminal-output contract that gitissue skills consume at runtime:
+the symbol vocabulary, output structure, progress patterns, table and error
+formats, and the behavioral rules for confirmations, confidence, first-run, and
+empty states. This is the single source of truth for skill output.
+
+`DESIGN.md` (repo root) is the human-facing style guide — it adds the color
+palette and per-command output mockups on top of this contract. When the two
+overlap, this document is authoritative for what skills emit.
+
+## Principles
+
+1. **Show, don't dump.** Structured output > raw text. Tables > JSON. Sections > walls of text.
+2. **Transparency builds trust.** Show confidence scores, step progress, and what's happening at each phase. No black boxes.
+3. **Errors are help.** When something fails, show what went wrong + how to fix + where to learn more.
+4. **Warmth in empty states.** "No items found" is not a design. Every empty state has context and a next action.
+5. **Distinctive, not decorative.** Step counters, confidence markers, and semantic symbols give gitissue its own feel — not generic AI slop.
+
+## Symbol Vocabulary
+
+| Symbol | Meaning | Color | Example |
+|--------|---------|-------|---------|
+| `●` | In progress | — | `● Scanning codebase...` |
+| `✓` | Success / complete | Green | `✓ Created issue #42` |
+| `✗` | Failure / error | Red | `✗ Not authenticated` |
+| `◆` | Section header | Bold | `◆ Issue Preview` |
+| `⚡` | Action / recommendation | — | `⚡ Parallelizable: #12 + #8` |
+| `⚠` | Warning | Yellow | `⚠ Stale: 1 issue (>14d)` |
+| `○` | Info / neutral | — | `○ First run — using defaults` |
+| `⟶` | Next action / leads to | — | `⟶ Spawning resolver subagent...` |
+| `+` | Added field | — | `+ Files: auth.py (high)` |
+| `=` | Preserved field | — | `= Original: preserved` |
+
+All symbols carry meaning without color. Never rely on color alone.
+
+`⟶` marks the transition to the next autonomous action in a loop (auto-pilot):
+what the orchestrator is about to do — spawn a subagent, start immediately,
+merge a partial PR. It reads as "leads to".
+
+## Output Structure
+
+Every command follows this hierarchy:
+
+```
+  ● Progress (what's happening now)
+
+  ◆ Section Header
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+    Content (indented 2 spaces)
+    More content
+
+  ✓ Result (what happened)
+    https://url (always on its own line)
+```
+
+Rules:
+- One blank line between sections
+- Two-space indent for content under headers
+- No trailing blank lines
+- URLs always on their own line, in cyan
+- Section separators: `┄` (light dash, not heavy box)
+
+## Progress Patterns
+
+**Multi-step pipeline** (issue-resolver):
+```
+  [0/5] Preflight    ✓ issue #42 open, not yet resolved
+  [1/5] Research     ✓ read 5 files, complexity: medium
+  [2/5] Plan         ● selecting approach...
+```
+
+**Single operation** (issue-creator):
+```
+  ● Scanning codebase...
+```
+
+## Table Format
+
+```
+  #  │ Issue              │ Pri │ Blocks │ Status
+  ───┼────────────────────┼─────┼────────┼───────────
+  1  │ #12 Fix auth       │ P1  │ #15    │ ready
+  2  │ #8  Add pagination │ P2  │ —      │ ready
+```
+
+- Box-drawing characters: `│ ─ ┼`
+- Right-align numbers, left-align text
+- Max width: 80 characters (truncate with `...` if needed)
+- Use `—` for empty cells (not blank)
+
+## Error Format
+
+Errors are the moment users need the most help.
+
+```
+  ✗ Short error description
+
+    To fix:  <actionable command>
+    Docs:    <url to relevant documentation>
+```
+
+Always include: what went wrong, how to fix it, where to learn more.
+
+## Confirmation Prompts
+
+```
+  Apply normalization? [Y/n]
+```
+
+Default option in uppercase. Alternatives in lowercase.
+
+## Confidence Markers
+
+Unique to gitissue. Show honesty about what's inferred:
+
+```
+  + Files:    auth.py (high), config.py (medium)
+  + Criteria: 3 acceptance criteria (medium)
+```
+
+Levels: `high` (direct match), `medium` (keyword inference), `low` (best guess, marked `(needs review)` in the issue).
+
+## First-Run Experience
+
+When no `.gitissue.yml` exists:
+
+```
+  ○ First run — using default config. Run /init-gitissue to customize.
+```
+
+One line, then proceed normally. Non-intrusive.
+
+## Empty States
+
+Every empty state has warmth and a next action:
+
+| Scenario | Output |
+|----------|--------|
+| No files identified | `⚠ Could not identify affected files. Issue created with manual-review flag. Tip: mention specific filenames for better results.` |
+| No open issues (triage) | `○ No open issues found. Nothing to triage! Create issues with /issue-creator to get started.` |
+| Already normalized | `✓ Issue #42 is already normalized (v1, 2026-03-15). No changes needed.` |
+| Issue not found | `✗ Issue #42 not found\n\n  To fix: gh issue list\n  Check: is this the right repository?` |
+
+## GitHub Markdown Rendering
+
+Normalized issues must render cleanly in GitHub's web UI:
+
+- Use standard markdown (no HTML except the invisible marker)
+- Section headers: `## Type`, `## Description`, `## Acceptance Criteria`
+- Code blocks for file paths and technical details
+- Normalization marker: `<!-- gitissue:normalized v1 -->` (invisible in rendered view)
+- Reporter's original text: in a `> Reporter Context` blockquote
+- Confidence markers in parentheses: `(high confidence)`, `(needs review)`

--- a/skills/issue-creator/references/modes.md
+++ b/skills/issue-creator/references/modes.md
@@ -217,7 +217,7 @@ Display all extracted items in a table for review before creating anything:
   3  │ improvement │ Refactor auth middleware             │ L
 ```
 
-Use DESIGN.md table format: box-drawing characters `│ ─ ┼`, right-align numbers, left-align text, max 80 chars wide (truncate titles with `...`).
+Use `references/docs/terminal-style.md` table format: box-drawing characters `│ ─ ┼`, right-align numbers, left-align text, max 80 chars wide (truncate titles with `...`).
 
 ### Step 3 — Duplicate Check
 

--- a/skills/issue-pr-review/references/docs/github-projects-sync.md
+++ b/skills/issue-pr-review/references/docs/github-projects-sync.md
@@ -260,7 +260,7 @@ No status changes. Triage is read-only with respect to the project board. Future
 
 ## Terminal Output
 
-Follow DESIGN.md conventions for all sync output:
+Follow `references/docs/terminal-style.md` conventions for all sync output:
 
 - `●` when sync is in progress
 - `✓` on success

--- a/skills/issue-resolver/references/docs/github-projects-sync.md
+++ b/skills/issue-resolver/references/docs/github-projects-sync.md
@@ -260,7 +260,7 @@ No status changes. Triage is read-only with respect to the project board. Future
 
 ## Terminal Output
 
-Follow DESIGN.md conventions for all sync output:
+Follow `references/docs/terminal-style.md` conventions for all sync output:
 
 - `●` when sync is in progress
 - `✓` on success

--- a/skills/issue-triage/SKILL.md
+++ b/skills/issue-triage/SKILL.md
@@ -54,7 +54,7 @@ Read and parse the JSON file. If the JSON is malformed or unparseable, output th
 
 ### 3. Render the cached report
 
-Compute report age from the `updated` timestamp relative to now. Render the triage table to terminal using the same DESIGN.md format as Step 8, with a cache header:
+Compute report age from the `updated` timestamp relative to now. Render the triage table to terminal using the same `references/docs/terminal-style.md` format as Step 8, with a cache header:
 
 ```
 ◆ Issue Triage (cached)
@@ -272,6 +272,7 @@ Check these files relative to the skill's directory (the dirname of this SKILL.m
 - `references/docs/platform-github.md` — GitHub platform driver reference
 - `references/docs/shared-agent-conventions.md` — shared subagent conventions
 - `references/docs/agent-model-effort.md` — per-agent model and reasoning-effort mapping
+- `references/docs/terminal-style.md` — terminal output style contract (symbols, output structure, table/error formats)
 
 ---
 
@@ -435,7 +436,7 @@ All tracker access follows the GitHub driver — `--json` with explicit field se
 
 ## Output Conventions
 
-Terminal output follows the DESIGN.md contract — symbols `● ✓ ✗ ◆ ⚡ ⚠ ○`, two-space indent, `┄` separators, URLs on their own line, ≤80 chars, one blank line between sections, static sequential output (no animation), plus `│ ─ ┼` tables (right-align numbers, `—` for empty cells). Errors use the rich format from `references/error-messages.md`: `✗ what failed`, then `To fix:  <command>`, then a docs link when applicable. The complete catalog in `references/error-messages.md` covers authentication failures, CLI not found, no remote, no issues, too many issues, circular dependencies, and API rate limits.
+Terminal output follows the `references/docs/terminal-style.md` contract — symbols `● ✓ ✗ ◆ ⚡ ⚠ ○`, two-space indent, `┄` separators, URLs on their own line, ≤80 chars, one blank line between sections, static sequential output (no animation), plus `│ ─ ┼` tables (right-align numbers, `—` for empty cells). Errors use the rich format from `references/error-messages.md`: `✗ what failed`, then `To fix:  <command>`, then a docs link when applicable. The complete catalog in `references/error-messages.md` covers authentication failures, CLI not found, no remote, no issues, too many issues, circular dependencies, and API rate limits.
 
 ## GitHub Projects Sync
 
@@ -477,5 +478,5 @@ An update (`/issue-triage update`) runs Steps 1–9 and overwrites the cache, en
 
 - **`references/error-messages.md`** — Complete error catalog with triggers and exact output
 - **`references/docs/github-projects-sync.md`** — Shared GitHub Projects status sync reference
-- **`DESIGN.md`** — Terminal output style guide (repo root)
+- **`references/docs/terminal-style.md`** — Terminal output style contract (bundled at build time; the repo-root `DESIGN.md` is the human-facing companion and is not bundled)
 - **`references/docs/config-schema.md`** — Full configuration schema

--- a/skills/issue-triage/references/docs/github-projects-sync.md
+++ b/skills/issue-triage/references/docs/github-projects-sync.md
@@ -260,7 +260,7 @@ No status changes. Triage is read-only with respect to the project board. Future
 
 ## Terminal Output
 
-Follow DESIGN.md conventions for all sync output:
+Follow `references/docs/terminal-style.md` conventions for all sync output:
 
 - `●` when sync is in progress
 - `✓` on success

--- a/skills/issue-triage/references/docs/terminal-style.md
+++ b/skills/issue-triage/references/docs/terminal-style.md
@@ -1,0 +1,155 @@
+<!-- Generated from /docs/terminal-style.md. Do not edit. Edit source and run ./scripts/build.sh. -->
+# Terminal Output Style Contract
+
+The canonical terminal-output contract that gitissue skills consume at runtime:
+the symbol vocabulary, output structure, progress patterns, table and error
+formats, and the behavioral rules for confirmations, confidence, first-run, and
+empty states. This is the single source of truth for skill output.
+
+`DESIGN.md` (repo root) is the human-facing style guide — it adds the color
+palette and per-command output mockups on top of this contract. When the two
+overlap, this document is authoritative for what skills emit.
+
+## Principles
+
+1. **Show, don't dump.** Structured output > raw text. Tables > JSON. Sections > walls of text.
+2. **Transparency builds trust.** Show confidence scores, step progress, and what's happening at each phase. No black boxes.
+3. **Errors are help.** When something fails, show what went wrong + how to fix + where to learn more.
+4. **Warmth in empty states.** "No items found" is not a design. Every empty state has context and a next action.
+5. **Distinctive, not decorative.** Step counters, confidence markers, and semantic symbols give gitissue its own feel — not generic AI slop.
+
+## Symbol Vocabulary
+
+| Symbol | Meaning | Color | Example |
+|--------|---------|-------|---------|
+| `●` | In progress | — | `● Scanning codebase...` |
+| `✓` | Success / complete | Green | `✓ Created issue #42` |
+| `✗` | Failure / error | Red | `✗ Not authenticated` |
+| `◆` | Section header | Bold | `◆ Issue Preview` |
+| `⚡` | Action / recommendation | — | `⚡ Parallelizable: #12 + #8` |
+| `⚠` | Warning | Yellow | `⚠ Stale: 1 issue (>14d)` |
+| `○` | Info / neutral | — | `○ First run — using defaults` |
+| `⟶` | Next action / leads to | — | `⟶ Spawning resolver subagent...` |
+| `+` | Added field | — | `+ Files: auth.py (high)` |
+| `=` | Preserved field | — | `= Original: preserved` |
+
+All symbols carry meaning without color. Never rely on color alone.
+
+`⟶` marks the transition to the next autonomous action in a loop (auto-pilot):
+what the orchestrator is about to do — spawn a subagent, start immediately,
+merge a partial PR. It reads as "leads to".
+
+## Output Structure
+
+Every command follows this hierarchy:
+
+```
+  ● Progress (what's happening now)
+
+  ◆ Section Header
+  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+    Content (indented 2 spaces)
+    More content
+
+  ✓ Result (what happened)
+    https://url (always on its own line)
+```
+
+Rules:
+- One blank line between sections
+- Two-space indent for content under headers
+- No trailing blank lines
+- URLs always on their own line, in cyan
+- Section separators: `┄` (light dash, not heavy box)
+
+## Progress Patterns
+
+**Multi-step pipeline** (issue-resolver):
+```
+  [0/5] Preflight    ✓ issue #42 open, not yet resolved
+  [1/5] Research     ✓ read 5 files, complexity: medium
+  [2/5] Plan         ● selecting approach...
+```
+
+**Single operation** (issue-creator):
+```
+  ● Scanning codebase...
+```
+
+## Table Format
+
+```
+  #  │ Issue              │ Pri │ Blocks │ Status
+  ───┼────────────────────┼─────┼────────┼───────────
+  1  │ #12 Fix auth       │ P1  │ #15    │ ready
+  2  │ #8  Add pagination │ P2  │ —      │ ready
+```
+
+- Box-drawing characters: `│ ─ ┼`
+- Right-align numbers, left-align text
+- Max width: 80 characters (truncate with `...` if needed)
+- Use `—` for empty cells (not blank)
+
+## Error Format
+
+Errors are the moment users need the most help.
+
+```
+  ✗ Short error description
+
+    To fix:  <actionable command>
+    Docs:    <url to relevant documentation>
+```
+
+Always include: what went wrong, how to fix it, where to learn more.
+
+## Confirmation Prompts
+
+```
+  Apply normalization? [Y/n]
+```
+
+Default option in uppercase. Alternatives in lowercase.
+
+## Confidence Markers
+
+Unique to gitissue. Show honesty about what's inferred:
+
+```
+  + Files:    auth.py (high), config.py (medium)
+  + Criteria: 3 acceptance criteria (medium)
+```
+
+Levels: `high` (direct match), `medium` (keyword inference), `low` (best guess, marked `(needs review)` in the issue).
+
+## First-Run Experience
+
+When no `.gitissue.yml` exists:
+
+```
+  ○ First run — using default config. Run /init-gitissue to customize.
+```
+
+One line, then proceed normally. Non-intrusive.
+
+## Empty States
+
+Every empty state has warmth and a next action:
+
+| Scenario | Output |
+|----------|--------|
+| No files identified | `⚠ Could not identify affected files. Issue created with manual-review flag. Tip: mention specific filenames for better results.` |
+| No open issues (triage) | `○ No open issues found. Nothing to triage! Create issues with /issue-creator to get started.` |
+| Already normalized | `✓ Issue #42 is already normalized (v1, 2026-03-15). No changes needed.` |
+| Issue not found | `✗ Issue #42 not found\n\n  To fix: gh issue list\n  Check: is this the right repository?` |
+
+## GitHub Markdown Rendering
+
+Normalized issues must render cleanly in GitHub's web UI:
+
+- Use standard markdown (no HTML except the invisible marker)
+- Section headers: `## Type`, `## Description`, `## Acceptance Criteria`
+- Code blocks for file paths and technical details
+- Normalization marker: `<!-- gitissue:normalized v1 -->` (invisible in rendered view)
+- Reporter's original text: in a `> Reporter Context` blockquote
+- Confidence markers in parentheses: `(high confidence)`, `(needs review)`

--- a/skills/issue-triage/references/output-and-persist.md
+++ b/skills/issue-triage/references/output-and-persist.md
@@ -5,7 +5,7 @@ Full Step 8 rendering spec and Step 9 JSON schema. SKILL.md shows a summary; rea
 ## Step 8 — Output
 
 
-Display the full triage results following DESIGN.md conventions.
+Display the full triage results following `references/docs/terminal-style.md` conventions.
 
 ### Triage Table
 
@@ -20,7 +20,7 @@ Display the full triage results following DESIGN.md conventions.
   4  │ #3  Old UI bug     │ P3  │ —      │ stale (28d)
 ```
 
-Table rules (per DESIGN.md):
+Table rules (per `references/docs/terminal-style.md`):
 - Box-drawing characters: `│ ─ ┼`
 - Right-align numbers, left-align text
 - Max width: 80 characters (truncate issue titles with `...` if needed)

--- a/src/skills/auto-pilot/SKILL.source.md
+++ b/src/skills/auto-pilot/SKILL.source.md
@@ -113,6 +113,7 @@ Check these files relative to the skill's directory (the dirname of this SKILL.m
 - `references/docs/platform-github.md` — GitHub platform driver reference
 - `references/docs/shared-agent-conventions.md` — shared subagent conventions
 - `references/docs/agent-model-effort.md` — per-agent model and reasoning-effort mapping
+- `references/docs/terminal-style.md` — terminal output style contract (symbols, output structure, table/error formats)
 
 If the working tree is dirty, auto-stash before starting; if not on the default
 branch, auto-switch and rebase on a clean tree. Both procedures (the stash-first
@@ -318,7 +319,7 @@ All tracker access follows the GitHub driver — `--json` with explicit field se
 
 ## Output Conventions
 
-Terminal output follows the DESIGN.md contract — symbols `● ✓ ✗ ◆ ⚡ ⚠ ○`, two-space indent, `┄` separators, URLs on their own line, ≤80 chars, one blank line between sections, static sequential output (no animation), plus auto-pilot's `[Iteration {i}/{max}]` loop counter and the resolver's inherited `[N/5]` step counter. Errors use the rich format from `references/error-messages.md`: `✗ what failed`, then `To fix:  <command>`, then a docs link when applicable.
+Terminal output follows the `docs/terminal-style.md` contract — symbols `● ✓ ✗ ◆ ⚡ ⚠ ○`, two-space indent, `┄` separators, URLs on their own line, ≤80 chars, one blank line between sections, static sequential output (no animation), plus auto-pilot's `[Iteration {i}/{max}]` loop counter and the resolver's inherited `[N/5]` step counter. Errors use the rich format from `references/error-messages.md`: `✗ what failed`, then `To fix:  <command>`, then a docs link when applicable.
 
 ## Prompt Injection Boundary
 
@@ -353,4 +354,4 @@ On final stop, the **Final Summary** table (above) lists each iteration's issue,
 - **`references/subagent-prompts.md`** — resolver, reviewer, analyzer, and batch-resolver prompts (read once at skill start)
 - **`references/error-messages.md`** — full error catalog with triggers and exact output
 - **`docs/naming-conventions.md`** — branch, commit, PR, and issue naming
-- **`DESIGN.md`** (repo root) — terminal output style guide; **`docs/config-schema.md`** — full configuration schema
+- **`docs/terminal-style.md`** — terminal output style contract (bundled at build time; the repo-root `DESIGN.md` is the human-facing companion and is not bundled); **`docs/config-schema.md`** — full configuration schema

--- a/src/skills/init-gitissue/SKILL.source.md
+++ b/src/skills/init-gitissue/SKILL.source.md
@@ -65,6 +65,7 @@ Check these files relative to the skill's directory (the dirname of this SKILL.m
 - `references/docs/idd-methodology.md` — IDD methodology reference
 - `references/docs/github-projects-sync.md` — GitHub Projects status sync reference
 - `references/docs/platform-github.md` — GitHub platform driver reference
+- `references/docs/terminal-style.md` — terminal output style contract (symbols, output structure, table/error formats)
 
 ## Configuration Check
 
@@ -352,7 +353,7 @@ Full example outputs for three scenarios (TypeScript + Next.js project, minimal 
 
 ## Output Conventions
 
-Terminal output follows the DESIGN.md contract — symbols `● ✓ ✗ ◆ ⚡ ⚠ ○`, two-space indent, `┄` separators, URLs on their own line, ≤80 chars, one blank line between sections, static sequential output (no animation). Errors use the rich format from `references/error-messages.md`: `✗ what failed`, then `To fix:  <command>`, then a docs link when applicable.
+Terminal output follows the `docs/terminal-style.md` contract — symbols `● ✓ ✗ ◆ ⚡ ⚠ ○`, two-space indent, `┄` separators, URLs on their own line, ≤80 chars, one blank line between sections, static sequential output (no animation). Errors use the rich format from `references/error-messages.md`: `✗ what failed`, then `To fix:  <command>`, then a docs link when applicable.
 
 ## Expected Output
 
@@ -388,4 +389,4 @@ After a successful run, the repo root contains a `.gitissue.yml` file and the te
 - **`references/error-messages.md`** — Complete error catalog with triggers and exact output
 - **`docs/naming-conventions.md`** — Branch, commit, PR, and issue naming conventions (referenced by generated config)
 - **`docs/config-schema.md`** — Full configuration schema that this skill generates
-- **`DESIGN.md`** — Terminal output style guide (repo root)
+- **`docs/terminal-style.md`** — Terminal output style contract (bundled at build time; the repo-root `DESIGN.md` is the human-facing companion and is not bundled)

--- a/src/skills/issue-analysis/SKILL.source.md
+++ b/src/skills/issue-analysis/SKILL.source.md
@@ -40,7 +40,7 @@ When invoked as `/issue-analysis <N> view`, skip the entire analysis pipeline (S
      Check:   was the file edited manually?
    ```
 5. Compute report age from the `timestamp` field relative to now
-6. Render the full analysis report to terminal using the same DESIGN.md format as Step 6, with a cache header:
+6. Render the full analysis report to terminal using the same `docs/terminal-style.md` format as Step 6, with a cache header:
 
 ```
 ◆ Issue Analysis (cached)
@@ -187,6 +187,7 @@ Check these files relative to the skill's directory (the dirname of this SKILL.m
 - `references/docs/platform-github.md` — GitHub platform driver reference
 - `references/docs/shared-agent-conventions.md` — shared subagent conventions
 - `references/docs/agent-model-effort.md` — per-agent model and reasoning-effort mapping
+- `references/docs/terminal-style.md` — terminal output style contract (symbols, output structure, table/error formats)
 
 The steps below include both the subagent delegation path and the inline fallback.
 
@@ -269,7 +270,7 @@ Quick summary:
 ---
 ## Step 8-9 — Output & Persist
 
-Step 8 renders the analysis as a structured terminal report following DESIGN.md conventions; Step 9 persists the same data to `.gitissue/analysis-<N>.json`. Full rendering spec (section layout, color codes, truncation rules) and JSON schema live in `references/output-and-persist.md` — read that file when implementing or debugging either step.
+Step 8 renders the analysis as a structured terminal report following `docs/terminal-style.md` conventions; Step 9 persists the same data to `.gitissue/analysis-<N>.json`. Full rendering spec (section layout, color codes, truncation rules) and JSON schema live in `references/output-and-persist.md` — read that file when implementing or debugging either step.
 
 Summary:
 - Terminal report has 8 sections: header, classification, root cause, affected files, options, complexity, risk, recommendation.
@@ -408,12 +409,12 @@ All tracker access follows the GitHub driver — `--json` with explicit field se
 
 ## Output Conventions
 
-Terminal output follows the DESIGN.md contract — symbols `● ✓ ✗ ◆ ⚡ ⚠ ○`, two-space indent, `┄` separators, URLs on their own line, ≤80 chars, one blank line between sections, static sequential output (no animation), plus a `[N/8]` pipeline step counter and `│ ─ ┼` tables (right-align numbers, `—` for empty cells). Errors use the rich format from `references/error-messages.md`: `✗ what failed`, then `To fix:  <command>`, then a docs link when applicable.
+Terminal output follows the `docs/terminal-style.md` contract — symbols `● ✓ ✗ ◆ ⚡ ⚠ ○`, two-space indent, `┄` separators, URLs on their own line, ≤80 chars, one blank line between sections, static sequential output (no animation), plus a `[N/8]` pipeline step counter and `│ ─ ┼` tables (right-align numbers, `—` for empty cells). Errors use the rich format from `references/error-messages.md`: `✗ what failed`, then `To fix:  <command>`, then a docs link when applicable.
 
 ## Additional Resources
 
 - **`shared/agents/codebase-researcher.md`** — Codebase Researcher subagent prompt (Steps 2-5 delegation)
 - **`shared/agents/synthesizer.md`** — Synthesizer subagent prompt (Steps 6-7 delegation)
 - **`references/error-messages.md`** — Complete error catalog with triggers and exact output
-- **`DESIGN.md`** — Terminal output style guide (repo root)
+- **`docs/terminal-style.md`** — Terminal output style contract (bundled at build time; the repo-root `DESIGN.md` is the human-facing companion and is not bundled)
 - **`docs/config-schema.md`** — Full configuration schema

--- a/src/skills/issue-analysis/references/output-and-persist.md
+++ b/src/skills/issue-analysis/references/output-and-persist.md
@@ -5,7 +5,7 @@ Full Step 8 terminal rendering spec and Step 9 JSON persistence schema. SKILL.md
 ## Step 8 — Output (Terminal Report)
 
 
-Display the full analysis following DESIGN.md conventions.
+Display the full analysis following `docs/terminal-style.md` conventions.
 
 ### Issue header
 
@@ -60,7 +60,7 @@ Omit categories that have no entries.
     tests/test_auth.py           │ high      │ existing tests
 ```
 
-Table rules (per DESIGN.md): box-drawing characters `│ ─ ┼`, max 80 chars wide, truncate paths with `...` if needed.
+Table rules (per `docs/terminal-style.md`): box-drawing characters `│ ─ ┼`, max 80 chars wide, truncate paths with `...` if needed.
 
 ### Git history
 

--- a/src/skills/issue-creator/SKILL.source.md
+++ b/src/skills/issue-creator/SKILL.source.md
@@ -148,6 +148,7 @@ Check these files relative to the skill's directory (the dirname of this SKILL.m
 - `references/docs/platform-github.md` — GitHub platform driver reference
 - `references/docs/shared-agent-conventions.md` — shared subagent conventions
 - `references/docs/agent-model-effort.md` — per-agent model and reasoning-effort mapping
+- `references/docs/terminal-style.md` — terminal output style contract (symbols, output structure, table/error formats)
 
 ---
 
@@ -346,7 +347,7 @@ All tracker access follows the GitHub driver — `--json` with explicit field se
 
 ## Output Conventions
 
-Terminal output follows the DESIGN.md contract — symbols `● ✓ ✗ ◆ ⚡ ⚠ ○`, two-space indent, `┄` separators, URLs on their own line, ≤80 chars, one blank line between sections, static sequential output (no animation); issue-creator additionally uses `+` (added field) and `=` (preserved field). Errors use the rich format from `references/error-messages.md`: `✗ what failed`, then `To fix:  <command>`, then a docs link when applicable.
+Terminal output follows the `docs/terminal-style.md` contract — symbols `● ✓ ✗ ◆ ⚡ ⚠ ○`, two-space indent, `┄` separators, URLs on their own line, ≤80 chars, one blank line between sections, static sequential output (no animation); issue-creator additionally uses `+` (added field) and `=` (preserved field). Errors use the rich format from `references/error-messages.md`: `✗ what failed`, then `To fix:  <command>`, then a docs link when applicable.
 
 ## GitHub Projects Sync
 

--- a/src/skills/issue-creator/references/modes.md
+++ b/src/skills/issue-creator/references/modes.md
@@ -217,7 +217,7 @@ Display all extracted items in a table for review before creating anything:
   3  │ improvement │ Refactor auth middleware             │ L
 ```
 
-Use DESIGN.md table format: box-drawing characters `│ ─ ┼`, right-align numbers, left-align text, max 80 chars wide (truncate titles with `...`).
+Use `docs/terminal-style.md` table format: box-drawing characters `│ ─ ┼`, right-align numbers, left-align text, max 80 chars wide (truncate titles with `...`).
 
 ### Step 3 — Duplicate Check
 

--- a/src/skills/issue-triage/SKILL.source.md
+++ b/src/skills/issue-triage/SKILL.source.md
@@ -54,7 +54,7 @@ Read and parse the JSON file. If the JSON is malformed or unparseable, output th
 
 ### 3. Render the cached report
 
-Compute report age from the `updated` timestamp relative to now. Render the triage table to terminal using the same DESIGN.md format as Step 8, with a cache header:
+Compute report age from the `updated` timestamp relative to now. Render the triage table to terminal using the same `docs/terminal-style.md` format as Step 8, with a cache header:
 
 ```
 ◆ Issue Triage (cached)
@@ -272,6 +272,7 @@ Check these files relative to the skill's directory (the dirname of this SKILL.m
 - `references/docs/platform-github.md` — GitHub platform driver reference
 - `references/docs/shared-agent-conventions.md` — shared subagent conventions
 - `references/docs/agent-model-effort.md` — per-agent model and reasoning-effort mapping
+- `references/docs/terminal-style.md` — terminal output style contract (symbols, output structure, table/error formats)
 
 ---
 
@@ -435,7 +436,7 @@ All tracker access follows the GitHub driver — `--json` with explicit field se
 
 ## Output Conventions
 
-Terminal output follows the DESIGN.md contract — symbols `● ✓ ✗ ◆ ⚡ ⚠ ○`, two-space indent, `┄` separators, URLs on their own line, ≤80 chars, one blank line between sections, static sequential output (no animation), plus `│ ─ ┼` tables (right-align numbers, `—` for empty cells). Errors use the rich format from `references/error-messages.md`: `✗ what failed`, then `To fix:  <command>`, then a docs link when applicable. The complete catalog in `references/error-messages.md` covers authentication failures, CLI not found, no remote, no issues, too many issues, circular dependencies, and API rate limits.
+Terminal output follows the `docs/terminal-style.md` contract — symbols `● ✓ ✗ ◆ ⚡ ⚠ ○`, two-space indent, `┄` separators, URLs on their own line, ≤80 chars, one blank line between sections, static sequential output (no animation), plus `│ ─ ┼` tables (right-align numbers, `—` for empty cells). Errors use the rich format from `references/error-messages.md`: `✗ what failed`, then `To fix:  <command>`, then a docs link when applicable. The complete catalog in `references/error-messages.md` covers authentication failures, CLI not found, no remote, no issues, too many issues, circular dependencies, and API rate limits.
 
 ## GitHub Projects Sync
 
@@ -477,5 +478,5 @@ An update (`/issue-triage update`) runs Steps 1–9 and overwrites the cache, en
 
 - **`references/error-messages.md`** — Complete error catalog with triggers and exact output
 - **`docs/github-projects-sync.md`** — Shared GitHub Projects status sync reference
-- **`DESIGN.md`** — Terminal output style guide (repo root)
+- **`docs/terminal-style.md`** — Terminal output style contract (bundled at build time; the repo-root `DESIGN.md` is the human-facing companion and is not bundled)
 - **`docs/config-schema.md`** — Full configuration schema

--- a/src/skills/issue-triage/references/output-and-persist.md
+++ b/src/skills/issue-triage/references/output-and-persist.md
@@ -5,7 +5,7 @@ Full Step 8 rendering spec and Step 9 JSON schema. SKILL.md shows a summary; rea
 ## Step 8 — Output
 
 
-Display the full triage results following DESIGN.md conventions.
+Display the full triage results following `docs/terminal-style.md` conventions.
 
 ### Triage Table
 
@@ -20,7 +20,7 @@ Display the full triage results following DESIGN.md conventions.
   4  │ #3  Old UI bug     │ P3  │ —      │ stale (28d)
 ```
 
-Table rules (per DESIGN.md):
+Table rules (per `docs/terminal-style.md`):
 - Box-drawing characters: `│ ─ ┼`
 - Right-align numbers, left-align text
 - Max width: 80 characters (truncate issue titles with `...` if needed)


### PR DESCRIPTION
Closes #232

## Problem
Follow-up to #196. #196 repointed the dangling `DESIGN.md` references to the bundled `docs/terminal-style.md` only in issue-resolver and issue-pr-review (its named scope). The **five** other public skills still pointed at the repo-root `DESIGN.md`, which `build.py` never bundles (its regex matches only `docs/<name>.md` tokens), so those references dangled in the installed copies:
- auto-pilot, init-gitissue, issue-triage, issue-analysis — Additional-Resources pointers + inline output-contract prose
- **issue-creator** — inline prose only (`SKILL.source.md`, `references/modes.md`); surfaced during this change because the shared-doc edit below forced terminal-style.md into its bundle. Repointed here so no public skill is left half-done.

## Change
- Repoint every `DESIGN.md` reference in those five skills at `docs/terminal-style.md` (the bundled runtime doc created in #196). Each repointed pointer notes the repo-root `DESIGN.md` is the human-facing companion and is not bundled.
- Repoint the shared `docs/github-projects-sync.md` "Follow DESIGN.md conventions" line. Via the build's transitive closure this now bundles `terminal-style.md` into **all seven** public skills.
- Add `references/docs/terminal-style.md` to every skill's bundled-dependency precheck list so the #195 drift guard stays green.

## No regression to already-merged work
- **#195 drift guard**: `./scripts/build.sh` exits 0 — all seven precheck lists now name terminal-style.md, matching the bundled set.
- **#193 registry**: unchanged. terminal-style.md was already the 10th runtime doc in CLAUDE.md's "all 10 bundled" line; widening its bundling to more skills does not change the distinct-doc count.

## Verification
- `./scripts/build.sh` exit 0; `git diff --exit-code -- skills/` clean; all 7 public skills flatten with terminal-style.md bundled.
- Grep of the built SKILL.md + bundled refs: the only surviving `DESIGN.md` mentions are the intentional "human-facing companion, not bundled" prose — no "open this doc" dangling pointer remains.
- Tests pass: idd-lint (27), build-script (19), flattened-self-contained (7), dependency-closure (27), flattened-coexistence (5), build-determinism (byte-identical), autopilot-portability (11), idd-doctor, and the #200 suites test-issue-triage / test-issue-analysis / test-issue-creator-modes.

Follow-up to #196. Part of #182.