### PR TITLE
feat(resolver): adapt resolver and PR-review effort to task complexity (#240)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- gitissue:normalized v1 -->
 
+## [Unreleased]
+
+### Features
+- **resolver, review:** adapt effort to task complexity (#240) — `/issue-resolver` picks a pipeline **profile** (`light`/`full`) from the issue's pre-work `Effort` band before any subagent spawn, so trivial issues (XS/S) take a fast path (lighter Research, skipped 3-option Plan, skipped propose-skills, QA capped at 1 cycle) while complex or ambiguous work keeps the full pipeline; `/issue-pr-review` scales review depth from a diff-size/labels/linked-issue signal (fuller-of-disagreeing). The Decision Record + Acceptance Criteria table always emit, and the AC + traceability hard-blocks always run at full strength. The chosen profile is surfaced on the tracker line and in the `runs.jsonl` `profile` field. Opt out with `resolve.adaptive_effort: false` / `review.adaptive_depth: false` (both default `true`). Shared mechanism documented in `docs/agent-model-effort.md` (Complexity → pipeline profile). @luongnv89
+
 ## [v0.18.0] — 2026-07-09
 
 The Fable 5 review release: implement all seven recommendations (R1–R7) of the concept & methodology review — extract the spec, shrink the machinery, prove the methodology without an agent, and measure it.

--- a/docs/agent-model-effort.md
+++ b/docs/agent-model-effort.md
@@ -69,3 +69,97 @@ For each spawned step the orchestrator should:
 
 Selection is bounded by the same cost-awareness as model suggestion: prefer the
 lowest tier that can do the step correctly.
+
+## Complexity → pipeline profile
+
+Model/effort selection above is **advisory** — it tunes *how hard* each agent
+thinks but never changes *which* steps run. The **pipeline profile** is a
+distinct, second mechanism layered on the **same `XS … XL` scale**: it scales
+*how much pipeline runs* — which optional steps fire, how many QA/review cycles
+are allowed — so a trivial one-character edit does not pay the full
+orchestration cost of a multi-subsystem change. Unlike model/effort, the profile
+**does** change control flow (it can collapse a step or cap a loop), so it is a
+**gated** control, not advisory. The two are independent: model/effort sizes the
+agents a step spawns; the profile decides whether the lighter-weight step runs at
+all. They share the scale and nothing else — do **not** invent a second
+classifier for the profile.
+
+### The two profiles
+
+| Profile | Effort band | Intent |
+|---------|-------------|--------|
+| **light** | XS, S | Trivial/small work — collapse optional phases, cap the review-fix loop to one cycle. |
+| **full**  | M, L, XL | Everything today runs unchanged — the current pipeline in full. |
+
+The profile is a **coarse** switch (two states), deliberately not one profile per
+band: the goal is a fast path for the long tail of trivial work, not five
+gradations. Model/effort selection already provides the fine-grained,
+per-agent scaling within either profile.
+
+### Selecting the profile (pre-work signal)
+
+The profile is chosen from a **pre-work** signal — before the first expensive
+subagent spawn — so the saving is real. If the profile were derived from an
+agent's *output* (e.g. the researcher's `complexity`), the dominant cost would
+already be paid before the decision, and the fast path would save almost nothing.
+The pre-work signal is the issue's **`Effort` band** in its `## Metadata` section
+(the `XS … XL` value written by `/issue-creator`, the same scale this whole
+document uses).
+
+Resolve the profile from that band, **erring toward `full` whenever the signal
+is weak**:
+
+| Condition on the pre-work signal | Profile |
+|----------------------------------|---------|
+| `Effort` is `M`, `L`, or `XL` | **full** |
+| `Effort` is `XS` or `S` **and** asserted (not low-confidence) | **light** |
+| `Effort` is `XS`/`S` but marked `(needs review)` / low-confidence | **full** (ambiguous → fuller) |
+| `Effort` is absent / unparseable | **full** (safe default) |
+
+The low-confidence and absent rows are the safety contract: an uncertain estimate
+must never under-serve a task that turns out to be hard. A skill **may** refine
+the profile *upward* once a stronger signal arrives (e.g. the researcher reports
+`high`/`complex` on what the band called `S`) — never downward. Downgrading on a
+mid-pipeline signal would defeat the pre-work guarantee and risk truncating work
+already deep in the full path.
+
+### What each consuming skill does with the profile
+
+This document defines the *scale → profile* mapping and the pre-work-signal rule;
+each skill owns exactly *which* of its steps the `light` profile collapses (its
+pipeline reference spells out the per-step mechanics):
+
+- **`/issue-resolver`** — `light` keeps a **lighter** Research step (the
+  already-resolved safety check still runs), skips the 3-option synthesis in Plan
+  (a direct minimal plan is used), skips the interactive propose-relevant-skills
+  sub-step, and caps QA at **one** cycle. Implement and Deliver are unchanged, and
+  the durable PR artifacts (Decision Record + Acceptance Criteria Verification
+  table) are **always** emitted — the profile never removes durable memory.
+- **`/issue-pr-review`** — has no researcher, so it derives its own pre-work
+  signal (diff size / files-changed / labels / linked-issue `Effort`, taking the
+  **fuller** of any that disagree) and scales review **depth** — the `light`
+  profile caps the review-fix loop to one cycle and skips optional passes, while
+  the acceptance-criteria and traceability hard-blocks still run at full strength.
+
+### Surfacing the profile (transparency)
+
+The chosen profile is **surfaced to the user** wherever the skill already reports
+progress, so the effort decision is transparent and reviewable — never a hidden
+downgrade:
+
+- On the pipeline **tracker line** for the step where it is decided (e.g. the
+  resolver's `[0/5] Preflight` line names `effort: light` or `effort: full`).
+- In the **run log** (`.gitissue/runs.jsonl`) as the optional `profile` field, so
+  `/idd-doctor` and audits can see how often the fast path fired (see
+  `docs/config-schema.md`).
+
+### Opting out
+
+Each consuming skill exposes an explicit off-switch so a maintainer can force the
+full pipeline on every issue regardless of band: `resolve.adaptive_effort`
+(default `true`) for `/issue-resolver` and `review.adaptive_depth` (default
+`true`) for `/issue-pr-review`. When the switch is `false`, the skill behaves
+exactly as it did before this mechanism existed — the profile is pinned to
+`full`. Defaults are **on** so zero-config users get the fast path for trivial
+work automatically; the switch exists for maintainers who prefer uniform
+full-treatment (see `docs/config-schema.md`).

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -83,6 +83,10 @@ resolve:
   # Default: "auto"
   # "auto": proceed immediately after planning
   # "comment-and-wait": show plan and wait for user approval
+  # Note: with resolve.adaptive_effort: true (default), a light-profile (trivial
+  #   XS/S) issue proceeds on a direct minimal plan without the option prompt —
+  #   it produces no 3-option comparison to wait on. Set adaptive_effort: false
+  #   to force the approval wait on every issue regardless of complexity.
   approval_gate: auto
 
   # Branch naming prefix

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -122,6 +122,23 @@ resolve:
   # Maximum: 10
   qa_max_cycles: 5
 
+  # Scale the resolve pipeline to each issue's complexity (adaptive effort).
+  # Type: boolean
+  # Default: true
+  # When true, trivial issues (pre-work Effort band XS/S, asserted) take a
+  # lighter, faster, lower-token path: a lighter Research step (the
+  # already-resolved safety check still runs), the 3-option synthesis in Plan is
+  # skipped for a direct minimal plan, the propose-relevant-skills sub-step is
+  # skipped, and QA is capped at 1 cycle. The Decision Record and Acceptance
+  # Criteria Verification table are always emitted regardless. Complex or
+  # ambiguous issues (M/L/XL, low-confidence, or no band) keep the full pipeline.
+  # When false, every issue gets the full pipeline as before — the profile is
+  # pinned to "full". The chosen profile is surfaced on the [0/5] tracker line
+  # and in the run log's `profile` field. See
+  # https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md
+  # (Complexity → pipeline profile).
+  adaptive_effort: true
+
   # UI/UX review settings (Step 4 — QA)
   # Code-level UI review is auto-detected per issue and always runs when UI
   # work is present; it needs no flag and runs in any environment (including
@@ -144,6 +161,21 @@ review:
   # Minimum: 1
   # Maximum: 10
   max_cycles: 3
+
+  # Scale review depth to each PR's complexity (adaptive depth).
+  # Type: boolean
+  # Default: true
+  # When true, /issue-pr-review derives a pre-work complexity signal from the PR
+  # (diff size, files-changed, labels, and the linked issue's Effort band — the
+  # fuller of any that disagree) and, for a trivial PR, caps the review-fix loop
+  # at 1 cycle and skips optional passes. The acceptance-criteria and
+  # traceability hard-blocks always run at full strength. Complex or ambiguous
+  # PRs keep the full max_cycles depth. When false, every PR gets full review
+  # depth as before — the profile is pinned to "full". The chosen depth is
+  # surfaced on the [1/7] tracker line. See
+  # https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md
+  # (Complexity → pipeline profile).
+  adaptive_depth: true
 
   # Auto-merge PR when clean (overridden to true in --auto mode)
   # Type: boolean
@@ -463,8 +495,10 @@ graph TD
     RS --> R5["pr_auto_link"]
     RS --> R6["max_commits"]
     RS --> R7["qa_max_cycles"]
+    RS --> R8["adaptive_effort"]
 
     RV --> RV1["max_cycles"]
+    RV --> RV14["adaptive_depth"]
     RV --> RV2["auto_merge"]
     RV --> RV3["confidence_threshold"]
     RV --> RV4["run_tests"]
@@ -539,6 +573,7 @@ Each line carries at minimum a **timestamp, issue number, mode, outcome**, and t
 | `outcome` | string | yes | Terminal outcome. Resolver: `success`, `already_resolved`, `failed`. Auto-pilot: one of its six categorical outcomes (`merged`, `left_open`, `partial_followup`, `blocked_by_dependency`, `failed`, `skipped`). |
 | `pr` | integer or null | yes | PR number when a PR was created, else `null` |
 | `complexity` | string | no | Research complexity on the **3-value** run-log scale (`low` / `medium` / `high`) when known. Collapse the researcher's 5-value estimate before writing: `trivial` or `low` → `low`; `medium` → `medium`; `high` or `complex` → `high`. Never emit `trivial` or `complex` in runs.jsonl. |
+| `profile` | string | no | The adaptive-effort pipeline profile the run selected: `light` (trivial fast path) or `full`. Omitted when `resolve.adaptive_effort` is `false` or the signal was unavailable. Lets `/idd-doctor` and audits see how often the fast path fired. See [agent-model-effort.md](https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md) (Complexity → pipeline profile). |
 | `qa_cycles` | integer | no | Number of QA review-fix cycles run (resolver) |
 | `duration_s` | integer | no | Wall-clock duration of the run in seconds, when measurable |
 | `skipped_reason` | string | no | Why the issue was skipped (auto-pilot skips, and any `skipped`/`already_resolved` outcome), e.g. `already_resolved`, `blocked_label`, `blocked_by_dependency`, `in_skip_list`, `assigned_to_other` |
@@ -546,7 +581,8 @@ Each line carries at minimum a **timestamp, issue number, mode, outcome**, and t
 Example lines:
 
 ```jsonl
-{"ts":"2026-06-26T14:31:07Z","issue":141,"mode":"auto","skill":"issue-resolver","complexity":"medium","qa_cycles":2,"outcome":"success","pr":150,"duration_s":372}
+{"ts":"2026-06-26T14:31:07Z","issue":141,"mode":"auto","skill":"issue-resolver","complexity":"medium","profile":"full","qa_cycles":2,"outcome":"success","pr":150,"duration_s":372}
+{"ts":"2026-06-26T15:02:41Z","issue":152,"mode":"auto","skill":"issue-resolver","complexity":"low","profile":"light","qa_cycles":1,"outcome":"success","pr":161,"duration_s":94}
 {"ts":"2026-06-26T14:48:12Z","issue":118,"mode":"balanced","skill":"auto-pilot","outcome":"skipped","pr":null,"skipped_reason":"blocked_by_dependency"}
 ```
 
@@ -648,8 +684,11 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `resolve.test_timeout` | `300` | 5 minute test timeout |
 | *(removed)* `resolve.pr_auto_link` | — | Deprecated; `Closes #N` is unconditional per SPEC §5.1 |
 | `resolve.max_commits` | `10` | Max commits warning |
+| `resolve.qa_max_cycles` | `5` | Max QA review-fix cycles during resolve Step 4 |
+| `resolve.adaptive_effort` | `true` | Scale the resolve pipeline to issue complexity — trivial issues (Effort XS/S) take a lighter path (lighter Research, skip 3-option Plan, skip propose-skills, QA capped at 1 cycle); `false` pins every issue to the full pipeline ([agent-model-effort.md](https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md)) |
 | `resolve.ui_review.browser_review` | `"ask"` | Browser (screenshot) UI review mode; code UI review is auto-detected and always runs |
 | `review.max_cycles` | `3` | Max review-fix cycles |
+| `review.adaptive_depth` | `true` | Scale review depth to PR complexity — a trivial PR caps the review-fix loop at 1 cycle and skips optional passes (AC + traceability hard-blocks still run); `false` pins every PR to full depth ([agent-model-effort.md](https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md)) |
 | `review.auto_merge` | `false` | Auto-merge PR when clean |
 | `review.confidence_threshold` | `80` | Min confidence level for issues |
 | `review.run_tests` | `true` | Run tests during review |

--- a/skills/auto-pilot/SKILL.md
+++ b/skills/auto-pilot/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Requires git and GitHub CLI (gh) with auth and push access. Requires merge permission for auto-merge. Requires issue-triage, issue-resolver, issue-analysis, and issue-pr-review to be installed from the same distribution. Optional: issue-creator for normalizing unstructured issues mid-loop."
 effort: max
 metadata:
-  version: 2.4.0
+  version: 2.4.1
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -173,7 +173,7 @@ The auto-pilot processes multiple issues in a single session. Without careful co
 
 The solution: the main agent acts as a **lightweight orchestrator** that delegates heavy work to subagents via the Agent tool. Each subagent gets a fresh context window, does its work, and returns a concise result. The main agent never reads code, diffs, or test output directly.
 
-Auto-pilot delegates to the resolver/reviewer **skills**, which spawn the shared agents (researcher, synthesizer, implementer, code reviewer, UI reviewer, fixer) under their role identities. Those skills size each agent's model/effort per `references/docs/agent-model-effort.md` and follow the shared conventions in `references/docs/shared-agent-conventions.md`; auto-pilot folds the telemetry they return (`complexity`, `qa_cycles`, `duration_s`) into its single run-log line per issue (see the run-log note below).
+Auto-pilot delegates to the resolver/reviewer **skills**, which spawn the shared agents (researcher, synthesizer, implementer, code reviewer, UI reviewer, fixer) under their role identities. Those skills size each agent's model/effort per `references/docs/agent-model-effort.md` and follow the shared conventions in `references/docs/shared-agent-conventions.md`; auto-pilot folds the telemetry they return (`complexity`, `profile`, `qa_cycles`, `duration_s`) into its single run-log line per issue (see the run-log note below).
 
 ### Subagent Architecture
 
@@ -263,8 +263,8 @@ the log accurate: the single-writer rule and the batch fan-out. Both live in
 
 Populate from the iteration's known values plus the resolver's returned telemetry
 (`ts`, `issue`, `mode`, `skill`, `outcome`, `pr`, and `qa_cycles` / `complexity` /
-`duration_s` when present). **When the outcome is `skipped`, always include
-`skipped_reason`** — a skip never ran the resolver, so it carries no telemetry.
+`profile` / `duration_s` when present). **When the outcome is `skipped`, always
+include `skipped_reason`** — a skip never ran the resolver, so it carries no telemetry.
 The full field list lives in `references/run-log.md` → *Fields to populate*.
 
 ```bash

--- a/skills/auto-pilot/references/docs/agent-model-effort.md
+++ b/skills/auto-pilot/references/docs/agent-model-effort.md
@@ -70,3 +70,97 @@ For each spawned step the orchestrator should:
 
 Selection is bounded by the same cost-awareness as model suggestion: prefer the
 lowest tier that can do the step correctly.
+
+## Complexity → pipeline profile
+
+Model/effort selection above is **advisory** — it tunes *how hard* each agent
+thinks but never changes *which* steps run. The **pipeline profile** is a
+distinct, second mechanism layered on the **same `XS … XL` scale**: it scales
+*how much pipeline runs* — which optional steps fire, how many QA/review cycles
+are allowed — so a trivial one-character edit does not pay the full
+orchestration cost of a multi-subsystem change. Unlike model/effort, the profile
+**does** change control flow (it can collapse a step or cap a loop), so it is a
+**gated** control, not advisory. The two are independent: model/effort sizes the
+agents a step spawns; the profile decides whether the lighter-weight step runs at
+all. They share the scale and nothing else — do **not** invent a second
+classifier for the profile.
+
+### The two profiles
+
+| Profile | Effort band | Intent |
+|---------|-------------|--------|
+| **light** | XS, S | Trivial/small work — collapse optional phases, cap the review-fix loop to one cycle. |
+| **full**  | M, L, XL | Everything today runs unchanged — the current pipeline in full. |
+
+The profile is a **coarse** switch (two states), deliberately not one profile per
+band: the goal is a fast path for the long tail of trivial work, not five
+gradations. Model/effort selection already provides the fine-grained,
+per-agent scaling within either profile.
+
+### Selecting the profile (pre-work signal)
+
+The profile is chosen from a **pre-work** signal — before the first expensive
+subagent spawn — so the saving is real. If the profile were derived from an
+agent's *output* (e.g. the researcher's `complexity`), the dominant cost would
+already be paid before the decision, and the fast path would save almost nothing.
+The pre-work signal is the issue's **`Effort` band** in its `## Metadata` section
+(the `XS … XL` value written by `/issue-creator`, the same scale this whole
+document uses).
+
+Resolve the profile from that band, **erring toward `full` whenever the signal
+is weak**:
+
+| Condition on the pre-work signal | Profile |
+|----------------------------------|---------|
+| `Effort` is `M`, `L`, or `XL` | **full** |
+| `Effort` is `XS` or `S` **and** asserted (not low-confidence) | **light** |
+| `Effort` is `XS`/`S` but marked `(needs review)` / low-confidence | **full** (ambiguous → fuller) |
+| `Effort` is absent / unparseable | **full** (safe default) |
+
+The low-confidence and absent rows are the safety contract: an uncertain estimate
+must never under-serve a task that turns out to be hard. A skill **may** refine
+the profile *upward* once a stronger signal arrives (e.g. the researcher reports
+`high`/`complex` on what the band called `S`) — never downward. Downgrading on a
+mid-pipeline signal would defeat the pre-work guarantee and risk truncating work
+already deep in the full path.
+
+### What each consuming skill does with the profile
+
+This document defines the *scale → profile* mapping and the pre-work-signal rule;
+each skill owns exactly *which* of its steps the `light` profile collapses (its
+pipeline reference spells out the per-step mechanics):
+
+- **`/issue-resolver`** — `light` keeps a **lighter** Research step (the
+  already-resolved safety check still runs), skips the 3-option synthesis in Plan
+  (a direct minimal plan is used), skips the interactive propose-relevant-skills
+  sub-step, and caps QA at **one** cycle. Implement and Deliver are unchanged, and
+  the durable PR artifacts (Decision Record + Acceptance Criteria Verification
+  table) are **always** emitted — the profile never removes durable memory.
+- **`/issue-pr-review`** — has no researcher, so it derives its own pre-work
+  signal (diff size / files-changed / labels / linked-issue `Effort`, taking the
+  **fuller** of any that disagree) and scales review **depth** — the `light`
+  profile caps the review-fix loop to one cycle and skips optional passes, while
+  the acceptance-criteria and traceability hard-blocks still run at full strength.
+
+### Surfacing the profile (transparency)
+
+The chosen profile is **surfaced to the user** wherever the skill already reports
+progress, so the effort decision is transparent and reviewable — never a hidden
+downgrade:
+
+- On the pipeline **tracker line** for the step where it is decided (e.g. the
+  resolver's `[0/5] Preflight` line names `effort: light` or `effort: full`).
+- In the **run log** (`.gitissue/runs.jsonl`) as the optional `profile` field, so
+  `/idd-doctor` and audits can see how often the fast path fired (see
+  `references/docs/config-schema.md`).
+
+### Opting out
+
+Each consuming skill exposes an explicit off-switch so a maintainer can force the
+full pipeline on every issue regardless of band: `resolve.adaptive_effort`
+(default `true`) for `/issue-resolver` and `review.adaptive_depth` (default
+`true`) for `/issue-pr-review`. When the switch is `false`, the skill behaves
+exactly as it did before this mechanism existed — the profile is pinned to
+`full`. Defaults are **on** so zero-config users get the fast path for trivial
+work automatically; the switch exists for maintainers who prefer uniform
+full-treatment (see `references/docs/config-schema.md`).

--- a/skills/auto-pilot/references/docs/config-schema.md
+++ b/skills/auto-pilot/references/docs/config-schema.md
@@ -123,6 +123,23 @@ resolve:
   # Maximum: 10
   qa_max_cycles: 5
 
+  # Scale the resolve pipeline to each issue's complexity (adaptive effort).
+  # Type: boolean
+  # Default: true
+  # When true, trivial issues (pre-work Effort band XS/S, asserted) take a
+  # lighter, faster, lower-token path: a lighter Research step (the
+  # already-resolved safety check still runs), the 3-option synthesis in Plan is
+  # skipped for a direct minimal plan, the propose-relevant-skills sub-step is
+  # skipped, and QA is capped at 1 cycle. The Decision Record and Acceptance
+  # Criteria Verification table are always emitted regardless. Complex or
+  # ambiguous issues (M/L/XL, low-confidence, or no band) keep the full pipeline.
+  # When false, every issue gets the full pipeline as before — the profile is
+  # pinned to "full". The chosen profile is surfaced on the [0/5] tracker line
+  # and in the run log's `profile` field. See
+  # https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md
+  # (Complexity → pipeline profile).
+  adaptive_effort: true
+
   # UI/UX review settings (Step 4 — QA)
   # Code-level UI review is auto-detected per issue and always runs when UI
   # work is present; it needs no flag and runs in any environment (including
@@ -145,6 +162,21 @@ review:
   # Minimum: 1
   # Maximum: 10
   max_cycles: 3
+
+  # Scale review depth to each PR's complexity (adaptive depth).
+  # Type: boolean
+  # Default: true
+  # When true, /issue-pr-review derives a pre-work complexity signal from the PR
+  # (diff size, files-changed, labels, and the linked issue's Effort band — the
+  # fuller of any that disagree) and, for a trivial PR, caps the review-fix loop
+  # at 1 cycle and skips optional passes. The acceptance-criteria and
+  # traceability hard-blocks always run at full strength. Complex or ambiguous
+  # PRs keep the full max_cycles depth. When false, every PR gets full review
+  # depth as before — the profile is pinned to "full". The chosen depth is
+  # surfaced on the [1/7] tracker line. See
+  # https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md
+  # (Complexity → pipeline profile).
+  adaptive_depth: true
 
   # Auto-merge PR when clean (overridden to true in --auto mode)
   # Type: boolean
@@ -464,8 +496,10 @@ graph TD
     RS --> R5["pr_auto_link"]
     RS --> R6["max_commits"]
     RS --> R7["qa_max_cycles"]
+    RS --> R8["adaptive_effort"]
 
     RV --> RV1["max_cycles"]
+    RV --> RV14["adaptive_depth"]
     RV --> RV2["auto_merge"]
     RV --> RV3["confidence_threshold"]
     RV --> RV4["run_tests"]
@@ -540,6 +574,7 @@ Each line carries at minimum a **timestamp, issue number, mode, outcome**, and t
 | `outcome` | string | yes | Terminal outcome. Resolver: `success`, `already_resolved`, `failed`. Auto-pilot: one of its six categorical outcomes (`merged`, `left_open`, `partial_followup`, `blocked_by_dependency`, `failed`, `skipped`). |
 | `pr` | integer or null | yes | PR number when a PR was created, else `null` |
 | `complexity` | string | no | Research complexity on the **3-value** run-log scale (`low` / `medium` / `high`) when known. Collapse the researcher's 5-value estimate before writing: `trivial` or `low` → `low`; `medium` → `medium`; `high` or `complex` → `high`. Never emit `trivial` or `complex` in runs.jsonl. |
+| `profile` | string | no | The adaptive-effort pipeline profile the run selected: `light` (trivial fast path) or `full`. Omitted when `resolve.adaptive_effort` is `false` or the signal was unavailable. Lets `/idd-doctor` and audits see how often the fast path fired. See [agent-model-effort.md](https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md) (Complexity → pipeline profile). |
 | `qa_cycles` | integer | no | Number of QA review-fix cycles run (resolver) |
 | `duration_s` | integer | no | Wall-clock duration of the run in seconds, when measurable |
 | `skipped_reason` | string | no | Why the issue was skipped (auto-pilot skips, and any `skipped`/`already_resolved` outcome), e.g. `already_resolved`, `blocked_label`, `blocked_by_dependency`, `in_skip_list`, `assigned_to_other` |
@@ -547,7 +582,8 @@ Each line carries at minimum a **timestamp, issue number, mode, outcome**, and t
 Example lines:
 
 ```jsonl
-{"ts":"2026-06-26T14:31:07Z","issue":141,"mode":"auto","skill":"issue-resolver","complexity":"medium","qa_cycles":2,"outcome":"success","pr":150,"duration_s":372}
+{"ts":"2026-06-26T14:31:07Z","issue":141,"mode":"auto","skill":"issue-resolver","complexity":"medium","profile":"full","qa_cycles":2,"outcome":"success","pr":150,"duration_s":372}
+{"ts":"2026-06-26T15:02:41Z","issue":152,"mode":"auto","skill":"issue-resolver","complexity":"low","profile":"light","qa_cycles":1,"outcome":"success","pr":161,"duration_s":94}
 {"ts":"2026-06-26T14:48:12Z","issue":118,"mode":"balanced","skill":"auto-pilot","outcome":"skipped","pr":null,"skipped_reason":"blocked_by_dependency"}
 ```
 
@@ -649,8 +685,11 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `resolve.test_timeout` | `300` | 5 minute test timeout |
 | *(removed)* `resolve.pr_auto_link` | — | Deprecated; `Closes #N` is unconditional per SPEC §5.1 |
 | `resolve.max_commits` | `10` | Max commits warning |
+| `resolve.qa_max_cycles` | `5` | Max QA review-fix cycles during resolve Step 4 |
+| `resolve.adaptive_effort` | `true` | Scale the resolve pipeline to issue complexity — trivial issues (Effort XS/S) take a lighter path (lighter Research, skip 3-option Plan, skip propose-skills, QA capped at 1 cycle); `false` pins every issue to the full pipeline ([agent-model-effort.md](https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md)) |
 | `resolve.ui_review.browser_review` | `"ask"` | Browser (screenshot) UI review mode; code UI review is auto-detected and always runs |
 | `review.max_cycles` | `3` | Max review-fix cycles |
+| `review.adaptive_depth` | `true` | Scale review depth to PR complexity — a trivial PR caps the review-fix loop at 1 cycle and skips optional passes (AC + traceability hard-blocks still run); `false` pins every PR to full depth ([agent-model-effort.md](https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md)) |
 | `review.auto_merge` | `false` | Auto-merge PR when clean |
 | `review.confidence_threshold` | `80` | Min confidence level for issues |
 | `review.run_tests` | `true` | Run tests during review |

--- a/skills/auto-pilot/references/docs/config-schema.md
+++ b/skills/auto-pilot/references/docs/config-schema.md
@@ -84,6 +84,10 @@ resolve:
   # Default: "auto"
   # "auto": proceed immediately after planning
   # "comment-and-wait": show plan and wait for user approval
+  # Note: with resolve.adaptive_effort: true (default), a light-profile (trivial
+  #   XS/S) issue proceeds on a direct minimal plan without the option prompt —
+  #   it produces no 3-option comparison to wait on. Set adaptive_effort: false
+  #   to force the approval wait on every issue regardless of complexity.
   approval_gate: auto
 
   # Branch naming prefix

--- a/skills/auto-pilot/references/run-log.md
+++ b/skills/auto-pilot/references/run-log.md
@@ -14,10 +14,10 @@ is invoked with `--no-run-log` (see *Resolver Subagent* in
 `references/subagent-prompts.md`), so it **does not** append its own line — only
 auto-pilot writes here. Writing in both places would double-write one line per
 issue and skew `/idd-doctor`'s resolve-rate and median-QA metrics. The resolver
-**returns** its telemetry (`qa_cycles`, `complexity`, `duration_s`) in its
-result; fold those into the **single line** auto-pilot writes (enriched with that
-telemetry) so the per-issue QA signal survives even though the resolver stayed
-silent. The resolver's run `status` informs auto-pilot's decision but is **not**
+**returns** its telemetry (`qa_cycles`, `complexity`, `profile`, `duration_s`) in
+its result; fold those into the **single line** auto-pilot writes (enriched with
+that telemetry) so the per-issue QA signal survives even though the resolver
+stayed silent. The resolver's run `status` informs auto-pilot's decision but is **not**
 copied into the row's `outcome` — that field stays auto-pilot's own six
 categorical label (set from the merge result).
 
@@ -41,7 +41,9 @@ telemetry: `ts` (current UTC, ISO 8601), `issue` (the number), `mode` (the
 auto-pilot merge mode — `conservative` / `balanced` / `aggressive`), `skill`
 (`auto-pilot`), `outcome` (one of the six categorical labels), `pr` (the PR
 number when one was created, else `null`), and — from the resolver's report-back
-— `qa_cycles`, `complexity`, and `duration_s` when present. **When the outcome is
-`skipped`, always include `skipped_reason`** (e.g. `already_resolved`,
+— `qa_cycles`, `complexity`, `profile`, and `duration_s` when present (`profile`
+is the adaptive-effort profile the resolve chose, `light` or `full`; omit it when
+the resolver returned none). **When the outcome is `skipped`, always include
+`skipped_reason`** (e.g. `already_resolved`,
 `blocked_label`, `blocked_by_dependency`, `in_skip_list`, `assigned_to_other`); a
 skip never ran the resolver, so it carries no resolver telemetry.

--- a/skills/auto-pilot/references/subagent-prompts.md
+++ b/skills/auto-pilot/references/subagent-prompts.md
@@ -41,6 +41,7 @@ When done, report back ONLY these fields:
 - tests_passed: count of tests passed
 - qa_cycles: number of QA cycles run
 - complexity: Research complexity collapsed to the runs.jsonl 3-value scale (see references/docs/config-schema.md — trivial/low→low, medium→medium, high/complex→high)
+- profile: the adaptive-effort pipeline profile the resolve selected ("light" or "full"), for the run-log `profile` field; omit/null when resolve.adaptive_effort is false or no profile was selected
 - duration_s: wall-clock seconds for the resolve, when measurable, for the run-log line
 - failure_step: which step failed (if status is failure)
 - failure_reason: short error description (if status is failure)
@@ -204,6 +205,10 @@ When done, report back ONLY these fields:
   primary issue's run-log line only, so a batch is not weighted N-fold)
 - complexity: the complexity assessed in Research (e.g. low/medium/high), shared on
   every fanned-out run-log line
+- profile: the adaptive-effort pipeline profile the batch resolve selected ("light"
+  or "full"), shared on every fanned-out run-log line like complexity; omit/null
+  when resolve.adaptive_effort is false. (A batch of several issues is rarely
+  trivial, so this is usually "full".)
 - duration_s: wall-clock seconds for the batch resolve, when measurable; like
   qa_cycles it is attributed to the primary issue's line only
 - failure_step: which step failed (if status is failure)

--- a/skills/init-gitissue/SKILL.md
+++ b/skills/init-gitissue/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Requires git. No GitHub CLI or authentication needed — generates a local config file only."
 effort: low
 metadata:
-  version: 0.3.5
+  version: 0.3.6
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 

--- a/skills/init-gitissue/references/docs/config-schema.md
+++ b/skills/init-gitissue/references/docs/config-schema.md
@@ -123,6 +123,23 @@ resolve:
   # Maximum: 10
   qa_max_cycles: 5
 
+  # Scale the resolve pipeline to each issue's complexity (adaptive effort).
+  # Type: boolean
+  # Default: true
+  # When true, trivial issues (pre-work Effort band XS/S, asserted) take a
+  # lighter, faster, lower-token path: a lighter Research step (the
+  # already-resolved safety check still runs), the 3-option synthesis in Plan is
+  # skipped for a direct minimal plan, the propose-relevant-skills sub-step is
+  # skipped, and QA is capped at 1 cycle. The Decision Record and Acceptance
+  # Criteria Verification table are always emitted regardless. Complex or
+  # ambiguous issues (M/L/XL, low-confidence, or no band) keep the full pipeline.
+  # When false, every issue gets the full pipeline as before — the profile is
+  # pinned to "full". The chosen profile is surfaced on the [0/5] tracker line
+  # and in the run log's `profile` field. See
+  # https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md
+  # (Complexity → pipeline profile).
+  adaptive_effort: true
+
   # UI/UX review settings (Step 4 — QA)
   # Code-level UI review is auto-detected per issue and always runs when UI
   # work is present; it needs no flag and runs in any environment (including
@@ -145,6 +162,21 @@ review:
   # Minimum: 1
   # Maximum: 10
   max_cycles: 3
+
+  # Scale review depth to each PR's complexity (adaptive depth).
+  # Type: boolean
+  # Default: true
+  # When true, /issue-pr-review derives a pre-work complexity signal from the PR
+  # (diff size, files-changed, labels, and the linked issue's Effort band — the
+  # fuller of any that disagree) and, for a trivial PR, caps the review-fix loop
+  # at 1 cycle and skips optional passes. The acceptance-criteria and
+  # traceability hard-blocks always run at full strength. Complex or ambiguous
+  # PRs keep the full max_cycles depth. When false, every PR gets full review
+  # depth as before — the profile is pinned to "full". The chosen depth is
+  # surfaced on the [1/7] tracker line. See
+  # https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md
+  # (Complexity → pipeline profile).
+  adaptive_depth: true
 
   # Auto-merge PR when clean (overridden to true in --auto mode)
   # Type: boolean
@@ -464,8 +496,10 @@ graph TD
     RS --> R5["pr_auto_link"]
     RS --> R6["max_commits"]
     RS --> R7["qa_max_cycles"]
+    RS --> R8["adaptive_effort"]
 
     RV --> RV1["max_cycles"]
+    RV --> RV14["adaptive_depth"]
     RV --> RV2["auto_merge"]
     RV --> RV3["confidence_threshold"]
     RV --> RV4["run_tests"]
@@ -540,6 +574,7 @@ Each line carries at minimum a **timestamp, issue number, mode, outcome**, and t
 | `outcome` | string | yes | Terminal outcome. Resolver: `success`, `already_resolved`, `failed`. Auto-pilot: one of its six categorical outcomes (`merged`, `left_open`, `partial_followup`, `blocked_by_dependency`, `failed`, `skipped`). |
 | `pr` | integer or null | yes | PR number when a PR was created, else `null` |
 | `complexity` | string | no | Research complexity on the **3-value** run-log scale (`low` / `medium` / `high`) when known. Collapse the researcher's 5-value estimate before writing: `trivial` or `low` → `low`; `medium` → `medium`; `high` or `complex` → `high`. Never emit `trivial` or `complex` in runs.jsonl. |
+| `profile` | string | no | The adaptive-effort pipeline profile the run selected: `light` (trivial fast path) or `full`. Omitted when `resolve.adaptive_effort` is `false` or the signal was unavailable. Lets `/idd-doctor` and audits see how often the fast path fired. See [agent-model-effort.md](https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md) (Complexity → pipeline profile). |
 | `qa_cycles` | integer | no | Number of QA review-fix cycles run (resolver) |
 | `duration_s` | integer | no | Wall-clock duration of the run in seconds, when measurable |
 | `skipped_reason` | string | no | Why the issue was skipped (auto-pilot skips, and any `skipped`/`already_resolved` outcome), e.g. `already_resolved`, `blocked_label`, `blocked_by_dependency`, `in_skip_list`, `assigned_to_other` |
@@ -547,7 +582,8 @@ Each line carries at minimum a **timestamp, issue number, mode, outcome**, and t
 Example lines:
 
 ```jsonl
-{"ts":"2026-06-26T14:31:07Z","issue":141,"mode":"auto","skill":"issue-resolver","complexity":"medium","qa_cycles":2,"outcome":"success","pr":150,"duration_s":372}
+{"ts":"2026-06-26T14:31:07Z","issue":141,"mode":"auto","skill":"issue-resolver","complexity":"medium","profile":"full","qa_cycles":2,"outcome":"success","pr":150,"duration_s":372}
+{"ts":"2026-06-26T15:02:41Z","issue":152,"mode":"auto","skill":"issue-resolver","complexity":"low","profile":"light","qa_cycles":1,"outcome":"success","pr":161,"duration_s":94}
 {"ts":"2026-06-26T14:48:12Z","issue":118,"mode":"balanced","skill":"auto-pilot","outcome":"skipped","pr":null,"skipped_reason":"blocked_by_dependency"}
 ```
 
@@ -649,8 +685,11 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `resolve.test_timeout` | `300` | 5 minute test timeout |
 | *(removed)* `resolve.pr_auto_link` | — | Deprecated; `Closes #N` is unconditional per SPEC §5.1 |
 | `resolve.max_commits` | `10` | Max commits warning |
+| `resolve.qa_max_cycles` | `5` | Max QA review-fix cycles during resolve Step 4 |
+| `resolve.adaptive_effort` | `true` | Scale the resolve pipeline to issue complexity — trivial issues (Effort XS/S) take a lighter path (lighter Research, skip 3-option Plan, skip propose-skills, QA capped at 1 cycle); `false` pins every issue to the full pipeline ([agent-model-effort.md](https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md)) |
 | `resolve.ui_review.browser_review` | `"ask"` | Browser (screenshot) UI review mode; code UI review is auto-detected and always runs |
 | `review.max_cycles` | `3` | Max review-fix cycles |
+| `review.adaptive_depth` | `true` | Scale review depth to PR complexity — a trivial PR caps the review-fix loop at 1 cycle and skips optional passes (AC + traceability hard-blocks still run); `false` pins every PR to full depth ([agent-model-effort.md](https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md)) |
 | `review.auto_merge` | `false` | Auto-merge PR when clean |
 | `review.confidence_threshold` | `80` | Min confidence level for issues |
 | `review.run_tests` | `true` | Run tests during review |

--- a/skills/init-gitissue/references/docs/config-schema.md
+++ b/skills/init-gitissue/references/docs/config-schema.md
@@ -84,6 +84,10 @@ resolve:
   # Default: "auto"
   # "auto": proceed immediately after planning
   # "comment-and-wait": show plan and wait for user approval
+  # Note: with resolve.adaptive_effort: true (default), a light-profile (trivial
+  #   XS/S) issue proceeds on a direct minimal plan without the option prompt —
+  #   it produces no 3-option comparison to wait on. Set adaptive_effort: false
+  #   to force the approval wait on every issue regardless of complexity.
   approval_gate: auto
 
   # Branch naming prefix

--- a/skills/init-gitissue/templates/gitissue-template.yml
+++ b/skills/init-gitissue/templates/gitissue-template.yml
@@ -47,6 +47,11 @@ resolve:
   # Max QA review-fix cycles during resolve Step 4
   qa_max_cycles: 5
 
+  # Scale the resolve pipeline to issue complexity (adaptive effort).
+  # true: trivial issues (Effort XS/S) take a lighter, faster path; complex or
+  # ambiguous issues keep the full pipeline. false: full pipeline for every issue.
+  adaptive_effort: true
+
   ui_review:
     browser_review: ask
 
@@ -67,6 +72,10 @@ triage:
 # PR review settings (used by /issue-pr-review and /auto-pilot)
 review:
   max_cycles: 3
+  # Scale review depth to PR complexity (adaptive depth).
+  # true: a trivial PR caps the review-fix loop at 1 cycle and skips optional
+  # passes; complex or ambiguous PRs keep full depth. false: full depth always.
+  adaptive_depth: true
   auto_merge: false
   confidence_threshold: 80
   run_tests: true

--- a/skills/issue-analysis/references/docs/agent-model-effort.md
+++ b/skills/issue-analysis/references/docs/agent-model-effort.md
@@ -70,3 +70,97 @@ For each spawned step the orchestrator should:
 
 Selection is bounded by the same cost-awareness as model suggestion: prefer the
 lowest tier that can do the step correctly.
+
+## Complexity → pipeline profile
+
+Model/effort selection above is **advisory** — it tunes *how hard* each agent
+thinks but never changes *which* steps run. The **pipeline profile** is a
+distinct, second mechanism layered on the **same `XS … XL` scale**: it scales
+*how much pipeline runs* — which optional steps fire, how many QA/review cycles
+are allowed — so a trivial one-character edit does not pay the full
+orchestration cost of a multi-subsystem change. Unlike model/effort, the profile
+**does** change control flow (it can collapse a step or cap a loop), so it is a
+**gated** control, not advisory. The two are independent: model/effort sizes the
+agents a step spawns; the profile decides whether the lighter-weight step runs at
+all. They share the scale and nothing else — do **not** invent a second
+classifier for the profile.
+
+### The two profiles
+
+| Profile | Effort band | Intent |
+|---------|-------------|--------|
+| **light** | XS, S | Trivial/small work — collapse optional phases, cap the review-fix loop to one cycle. |
+| **full**  | M, L, XL | Everything today runs unchanged — the current pipeline in full. |
+
+The profile is a **coarse** switch (two states), deliberately not one profile per
+band: the goal is a fast path for the long tail of trivial work, not five
+gradations. Model/effort selection already provides the fine-grained,
+per-agent scaling within either profile.
+
+### Selecting the profile (pre-work signal)
+
+The profile is chosen from a **pre-work** signal — before the first expensive
+subagent spawn — so the saving is real. If the profile were derived from an
+agent's *output* (e.g. the researcher's `complexity`), the dominant cost would
+already be paid before the decision, and the fast path would save almost nothing.
+The pre-work signal is the issue's **`Effort` band** in its `## Metadata` section
+(the `XS … XL` value written by `/issue-creator`, the same scale this whole
+document uses).
+
+Resolve the profile from that band, **erring toward `full` whenever the signal
+is weak**:
+
+| Condition on the pre-work signal | Profile |
+|----------------------------------|---------|
+| `Effort` is `M`, `L`, or `XL` | **full** |
+| `Effort` is `XS` or `S` **and** asserted (not low-confidence) | **light** |
+| `Effort` is `XS`/`S` but marked `(needs review)` / low-confidence | **full** (ambiguous → fuller) |
+| `Effort` is absent / unparseable | **full** (safe default) |
+
+The low-confidence and absent rows are the safety contract: an uncertain estimate
+must never under-serve a task that turns out to be hard. A skill **may** refine
+the profile *upward* once a stronger signal arrives (e.g. the researcher reports
+`high`/`complex` on what the band called `S`) — never downward. Downgrading on a
+mid-pipeline signal would defeat the pre-work guarantee and risk truncating work
+already deep in the full path.
+
+### What each consuming skill does with the profile
+
+This document defines the *scale → profile* mapping and the pre-work-signal rule;
+each skill owns exactly *which* of its steps the `light` profile collapses (its
+pipeline reference spells out the per-step mechanics):
+
+- **`/issue-resolver`** — `light` keeps a **lighter** Research step (the
+  already-resolved safety check still runs), skips the 3-option synthesis in Plan
+  (a direct minimal plan is used), skips the interactive propose-relevant-skills
+  sub-step, and caps QA at **one** cycle. Implement and Deliver are unchanged, and
+  the durable PR artifacts (Decision Record + Acceptance Criteria Verification
+  table) are **always** emitted — the profile never removes durable memory.
+- **`/issue-pr-review`** — has no researcher, so it derives its own pre-work
+  signal (diff size / files-changed / labels / linked-issue `Effort`, taking the
+  **fuller** of any that disagree) and scales review **depth** — the `light`
+  profile caps the review-fix loop to one cycle and skips optional passes, while
+  the acceptance-criteria and traceability hard-blocks still run at full strength.
+
+### Surfacing the profile (transparency)
+
+The chosen profile is **surfaced to the user** wherever the skill already reports
+progress, so the effort decision is transparent and reviewable — never a hidden
+downgrade:
+
+- On the pipeline **tracker line** for the step where it is decided (e.g. the
+  resolver's `[0/5] Preflight` line names `effort: light` or `effort: full`).
+- In the **run log** (`.gitissue/runs.jsonl`) as the optional `profile` field, so
+  `/idd-doctor` and audits can see how often the fast path fired (see
+  `references/docs/config-schema.md`).
+
+### Opting out
+
+Each consuming skill exposes an explicit off-switch so a maintainer can force the
+full pipeline on every issue regardless of band: `resolve.adaptive_effort`
+(default `true`) for `/issue-resolver` and `review.adaptive_depth` (default
+`true`) for `/issue-pr-review`. When the switch is `false`, the skill behaves
+exactly as it did before this mechanism existed — the profile is pinned to
+`full`. Defaults are **on** so zero-config users get the fast path for trivial
+work automatically; the switch exists for maintainers who prefer uniform
+full-treatment (see `references/docs/config-schema.md`).

--- a/skills/issue-analysis/references/docs/config-schema.md
+++ b/skills/issue-analysis/references/docs/config-schema.md
@@ -123,6 +123,23 @@ resolve:
   # Maximum: 10
   qa_max_cycles: 5
 
+  # Scale the resolve pipeline to each issue's complexity (adaptive effort).
+  # Type: boolean
+  # Default: true
+  # When true, trivial issues (pre-work Effort band XS/S, asserted) take a
+  # lighter, faster, lower-token path: a lighter Research step (the
+  # already-resolved safety check still runs), the 3-option synthesis in Plan is
+  # skipped for a direct minimal plan, the propose-relevant-skills sub-step is
+  # skipped, and QA is capped at 1 cycle. The Decision Record and Acceptance
+  # Criteria Verification table are always emitted regardless. Complex or
+  # ambiguous issues (M/L/XL, low-confidence, or no band) keep the full pipeline.
+  # When false, every issue gets the full pipeline as before — the profile is
+  # pinned to "full". The chosen profile is surfaced on the [0/5] tracker line
+  # and in the run log's `profile` field. See
+  # https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md
+  # (Complexity → pipeline profile).
+  adaptive_effort: true
+
   # UI/UX review settings (Step 4 — QA)
   # Code-level UI review is auto-detected per issue and always runs when UI
   # work is present; it needs no flag and runs in any environment (including
@@ -145,6 +162,21 @@ review:
   # Minimum: 1
   # Maximum: 10
   max_cycles: 3
+
+  # Scale review depth to each PR's complexity (adaptive depth).
+  # Type: boolean
+  # Default: true
+  # When true, /issue-pr-review derives a pre-work complexity signal from the PR
+  # (diff size, files-changed, labels, and the linked issue's Effort band — the
+  # fuller of any that disagree) and, for a trivial PR, caps the review-fix loop
+  # at 1 cycle and skips optional passes. The acceptance-criteria and
+  # traceability hard-blocks always run at full strength. Complex or ambiguous
+  # PRs keep the full max_cycles depth. When false, every PR gets full review
+  # depth as before — the profile is pinned to "full". The chosen depth is
+  # surfaced on the [1/7] tracker line. See
+  # https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md
+  # (Complexity → pipeline profile).
+  adaptive_depth: true
 
   # Auto-merge PR when clean (overridden to true in --auto mode)
   # Type: boolean
@@ -464,8 +496,10 @@ graph TD
     RS --> R5["pr_auto_link"]
     RS --> R6["max_commits"]
     RS --> R7["qa_max_cycles"]
+    RS --> R8["adaptive_effort"]
 
     RV --> RV1["max_cycles"]
+    RV --> RV14["adaptive_depth"]
     RV --> RV2["auto_merge"]
     RV --> RV3["confidence_threshold"]
     RV --> RV4["run_tests"]
@@ -540,6 +574,7 @@ Each line carries at minimum a **timestamp, issue number, mode, outcome**, and t
 | `outcome` | string | yes | Terminal outcome. Resolver: `success`, `already_resolved`, `failed`. Auto-pilot: one of its six categorical outcomes (`merged`, `left_open`, `partial_followup`, `blocked_by_dependency`, `failed`, `skipped`). |
 | `pr` | integer or null | yes | PR number when a PR was created, else `null` |
 | `complexity` | string | no | Research complexity on the **3-value** run-log scale (`low` / `medium` / `high`) when known. Collapse the researcher's 5-value estimate before writing: `trivial` or `low` → `low`; `medium` → `medium`; `high` or `complex` → `high`. Never emit `trivial` or `complex` in runs.jsonl. |
+| `profile` | string | no | The adaptive-effort pipeline profile the run selected: `light` (trivial fast path) or `full`. Omitted when `resolve.adaptive_effort` is `false` or the signal was unavailable. Lets `/idd-doctor` and audits see how often the fast path fired. See [agent-model-effort.md](https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md) (Complexity → pipeline profile). |
 | `qa_cycles` | integer | no | Number of QA review-fix cycles run (resolver) |
 | `duration_s` | integer | no | Wall-clock duration of the run in seconds, when measurable |
 | `skipped_reason` | string | no | Why the issue was skipped (auto-pilot skips, and any `skipped`/`already_resolved` outcome), e.g. `already_resolved`, `blocked_label`, `blocked_by_dependency`, `in_skip_list`, `assigned_to_other` |
@@ -547,7 +582,8 @@ Each line carries at minimum a **timestamp, issue number, mode, outcome**, and t
 Example lines:
 
 ```jsonl
-{"ts":"2026-06-26T14:31:07Z","issue":141,"mode":"auto","skill":"issue-resolver","complexity":"medium","qa_cycles":2,"outcome":"success","pr":150,"duration_s":372}
+{"ts":"2026-06-26T14:31:07Z","issue":141,"mode":"auto","skill":"issue-resolver","complexity":"medium","profile":"full","qa_cycles":2,"outcome":"success","pr":150,"duration_s":372}
+{"ts":"2026-06-26T15:02:41Z","issue":152,"mode":"auto","skill":"issue-resolver","complexity":"low","profile":"light","qa_cycles":1,"outcome":"success","pr":161,"duration_s":94}
 {"ts":"2026-06-26T14:48:12Z","issue":118,"mode":"balanced","skill":"auto-pilot","outcome":"skipped","pr":null,"skipped_reason":"blocked_by_dependency"}
 ```
 
@@ -649,8 +685,11 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `resolve.test_timeout` | `300` | 5 minute test timeout |
 | *(removed)* `resolve.pr_auto_link` | — | Deprecated; `Closes #N` is unconditional per SPEC §5.1 |
 | `resolve.max_commits` | `10` | Max commits warning |
+| `resolve.qa_max_cycles` | `5` | Max QA review-fix cycles during resolve Step 4 |
+| `resolve.adaptive_effort` | `true` | Scale the resolve pipeline to issue complexity — trivial issues (Effort XS/S) take a lighter path (lighter Research, skip 3-option Plan, skip propose-skills, QA capped at 1 cycle); `false` pins every issue to the full pipeline ([agent-model-effort.md](https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md)) |
 | `resolve.ui_review.browser_review` | `"ask"` | Browser (screenshot) UI review mode; code UI review is auto-detected and always runs |
 | `review.max_cycles` | `3` | Max review-fix cycles |
+| `review.adaptive_depth` | `true` | Scale review depth to PR complexity — a trivial PR caps the review-fix loop at 1 cycle and skips optional passes (AC + traceability hard-blocks still run); `false` pins every PR to full depth ([agent-model-effort.md](https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md)) |
 | `review.auto_merge` | `false` | Auto-merge PR when clean |
 | `review.confidence_threshold` | `80` | Min confidence level for issues |
 | `review.run_tests` | `true` | Run tests during review |

--- a/skills/issue-analysis/references/docs/config-schema.md
+++ b/skills/issue-analysis/references/docs/config-schema.md
@@ -84,6 +84,10 @@ resolve:
   # Default: "auto"
   # "auto": proceed immediately after planning
   # "comment-and-wait": show plan and wait for user approval
+  # Note: with resolve.adaptive_effort: true (default), a light-profile (trivial
+  #   XS/S) issue proceeds on a direct minimal plan without the option prompt —
+  #   it produces no 3-option comparison to wait on. Set adaptive_effort: false
+  #   to force the approval wait on every issue regardless of complexity.
   approval_gate: auto
 
   # Branch naming prefix

--- a/skills/issue-creator/references/docs/agent-model-effort.md
+++ b/skills/issue-creator/references/docs/agent-model-effort.md
@@ -70,3 +70,97 @@ For each spawned step the orchestrator should:
 
 Selection is bounded by the same cost-awareness as model suggestion: prefer the
 lowest tier that can do the step correctly.
+
+## Complexity → pipeline profile
+
+Model/effort selection above is **advisory** — it tunes *how hard* each agent
+thinks but never changes *which* steps run. The **pipeline profile** is a
+distinct, second mechanism layered on the **same `XS … XL` scale**: it scales
+*how much pipeline runs* — which optional steps fire, how many QA/review cycles
+are allowed — so a trivial one-character edit does not pay the full
+orchestration cost of a multi-subsystem change. Unlike model/effort, the profile
+**does** change control flow (it can collapse a step or cap a loop), so it is a
+**gated** control, not advisory. The two are independent: model/effort sizes the
+agents a step spawns; the profile decides whether the lighter-weight step runs at
+all. They share the scale and nothing else — do **not** invent a second
+classifier for the profile.
+
+### The two profiles
+
+| Profile | Effort band | Intent |
+|---------|-------------|--------|
+| **light** | XS, S | Trivial/small work — collapse optional phases, cap the review-fix loop to one cycle. |
+| **full**  | M, L, XL | Everything today runs unchanged — the current pipeline in full. |
+
+The profile is a **coarse** switch (two states), deliberately not one profile per
+band: the goal is a fast path for the long tail of trivial work, not five
+gradations. Model/effort selection already provides the fine-grained,
+per-agent scaling within either profile.
+
+### Selecting the profile (pre-work signal)
+
+The profile is chosen from a **pre-work** signal — before the first expensive
+subagent spawn — so the saving is real. If the profile were derived from an
+agent's *output* (e.g. the researcher's `complexity`), the dominant cost would
+already be paid before the decision, and the fast path would save almost nothing.
+The pre-work signal is the issue's **`Effort` band** in its `## Metadata` section
+(the `XS … XL` value written by `/issue-creator`, the same scale this whole
+document uses).
+
+Resolve the profile from that band, **erring toward `full` whenever the signal
+is weak**:
+
+| Condition on the pre-work signal | Profile |
+|----------------------------------|---------|
+| `Effort` is `M`, `L`, or `XL` | **full** |
+| `Effort` is `XS` or `S` **and** asserted (not low-confidence) | **light** |
+| `Effort` is `XS`/`S` but marked `(needs review)` / low-confidence | **full** (ambiguous → fuller) |
+| `Effort` is absent / unparseable | **full** (safe default) |
+
+The low-confidence and absent rows are the safety contract: an uncertain estimate
+must never under-serve a task that turns out to be hard. A skill **may** refine
+the profile *upward* once a stronger signal arrives (e.g. the researcher reports
+`high`/`complex` on what the band called `S`) — never downward. Downgrading on a
+mid-pipeline signal would defeat the pre-work guarantee and risk truncating work
+already deep in the full path.
+
+### What each consuming skill does with the profile
+
+This document defines the *scale → profile* mapping and the pre-work-signal rule;
+each skill owns exactly *which* of its steps the `light` profile collapses (its
+pipeline reference spells out the per-step mechanics):
+
+- **`/issue-resolver`** — `light` keeps a **lighter** Research step (the
+  already-resolved safety check still runs), skips the 3-option synthesis in Plan
+  (a direct minimal plan is used), skips the interactive propose-relevant-skills
+  sub-step, and caps QA at **one** cycle. Implement and Deliver are unchanged, and
+  the durable PR artifacts (Decision Record + Acceptance Criteria Verification
+  table) are **always** emitted — the profile never removes durable memory.
+- **`/issue-pr-review`** — has no researcher, so it derives its own pre-work
+  signal (diff size / files-changed / labels / linked-issue `Effort`, taking the
+  **fuller** of any that disagree) and scales review **depth** — the `light`
+  profile caps the review-fix loop to one cycle and skips optional passes, while
+  the acceptance-criteria and traceability hard-blocks still run at full strength.
+
+### Surfacing the profile (transparency)
+
+The chosen profile is **surfaced to the user** wherever the skill already reports
+progress, so the effort decision is transparent and reviewable — never a hidden
+downgrade:
+
+- On the pipeline **tracker line** for the step where it is decided (e.g. the
+  resolver's `[0/5] Preflight` line names `effort: light` or `effort: full`).
+- In the **run log** (`.gitissue/runs.jsonl`) as the optional `profile` field, so
+  `/idd-doctor` and audits can see how often the fast path fired (see
+  `references/docs/config-schema.md`).
+
+### Opting out
+
+Each consuming skill exposes an explicit off-switch so a maintainer can force the
+full pipeline on every issue regardless of band: `resolve.adaptive_effort`
+(default `true`) for `/issue-resolver` and `review.adaptive_depth` (default
+`true`) for `/issue-pr-review`. When the switch is `false`, the skill behaves
+exactly as it did before this mechanism existed — the profile is pinned to
+`full`. Defaults are **on** so zero-config users get the fast path for trivial
+work automatically; the switch exists for maintainers who prefer uniform
+full-treatment (see `references/docs/config-schema.md`).

--- a/skills/issue-creator/references/docs/config-schema.md
+++ b/skills/issue-creator/references/docs/config-schema.md
@@ -123,6 +123,23 @@ resolve:
   # Maximum: 10
   qa_max_cycles: 5
 
+  # Scale the resolve pipeline to each issue's complexity (adaptive effort).
+  # Type: boolean
+  # Default: true
+  # When true, trivial issues (pre-work Effort band XS/S, asserted) take a
+  # lighter, faster, lower-token path: a lighter Research step (the
+  # already-resolved safety check still runs), the 3-option synthesis in Plan is
+  # skipped for a direct minimal plan, the propose-relevant-skills sub-step is
+  # skipped, and QA is capped at 1 cycle. The Decision Record and Acceptance
+  # Criteria Verification table are always emitted regardless. Complex or
+  # ambiguous issues (M/L/XL, low-confidence, or no band) keep the full pipeline.
+  # When false, every issue gets the full pipeline as before — the profile is
+  # pinned to "full". The chosen profile is surfaced on the [0/5] tracker line
+  # and in the run log's `profile` field. See
+  # https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md
+  # (Complexity → pipeline profile).
+  adaptive_effort: true
+
   # UI/UX review settings (Step 4 — QA)
   # Code-level UI review is auto-detected per issue and always runs when UI
   # work is present; it needs no flag and runs in any environment (including
@@ -145,6 +162,21 @@ review:
   # Minimum: 1
   # Maximum: 10
   max_cycles: 3
+
+  # Scale review depth to each PR's complexity (adaptive depth).
+  # Type: boolean
+  # Default: true
+  # When true, /issue-pr-review derives a pre-work complexity signal from the PR
+  # (diff size, files-changed, labels, and the linked issue's Effort band — the
+  # fuller of any that disagree) and, for a trivial PR, caps the review-fix loop
+  # at 1 cycle and skips optional passes. The acceptance-criteria and
+  # traceability hard-blocks always run at full strength. Complex or ambiguous
+  # PRs keep the full max_cycles depth. When false, every PR gets full review
+  # depth as before — the profile is pinned to "full". The chosen depth is
+  # surfaced on the [1/7] tracker line. See
+  # https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md
+  # (Complexity → pipeline profile).
+  adaptive_depth: true
 
   # Auto-merge PR when clean (overridden to true in --auto mode)
   # Type: boolean
@@ -464,8 +496,10 @@ graph TD
     RS --> R5["pr_auto_link"]
     RS --> R6["max_commits"]
     RS --> R7["qa_max_cycles"]
+    RS --> R8["adaptive_effort"]
 
     RV --> RV1["max_cycles"]
+    RV --> RV14["adaptive_depth"]
     RV --> RV2["auto_merge"]
     RV --> RV3["confidence_threshold"]
     RV --> RV4["run_tests"]
@@ -540,6 +574,7 @@ Each line carries at minimum a **timestamp, issue number, mode, outcome**, and t
 | `outcome` | string | yes | Terminal outcome. Resolver: `success`, `already_resolved`, `failed`. Auto-pilot: one of its six categorical outcomes (`merged`, `left_open`, `partial_followup`, `blocked_by_dependency`, `failed`, `skipped`). |
 | `pr` | integer or null | yes | PR number when a PR was created, else `null` |
 | `complexity` | string | no | Research complexity on the **3-value** run-log scale (`low` / `medium` / `high`) when known. Collapse the researcher's 5-value estimate before writing: `trivial` or `low` → `low`; `medium` → `medium`; `high` or `complex` → `high`. Never emit `trivial` or `complex` in runs.jsonl. |
+| `profile` | string | no | The adaptive-effort pipeline profile the run selected: `light` (trivial fast path) or `full`. Omitted when `resolve.adaptive_effort` is `false` or the signal was unavailable. Lets `/idd-doctor` and audits see how often the fast path fired. See [agent-model-effort.md](https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md) (Complexity → pipeline profile). |
 | `qa_cycles` | integer | no | Number of QA review-fix cycles run (resolver) |
 | `duration_s` | integer | no | Wall-clock duration of the run in seconds, when measurable |
 | `skipped_reason` | string | no | Why the issue was skipped (auto-pilot skips, and any `skipped`/`already_resolved` outcome), e.g. `already_resolved`, `blocked_label`, `blocked_by_dependency`, `in_skip_list`, `assigned_to_other` |
@@ -547,7 +582,8 @@ Each line carries at minimum a **timestamp, issue number, mode, outcome**, and t
 Example lines:
 
 ```jsonl
-{"ts":"2026-06-26T14:31:07Z","issue":141,"mode":"auto","skill":"issue-resolver","complexity":"medium","qa_cycles":2,"outcome":"success","pr":150,"duration_s":372}
+{"ts":"2026-06-26T14:31:07Z","issue":141,"mode":"auto","skill":"issue-resolver","complexity":"medium","profile":"full","qa_cycles":2,"outcome":"success","pr":150,"duration_s":372}
+{"ts":"2026-06-26T15:02:41Z","issue":152,"mode":"auto","skill":"issue-resolver","complexity":"low","profile":"light","qa_cycles":1,"outcome":"success","pr":161,"duration_s":94}
 {"ts":"2026-06-26T14:48:12Z","issue":118,"mode":"balanced","skill":"auto-pilot","outcome":"skipped","pr":null,"skipped_reason":"blocked_by_dependency"}
 ```
 
@@ -649,8 +685,11 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `resolve.test_timeout` | `300` | 5 minute test timeout |
 | *(removed)* `resolve.pr_auto_link` | — | Deprecated; `Closes #N` is unconditional per SPEC §5.1 |
 | `resolve.max_commits` | `10` | Max commits warning |
+| `resolve.qa_max_cycles` | `5` | Max QA review-fix cycles during resolve Step 4 |
+| `resolve.adaptive_effort` | `true` | Scale the resolve pipeline to issue complexity — trivial issues (Effort XS/S) take a lighter path (lighter Research, skip 3-option Plan, skip propose-skills, QA capped at 1 cycle); `false` pins every issue to the full pipeline ([agent-model-effort.md](https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md)) |
 | `resolve.ui_review.browser_review` | `"ask"` | Browser (screenshot) UI review mode; code UI review is auto-detected and always runs |
 | `review.max_cycles` | `3` | Max review-fix cycles |
+| `review.adaptive_depth` | `true` | Scale review depth to PR complexity — a trivial PR caps the review-fix loop at 1 cycle and skips optional passes (AC + traceability hard-blocks still run); `false` pins every PR to full depth ([agent-model-effort.md](https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md)) |
 | `review.auto_merge` | `false` | Auto-merge PR when clean |
 | `review.confidence_threshold` | `80` | Min confidence level for issues |
 | `review.run_tests` | `true` | Run tests during review |

--- a/skills/issue-creator/references/docs/config-schema.md
+++ b/skills/issue-creator/references/docs/config-schema.md
@@ -84,6 +84,10 @@ resolve:
   # Default: "auto"
   # "auto": proceed immediately after planning
   # "comment-and-wait": show plan and wait for user approval
+  # Note: with resolve.adaptive_effort: true (default), a light-profile (trivial
+  #   XS/S) issue proceeds on a direct minimal plan without the option prompt —
+  #   it produces no 3-option comparison to wait on. Set adaptive_effort: false
+  #   to force the approval wait on every issue regardless of complexity.
   approval_gate: auto
 
   # Branch naming prefix

--- a/skills/issue-pr-review/SKILL.md
+++ b/skills/issue-pr-review/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Requires git and GitHub CLI (gh) with authentication. Self-contained — uses shared agents from shared/agents/."
 effort: high
 metadata:
-  version: 2.4.1
+  version: 2.5.0
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -79,6 +79,7 @@ If `origin` is missing or rebase conflicts occur, stop and ask (interactive) or 
 
 Load `.gitissue.yml` once. Defaults (full semantics in `references/docs/config-schema.md`):
 - `review.max_cycles: 3` — 3 LLM cycles suffice once the script pre-pass handles mechanical issues
+- `review.adaptive_depth: true` — scale review depth to the PR's complexity (see *Step 1 — Depth gate*). When `false`, every PR gets full-depth review (profile pinned to `full`).
 - `review.auto_merge: false` (overridden to `true` in auto mode)
 - `review.confidence_threshold: 80`
 - `review.run_tests: true`, `review.check_ci: true`
@@ -99,7 +100,7 @@ UI/UX **code** review needs no config flag — it is auto-detected per PR (*Step
 ```
   ◆ PR Review Pipeline
   ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
-  [1/7] PR Info      ✓ PR #87: fix(auth): resolve redirect (#42)
+  [1/7] PR Info      ✓ PR #87: fix(auth): resolve redirect (#42), depth: full
   [2/7] Pre-pass     ✓ lint clean, format clean, 17 tests passed
   [3/7] Review       ● analyzing changes...
   [4/7] Test         ✓ 17 tests passed, build ok
@@ -158,6 +159,43 @@ gh pr checkout {N}
 ```
 
 Use `{headRefName}` from Step 1 as `{branch_name}` for sync, commit, and push. Canonical command: `references/docs/platform-github.md` (*Pull requests* → Checkout PR head branch).
+
+### Depth gate (select the review profile)
+
+Decide **how deep** this review goes, so a one-line copy fix is not put through
+the same full-weight review as a multi-subsystem PR. The mechanism and the shared
+`XS … XL` scale it reuses are defined once in `references/docs/agent-model-effort.md`
+(*Complexity → pipeline profile*); this skill has no researcher, so it derives its
+own **pre-work** complexity signal from data already fetched in Step 1.
+
+When `review.adaptive_depth` is `false`, skip the gate: set `profile = full` and
+review at full depth as before. Otherwise compute the signal from the PR itself
+and take the **fuller** of any inputs that disagree (a "trivial" issue whose diff
+ballooned still earns full review):
+
+- **Diff size / files-changed** — from `statusCheckRollup`/`files` in Step 1
+  (`gh pr view {N} --json files`). Small (e.g. ≤ ~15 changed lines across 1 file)
+  leans `light`; larger leans `full`.
+- **Linked-issue `Effort` band** — when the PR links an issue (`Closes #N`), fetch
+  its `## Metadata` `Effort` (`gh issue view {N} --json body`). `XS`/`S` asserted
+  leans `light`; `M`/`L`/`XL`, or low-confidence, leans `full`.
+- **Labels** — a `security`/`CVE`/`vulnerability` label (case-insensitive) forces
+  `full` regardless of size (security-sensitive changes always get full review).
+
+Resolve to `profile = light` only when **every** available signal agrees on
+trivial; if any signal says `full`, or a signal is missing/ambiguous, use `full`
+(ambiguous → fuller). Surface the decision on the `[1/7]` tracker line:
+
+```
+[1/7] PR Info      ✓ PR #{N}: {title}
+                     {files_count} files changed, base: {base_branch}, depth: {profile}
+```
+
+`{profile}` is `light` or `full`. When `review.adaptive_depth` is `false`, still
+print `depth: full` so the line is uniform. The `light` profile scales the Review
+Loop only — see *Review Loop* (`light` caps cycles at 1 and skips optional passes;
+the acceptance-criteria and traceability hard-blocks always run at full strength).
+Full mechanics in `references/review-loop-mechanics.md` (*Depth gate*).
 
 ---
 
@@ -328,7 +366,16 @@ Cycle {N}:
 After Step 6, go back to Step 3 — but reuse the same reviewer agent via `SendMessage` (not a fresh spawn). Only spawn fresh for the confirmation pass.
 
 **Loop controls:**
-- **Max cycles:** `review.max_cycles` (default: 3)
+- **Max cycles:** `review.max_cycles` (default: 3). **`light` profile (Step 1
+  Depth gate) caps this at 1** — one review pass, one fix cycle if `action: "fix"`
+  issues are found, then the confirmation pass and exit. The reviewer still runs
+  on the `light` path (depth reduced, review never skipped); only the number of
+  review-fix iterations is capped. `full` uses `review.max_cycles` as before.
+- **`light` profile — optional passes:** the `light` depth skips the optional
+  browser UI review (the code UI review still auto-detects and runs when UI work
+  is present) and does not spin extra confirmation cycles. The two #36
+  hard-blocks — `acceptance_criteria: fail` and missing `Closes #N` — **still run
+  at full strength** on every profile; the fast path never relaxes them.
 - **Agent reuse:** Cycles 2+ reuse the existing reviewer and fixer agents. Fresh spawn only for the confirmation pass after fixer reports zero issues.
 - **Soft pass (when `review.soft_pass: true`, default):** Stop when ALL hold: zero `action: "fix"` issues remain AND (tests pass or `review.run_tests: false`) AND (CI passes, no CI configured, or `review.check_ci: false`) AND traceability is not `fail`. Medium `note` issues and `partial` dimensions are report-only — they do not block.
 - **Strict pass (when `review.soft_pass: false`):** Apply the same tests/CI gates, then require zero `action: "fix"` findings, zero remaining `action: "note"` findings, and `pass` for every enabled dimension. A `partial` dimension or any note is a strict blocker: exit the fix loop, report it under Remaining, and do not report clean or merge. Notes never become fixer inputs — Step 6 still fixes only `action: "fix"` — so strict mode surfaces these for manual remediation rather than looping without a fixable action.

--- a/skills/issue-pr-review/references/docs/agent-model-effort.md
+++ b/skills/issue-pr-review/references/docs/agent-model-effort.md
@@ -70,3 +70,97 @@ For each spawned step the orchestrator should:
 
 Selection is bounded by the same cost-awareness as model suggestion: prefer the
 lowest tier that can do the step correctly.
+
+## Complexity → pipeline profile
+
+Model/effort selection above is **advisory** — it tunes *how hard* each agent
+thinks but never changes *which* steps run. The **pipeline profile** is a
+distinct, second mechanism layered on the **same `XS … XL` scale**: it scales
+*how much pipeline runs* — which optional steps fire, how many QA/review cycles
+are allowed — so a trivial one-character edit does not pay the full
+orchestration cost of a multi-subsystem change. Unlike model/effort, the profile
+**does** change control flow (it can collapse a step or cap a loop), so it is a
+**gated** control, not advisory. The two are independent: model/effort sizes the
+agents a step spawns; the profile decides whether the lighter-weight step runs at
+all. They share the scale and nothing else — do **not** invent a second
+classifier for the profile.
+
+### The two profiles
+
+| Profile | Effort band | Intent |
+|---------|-------------|--------|
+| **light** | XS, S | Trivial/small work — collapse optional phases, cap the review-fix loop to one cycle. |
+| **full**  | M, L, XL | Everything today runs unchanged — the current pipeline in full. |
+
+The profile is a **coarse** switch (two states), deliberately not one profile per
+band: the goal is a fast path for the long tail of trivial work, not five
+gradations. Model/effort selection already provides the fine-grained,
+per-agent scaling within either profile.
+
+### Selecting the profile (pre-work signal)
+
+The profile is chosen from a **pre-work** signal — before the first expensive
+subagent spawn — so the saving is real. If the profile were derived from an
+agent's *output* (e.g. the researcher's `complexity`), the dominant cost would
+already be paid before the decision, and the fast path would save almost nothing.
+The pre-work signal is the issue's **`Effort` band** in its `## Metadata` section
+(the `XS … XL` value written by `/issue-creator`, the same scale this whole
+document uses).
+
+Resolve the profile from that band, **erring toward `full` whenever the signal
+is weak**:
+
+| Condition on the pre-work signal | Profile |
+|----------------------------------|---------|
+| `Effort` is `M`, `L`, or `XL` | **full** |
+| `Effort` is `XS` or `S` **and** asserted (not low-confidence) | **light** |
+| `Effort` is `XS`/`S` but marked `(needs review)` / low-confidence | **full** (ambiguous → fuller) |
+| `Effort` is absent / unparseable | **full** (safe default) |
+
+The low-confidence and absent rows are the safety contract: an uncertain estimate
+must never under-serve a task that turns out to be hard. A skill **may** refine
+the profile *upward* once a stronger signal arrives (e.g. the researcher reports
+`high`/`complex` on what the band called `S`) — never downward. Downgrading on a
+mid-pipeline signal would defeat the pre-work guarantee and risk truncating work
+already deep in the full path.
+
+### What each consuming skill does with the profile
+
+This document defines the *scale → profile* mapping and the pre-work-signal rule;
+each skill owns exactly *which* of its steps the `light` profile collapses (its
+pipeline reference spells out the per-step mechanics):
+
+- **`/issue-resolver`** — `light` keeps a **lighter** Research step (the
+  already-resolved safety check still runs), skips the 3-option synthesis in Plan
+  (a direct minimal plan is used), skips the interactive propose-relevant-skills
+  sub-step, and caps QA at **one** cycle. Implement and Deliver are unchanged, and
+  the durable PR artifacts (Decision Record + Acceptance Criteria Verification
+  table) are **always** emitted — the profile never removes durable memory.
+- **`/issue-pr-review`** — has no researcher, so it derives its own pre-work
+  signal (diff size / files-changed / labels / linked-issue `Effort`, taking the
+  **fuller** of any that disagree) and scales review **depth** — the `light`
+  profile caps the review-fix loop to one cycle and skips optional passes, while
+  the acceptance-criteria and traceability hard-blocks still run at full strength.
+
+### Surfacing the profile (transparency)
+
+The chosen profile is **surfaced to the user** wherever the skill already reports
+progress, so the effort decision is transparent and reviewable — never a hidden
+downgrade:
+
+- On the pipeline **tracker line** for the step where it is decided (e.g. the
+  resolver's `[0/5] Preflight` line names `effort: light` or `effort: full`).
+- In the **run log** (`.gitissue/runs.jsonl`) as the optional `profile` field, so
+  `/idd-doctor` and audits can see how often the fast path fired (see
+  `references/docs/config-schema.md`).
+
+### Opting out
+
+Each consuming skill exposes an explicit off-switch so a maintainer can force the
+full pipeline on every issue regardless of band: `resolve.adaptive_effort`
+(default `true`) for `/issue-resolver` and `review.adaptive_depth` (default
+`true`) for `/issue-pr-review`. When the switch is `false`, the skill behaves
+exactly as it did before this mechanism existed — the profile is pinned to
+`full`. Defaults are **on** so zero-config users get the fast path for trivial
+work automatically; the switch exists for maintainers who prefer uniform
+full-treatment (see `references/docs/config-schema.md`).

--- a/skills/issue-pr-review/references/docs/config-schema.md
+++ b/skills/issue-pr-review/references/docs/config-schema.md
@@ -123,6 +123,23 @@ resolve:
   # Maximum: 10
   qa_max_cycles: 5
 
+  # Scale the resolve pipeline to each issue's complexity (adaptive effort).
+  # Type: boolean
+  # Default: true
+  # When true, trivial issues (pre-work Effort band XS/S, asserted) take a
+  # lighter, faster, lower-token path: a lighter Research step (the
+  # already-resolved safety check still runs), the 3-option synthesis in Plan is
+  # skipped for a direct minimal plan, the propose-relevant-skills sub-step is
+  # skipped, and QA is capped at 1 cycle. The Decision Record and Acceptance
+  # Criteria Verification table are always emitted regardless. Complex or
+  # ambiguous issues (M/L/XL, low-confidence, or no band) keep the full pipeline.
+  # When false, every issue gets the full pipeline as before — the profile is
+  # pinned to "full". The chosen profile is surfaced on the [0/5] tracker line
+  # and in the run log's `profile` field. See
+  # https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md
+  # (Complexity → pipeline profile).
+  adaptive_effort: true
+
   # UI/UX review settings (Step 4 — QA)
   # Code-level UI review is auto-detected per issue and always runs when UI
   # work is present; it needs no flag and runs in any environment (including
@@ -145,6 +162,21 @@ review:
   # Minimum: 1
   # Maximum: 10
   max_cycles: 3
+
+  # Scale review depth to each PR's complexity (adaptive depth).
+  # Type: boolean
+  # Default: true
+  # When true, /issue-pr-review derives a pre-work complexity signal from the PR
+  # (diff size, files-changed, labels, and the linked issue's Effort band — the
+  # fuller of any that disagree) and, for a trivial PR, caps the review-fix loop
+  # at 1 cycle and skips optional passes. The acceptance-criteria and
+  # traceability hard-blocks always run at full strength. Complex or ambiguous
+  # PRs keep the full max_cycles depth. When false, every PR gets full review
+  # depth as before — the profile is pinned to "full". The chosen depth is
+  # surfaced on the [1/7] tracker line. See
+  # https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md
+  # (Complexity → pipeline profile).
+  adaptive_depth: true
 
   # Auto-merge PR when clean (overridden to true in --auto mode)
   # Type: boolean
@@ -464,8 +496,10 @@ graph TD
     RS --> R5["pr_auto_link"]
     RS --> R6["max_commits"]
     RS --> R7["qa_max_cycles"]
+    RS --> R8["adaptive_effort"]
 
     RV --> RV1["max_cycles"]
+    RV --> RV14["adaptive_depth"]
     RV --> RV2["auto_merge"]
     RV --> RV3["confidence_threshold"]
     RV --> RV4["run_tests"]
@@ -540,6 +574,7 @@ Each line carries at minimum a **timestamp, issue number, mode, outcome**, and t
 | `outcome` | string | yes | Terminal outcome. Resolver: `success`, `already_resolved`, `failed`. Auto-pilot: one of its six categorical outcomes (`merged`, `left_open`, `partial_followup`, `blocked_by_dependency`, `failed`, `skipped`). |
 | `pr` | integer or null | yes | PR number when a PR was created, else `null` |
 | `complexity` | string | no | Research complexity on the **3-value** run-log scale (`low` / `medium` / `high`) when known. Collapse the researcher's 5-value estimate before writing: `trivial` or `low` → `low`; `medium` → `medium`; `high` or `complex` → `high`. Never emit `trivial` or `complex` in runs.jsonl. |
+| `profile` | string | no | The adaptive-effort pipeline profile the run selected: `light` (trivial fast path) or `full`. Omitted when `resolve.adaptive_effort` is `false` or the signal was unavailable. Lets `/idd-doctor` and audits see how often the fast path fired. See [agent-model-effort.md](https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md) (Complexity → pipeline profile). |
 | `qa_cycles` | integer | no | Number of QA review-fix cycles run (resolver) |
 | `duration_s` | integer | no | Wall-clock duration of the run in seconds, when measurable |
 | `skipped_reason` | string | no | Why the issue was skipped (auto-pilot skips, and any `skipped`/`already_resolved` outcome), e.g. `already_resolved`, `blocked_label`, `blocked_by_dependency`, `in_skip_list`, `assigned_to_other` |
@@ -547,7 +582,8 @@ Each line carries at minimum a **timestamp, issue number, mode, outcome**, and t
 Example lines:
 
 ```jsonl
-{"ts":"2026-06-26T14:31:07Z","issue":141,"mode":"auto","skill":"issue-resolver","complexity":"medium","qa_cycles":2,"outcome":"success","pr":150,"duration_s":372}
+{"ts":"2026-06-26T14:31:07Z","issue":141,"mode":"auto","skill":"issue-resolver","complexity":"medium","profile":"full","qa_cycles":2,"outcome":"success","pr":150,"duration_s":372}
+{"ts":"2026-06-26T15:02:41Z","issue":152,"mode":"auto","skill":"issue-resolver","complexity":"low","profile":"light","qa_cycles":1,"outcome":"success","pr":161,"duration_s":94}
 {"ts":"2026-06-26T14:48:12Z","issue":118,"mode":"balanced","skill":"auto-pilot","outcome":"skipped","pr":null,"skipped_reason":"blocked_by_dependency"}
 ```
 
@@ -649,8 +685,11 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `resolve.test_timeout` | `300` | 5 minute test timeout |
 | *(removed)* `resolve.pr_auto_link` | — | Deprecated; `Closes #N` is unconditional per SPEC §5.1 |
 | `resolve.max_commits` | `10` | Max commits warning |
+| `resolve.qa_max_cycles` | `5` | Max QA review-fix cycles during resolve Step 4 |
+| `resolve.adaptive_effort` | `true` | Scale the resolve pipeline to issue complexity — trivial issues (Effort XS/S) take a lighter path (lighter Research, skip 3-option Plan, skip propose-skills, QA capped at 1 cycle); `false` pins every issue to the full pipeline ([agent-model-effort.md](https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md)) |
 | `resolve.ui_review.browser_review` | `"ask"` | Browser (screenshot) UI review mode; code UI review is auto-detected and always runs |
 | `review.max_cycles` | `3` | Max review-fix cycles |
+| `review.adaptive_depth` | `true` | Scale review depth to PR complexity — a trivial PR caps the review-fix loop at 1 cycle and skips optional passes (AC + traceability hard-blocks still run); `false` pins every PR to full depth ([agent-model-effort.md](https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md)) |
 | `review.auto_merge` | `false` | Auto-merge PR when clean |
 | `review.confidence_threshold` | `80` | Min confidence level for issues |
 | `review.run_tests` | `true` | Run tests during review |

--- a/skills/issue-pr-review/references/docs/config-schema.md
+++ b/skills/issue-pr-review/references/docs/config-schema.md
@@ -84,6 +84,10 @@ resolve:
   # Default: "auto"
   # "auto": proceed immediately after planning
   # "comment-and-wait": show plan and wait for user approval
+  # Note: with resolve.adaptive_effort: true (default), a light-profile (trivial
+  #   XS/S) issue proceeds on a direct minimal plan without the option prompt —
+  #   it produces no 3-option comparison to wait on. Set adaptive_effort: false
+  #   to force the approval wait on every issue regardless of complexity.
   approval_gate: auto
 
   # Branch naming prefix

--- a/skills/issue-pr-review/references/report-templates.md
+++ b/skills/issue-pr-review/references/report-templates.md
@@ -175,7 +175,7 @@ In interactive mode: never auto-merge — just report status.
 A clean review prints the 7-step tracker and a summary:
 
 ```
-  [1/7] PR Info       ✓ #87 fix(auth): resolve redirect (#42)
+  [1/7] PR Info       ✓ #87 fix(auth): resolve redirect (#42), depth: full
   [2/7] Script Pre    ✓ 3 lint fixes applied
   [3/7] Review        ✓ spec[ac:pass correctness:pass safety:pass]
                         standards[trace:pass maint:pass]

--- a/skills/issue-pr-review/references/review-loop-mechanics.md
+++ b/skills/issue-pr-review/references/review-loop-mechanics.md
@@ -2,6 +2,50 @@
 
 Exact spawn calls and the token-trade rationale for the reviewer/fixer agents used in Step 3 and the Review Loop of `/issue-pr-review`. SKILL.md keeps the summary (cold start → SendMessage re-review → fresh confirmation); this file holds the detail.
 
+## Depth gate (adaptive review depth)
+
+The Step 1 *Depth gate* selects a review `profile` — `light` or `full` — from a
+pre-work complexity signal, so a trivial PR is not reviewed as deeply as a
+multi-subsystem one. The mechanism and the shared `XS … XL` scale live in
+`references/docs/agent-model-effort.md` (*Complexity → pipeline profile*); this section is
+only how the review loop consumes the result.
+
+**Selecting the signal (no researcher here).** Unlike `/issue-resolver`,
+`/issue-pr-review` has no research subagent, so it derives the signal from data
+already fetched in Step 1 and takes the **fuller** of any inputs that disagree:
+
+- **Diff size / files-changed** (`gh pr view {N} --json files`) — small change
+  (≈ ≤ 15 changed lines in 1 file) leans `light`.
+- **Linked-issue `Effort` band** — when the PR body has `Closes #N`, read that
+  issue's `## Metadata` `Effort` (`gh issue view {N} --json body`); `XS`/`S`
+  asserted leans `light`, `M`/`L`/`XL` or low-confidence leans `full`.
+- **Security label** — any `security`/`CVE`/`vulnerability` label forces `full`.
+
+Resolve to `light` **only when every available signal agrees on trivial**; any
+`full` vote, or a missing/ambiguous signal, wins → `full`. When
+`review.adaptive_depth` is `false`, the gate is skipped and `profile = full`.
+
+**What `light` changes in the loop:**
+
+| Aspect | `full` (default) | `light` |
+|--------|------------------|---------|
+| Review-fix cycle cap | `review.max_cycles` (3) | **1** |
+| Optional browser UI review | runs when opted in + reachable | skipped |
+| Code UI review (auto-detected) | runs when UI work present | runs when UI work present (unchanged) |
+| AC + traceability hard-blocks | full strength | **full strength (unchanged)** |
+| Reviewer spawn | yes | yes (depth reduced, never skipped) |
+
+The `light` cap of 1 is a **ceiling that wins** — it is the effective cycle limit
+regardless of the configured value, i.e. `min(1, configured_cap)`. This matters
+under `/auto-pilot`, which overrides `review.max_cycles` with its `review_cycles`
+value (default 3): on the `light` path the effective cap is still **1**, never the
+overridden 3. The cap governs **only** the loop iteration count; the cold-start
+reviewer, the fixer, and the fresh confirmation pass below all still apply — a
+`light` review is one review pass + at most one fix + confirmation, not a skipped
+review. The two #36 hard-blocks (`acceptance_criteria: fail`, missing
+`Closes #N`) are never relaxed by the profile — a trivial PR that fails them still
+blocks soft-pass and does not merge.
+
 ## Why reuse the reviewer
 
 To minimize token usage, the review loop **reuses the same reviewer agent** across fix cycles instead of spawning a fresh one each time. The reviewer already has the codebase context loaded, so subsequent reviews are cheaper.

--- a/skills/issue-resolver/SKILL.md
+++ b/skills/issue-resolver/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Requires git and GitHub CLI (gh) with authentication and push access. Self-contained — uses shared agents from shared/agents/."
 effort: max
 metadata:
-  version: 0.16.1
+  version: 0.17.0
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -73,6 +73,7 @@ Defaults (full field reference in `references/docs/config-schema.md`):
 - `resolve.test_timeout: 300`
 - `resolve.max_commits: 10`
 - `resolve.qa_max_cycles: 5`
+- `resolve.adaptive_effort: true` — scale the pipeline to the issue's complexity (see *Step 0g — Complexity gate*). When `false`, every issue runs the full pipeline (profile pinned to `full`).
 - `resolve.ui_review.browser_review: "ask"` — gates only the optional browser/screenshot review; the code-level UI review (*Step 4 — UI/UX review*) is auto-detected and always runs.
 
 ---
@@ -162,7 +163,7 @@ The resolve pipeline has 6 steps (0-5). Display progress using the `[N/5]` step 
 ```
   ◆ Resolve Pipeline
   ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
-  [0/5] Preflight    ✓ issue #42 open, not yet resolved
+  [0/5] Preflight    ✓ issue #42 open, not yet resolved, effort: full
   [1/5] Research     ✓ read 12 files, complexity: medium
   [2/5] Plan         ✓ option 2 selected: balanced refactor
   [3/5] Implement    ✓ 3 files changed, 8 unit tests, 2 e2e tests
@@ -295,18 +296,61 @@ a custom prefix is used verbatim as `{configured-prefix}{N}-{short-description}`
 - Interactive mode: ask `continue` or `fresh`
 - Auto mode: `continue` (checkout existing branch)
 
-After preflight:
+### 0g — Complexity gate (select the pipeline profile)
+
+Decide **before Step 1** how much pipeline this issue earns, so a trivial edit
+does not pay the full orchestration cost. The mechanism, the shared `XS … XL`
+scale it reuses, and the safety rules are defined once in
+`references/docs/agent-model-effort.md` (*Complexity → pipeline profile*) — apply that
+document here; this sub-step is only the resolver's entry point into it.
+
+When `resolve.adaptive_effort` is `false`, skip the gate entirely: set
+`profile = full` and continue exactly as before. Otherwise select the profile
+from the issue's **pre-work `Effort` band** (the `XS … XL` value in the issue's
+`## Metadata`, written by `/issue-creator`) — never from a later agent output, so
+the saving is real:
+
+- `Effort` `XS`/`S`, asserted (not `(needs review)`/low-confidence) → `profile = light`
+- `Effort` `M`/`L`/`XL` → `profile = full`
+- `Effort` `XS`/`S` but low-confidence, **or** absent/unparseable → `profile = full` (ambiguous → fuller)
+
+The `light` profile changes later steps as follows (each step restates its own
+behavior; the full per-step mechanics are in `references/pipeline-steps.md`):
+
+- **Step 1 Research** — lighter scan, but the already-resolved safety check still runs.
+- **Step 2 Plan** — skip the 3-option synthesis; use a direct minimal plan.
+- **Step 3** — skip the interactive *Propose relevant skills* sub-step.
+- **Step 4 QA** — cap the review-fix loop at **1** cycle (overrides `resolve.qa_max_cycles`).
+
+`full` leaves every step exactly as it is today. Either way, **Deliver (Step 5)
+always emits the Decision Record and Acceptance Criteria Verification table** —
+the profile never removes durable memory.
+
+The profile may only be **revised upward** later (e.g. Step 1 research reports
+`high`/`complex` on what the band called `S` → switch to `full` for the remaining
+steps); never downgrade a `full` run to `light` mid-pipeline.
+
+After preflight (surface the chosen profile so the effort decision is transparent):
 ```
-[0/5] Preflight    ✓ issue #N open, branch: {branch_name}{workspace_note}
+[0/5] Preflight    ✓ issue #N open, branch: {branch_name}{workspace_note}, effort: {profile}
 ```
 
-`{workspace_note}` is ` (worktree)` in a worktree, empty otherwise.
+`{workspace_note}` is ` (worktree)` in a worktree, empty otherwise. `{profile}`
+is `light` or `full`. When `resolve.adaptive_effort` is `false`, still print
+`effort: full` (the pinned profile) so the line is uniform.
 
 ---
 
 ## Step 1 — Research
 
 Deeply understand the issue, affected codebase, and possible solutions; also verifies the issue hasn't already been fixed (early-exit path closes it in auto mode). Spawn the researcher (`references/agents/codebase-researcher.md`) with the canonical pattern — full delegation payload, phases, early-exit behavior, and inline fallback are in `references/pipeline-steps.md` (*Step 1 — Research*).
+
+**`light` profile:** run a **lighter** research pass — the already-resolved
+safety check and a focused scan of the obviously-affected file(s) still run, but
+skip the broad dependency trace and external solution research (a trivial edit
+does not need them). If this lighter pass nonetheless surfaces `high`/`complex`
+signals, revise the profile **upward** to `full` for the remaining steps (never
+downward) — see *Step 0g* and `references/pipeline-steps.md` (*Step 1 — Research*).
 
 After research:
 ```
@@ -322,6 +366,14 @@ Generate implementation options and select one. Spawn the synthesizer (`referenc
 It returns 3 options — minimal / balanced / comprehensive — with the balanced option usually recommended.
 
 Selection behavior (interactive auto, interactive comment-and-wait, auto-pilot) and inline fallback are in `references/pipeline-steps.md` (*Step 2 — Plan*).
+
+**`light` profile:** skip the 3-option synthesis entirely — do **not** spawn the
+synthesizer. Derive a **direct minimal plan** inline (the single obvious change
+that satisfies the acceptance criteria) and record it as the selected option, so
+the Decision Record still has a real `Selected option` to lift in Step 5. The
+design-confirm checkpoint does not apply (it is high-complexity only, which the
+`light` path is not). Full procedure in `references/pipeline-steps.md`
+(*Step 2 — Plan → `light` profile*).
 
 After plan selection:
 ```
@@ -355,6 +407,11 @@ relevant subset, let the user accept all/some/none into `selected_skills` — th
 implementer always falls back to internal agents, so selecting none is unchanged
 behavior. Full procedure in `references/pipeline-steps.md` (*Step 3 — Propose relevant skills*).
 
+**`light` profile:** skip this sub-step — set `selected_skills = []` and proceed
+straight to the implementer (a trivial edit does not warrant the extra prompt).
+This mirrors the auto-mode behavior; the implementer's internal-agent fallback is
+unchanged.
+
 Write code and tests based on the selected plan. Spawn the implementer (`references/agents/implementer.md`) with the canonical pattern, passing the plan, branch name, naming conventions, and `selected_skills`.
 
 For **bug** issues, the implementer first runs the red-capable reproduction checkpoint — reproduce the symptom, confirm it fails red, fix, then convert to a regression test. Surfaced as evidence in the PR Decision Record and acceptance table. Non-bug issues skip it; auto mode never blocks. See `references/bug-verification.md`.
@@ -386,6 +443,11 @@ UI review is **auto-detected per issue** — no config flag enables it. Scan the
 - **Browser UI review** — optional screenshots from a running app; runs only when reachable *and* opted in, else **skips with a warning, code UI review still runs** — fail-soft.
 
 Detection rules, `ui-reviewer` spawns, the `resolve.ui_review.browser_review` gate, and skip/success messages are in `references/pipeline-steps.md` (*Step 4 — UI/UX review*). Cycle mechanics and loop controls (`resolve.qa_max_cycles`, exit-on-clean, exit-on-stagnation) are in the same file (*Step 4 — QA*).
+
+**`light` profile:** cap the review-fix loop at **1** cycle (a single review pass;
+fix once if blocking issues are found, then deliver) instead of
+`resolve.qa_max_cycles`. One reviewer spawn still runs — the fast path reduces
+depth, it does not skip review. UI review remains auto-detected as usual.
 
 ---
 
@@ -445,18 +507,20 @@ already fixed (`already_resolved`), or a failed step (`failed`) — append exact
 (see *Suppression rule*), in which case append **nothing** and return the
 telemetry to the caller instead. Build the object from values already known
 (`ts`, `issue`, `mode`, `skill`, `outcome`, `pr`, plus optional `complexity`,
-`qa_cycles`, `duration_s`, `skipped_reason`) per the schema in
+`profile`, `qa_cycles`, `duration_s`, `skipped_reason`) per the schema in
 `references/docs/config-schema.md` (*`.gitissue/runs.jsonl` — run log*). Collapse researcher
 complexity to the 3-value run-log scale before writing (`trivial`/`low`→`low`,
-`medium`→`medium`, `high`/`complex`→`high`).
+`medium`→`medium`, `high`/`complex`→`high`). Set `profile` to the pipeline profile
+chosen in *Step 0g* (`light` or `full`); omit it only when `resolve.adaptive_effort`
+is `false` or no profile was selected (e.g. an early failure before Step 0g).
 
 > **Suppression rule (single writer under `/auto-pilot`).** `--no-run-log` is
 > passed only by `/auto-pilot`, which runs this resolver as a subagent and writes
 > the **single** run-log line per issue itself — appending here too would
 > double-write and skew `/idd-doctor`'s metrics. Instead **return** the telemetry
-> (`outcome`, `qa_cycles`, `complexity`, `duration_s`) in the subagent result so
-> the orchestrator folds it into its own line. Independent of `--auto`: a
-> standalone `/issue-resolver <N> --auto` is *not* suppressed and still writes.
+> (`outcome`, `qa_cycles`, `complexity`, `profile`, `duration_s`) in the subagent
+> result so the orchestrator folds it into its own line. Independent of `--auto`:
+> a standalone `/issue-resolver <N> --auto` is *not* suppressed and still writes.
 
 ```bash
 # Only when --no-run-log is NOT set:
@@ -493,6 +557,7 @@ When invoked with `--auto` (or by `/auto-pilot`), the entire pipeline runs witho
 
 - **Environment:** Export `IDD_AUTO_MODE=1` before any shell snippet that consults it (`references/docs/pre-commit-security.md`).
 - **Workspace:** Always in-place. Skip Step 0e entirely — no `git worktree add` on the default resolution path. Run mandatory Repo Sync, then *0f — Create branch*.
+- **Complexity gate:** *Step 0g* runs in auto mode too — it reads the pre-work `Effort` band (no prompt) and selects `light`/`full` the same way, so trivial issues resolve on the fast path autonomously. Under `/auto-pilot` the selected `profile` is **returned** in the telemetry (with `--no-run-log`) and folded into auto-pilot's single run-log line; a standalone `--auto` run writes `profile` itself.
 - **Preflight:** Skip assignment guard. Log blocking labels as warnings, don't stop.
 - **Research:** If already resolved, close the issue with a comment and exit cleanly.
 - **Plan:** Auto-select the recommended option; design-confirm never appears — log the selection and proceed.

--- a/skills/issue-resolver/references/docs/agent-model-effort.md
+++ b/skills/issue-resolver/references/docs/agent-model-effort.md
@@ -70,3 +70,97 @@ For each spawned step the orchestrator should:
 
 Selection is bounded by the same cost-awareness as model suggestion: prefer the
 lowest tier that can do the step correctly.
+
+## Complexity → pipeline profile
+
+Model/effort selection above is **advisory** — it tunes *how hard* each agent
+thinks but never changes *which* steps run. The **pipeline profile** is a
+distinct, second mechanism layered on the **same `XS … XL` scale**: it scales
+*how much pipeline runs* — which optional steps fire, how many QA/review cycles
+are allowed — so a trivial one-character edit does not pay the full
+orchestration cost of a multi-subsystem change. Unlike model/effort, the profile
+**does** change control flow (it can collapse a step or cap a loop), so it is a
+**gated** control, not advisory. The two are independent: model/effort sizes the
+agents a step spawns; the profile decides whether the lighter-weight step runs at
+all. They share the scale and nothing else — do **not** invent a second
+classifier for the profile.
+
+### The two profiles
+
+| Profile | Effort band | Intent |
+|---------|-------------|--------|
+| **light** | XS, S | Trivial/small work — collapse optional phases, cap the review-fix loop to one cycle. |
+| **full**  | M, L, XL | Everything today runs unchanged — the current pipeline in full. |
+
+The profile is a **coarse** switch (two states), deliberately not one profile per
+band: the goal is a fast path for the long tail of trivial work, not five
+gradations. Model/effort selection already provides the fine-grained,
+per-agent scaling within either profile.
+
+### Selecting the profile (pre-work signal)
+
+The profile is chosen from a **pre-work** signal — before the first expensive
+subagent spawn — so the saving is real. If the profile were derived from an
+agent's *output* (e.g. the researcher's `complexity`), the dominant cost would
+already be paid before the decision, and the fast path would save almost nothing.
+The pre-work signal is the issue's **`Effort` band** in its `## Metadata` section
+(the `XS … XL` value written by `/issue-creator`, the same scale this whole
+document uses).
+
+Resolve the profile from that band, **erring toward `full` whenever the signal
+is weak**:
+
+| Condition on the pre-work signal | Profile |
+|----------------------------------|---------|
+| `Effort` is `M`, `L`, or `XL` | **full** |
+| `Effort` is `XS` or `S` **and** asserted (not low-confidence) | **light** |
+| `Effort` is `XS`/`S` but marked `(needs review)` / low-confidence | **full** (ambiguous → fuller) |
+| `Effort` is absent / unparseable | **full** (safe default) |
+
+The low-confidence and absent rows are the safety contract: an uncertain estimate
+must never under-serve a task that turns out to be hard. A skill **may** refine
+the profile *upward* once a stronger signal arrives (e.g. the researcher reports
+`high`/`complex` on what the band called `S`) — never downward. Downgrading on a
+mid-pipeline signal would defeat the pre-work guarantee and risk truncating work
+already deep in the full path.
+
+### What each consuming skill does with the profile
+
+This document defines the *scale → profile* mapping and the pre-work-signal rule;
+each skill owns exactly *which* of its steps the `light` profile collapses (its
+pipeline reference spells out the per-step mechanics):
+
+- **`/issue-resolver`** — `light` keeps a **lighter** Research step (the
+  already-resolved safety check still runs), skips the 3-option synthesis in Plan
+  (a direct minimal plan is used), skips the interactive propose-relevant-skills
+  sub-step, and caps QA at **one** cycle. Implement and Deliver are unchanged, and
+  the durable PR artifacts (Decision Record + Acceptance Criteria Verification
+  table) are **always** emitted — the profile never removes durable memory.
+- **`/issue-pr-review`** — has no researcher, so it derives its own pre-work
+  signal (diff size / files-changed / labels / linked-issue `Effort`, taking the
+  **fuller** of any that disagree) and scales review **depth** — the `light`
+  profile caps the review-fix loop to one cycle and skips optional passes, while
+  the acceptance-criteria and traceability hard-blocks still run at full strength.
+
+### Surfacing the profile (transparency)
+
+The chosen profile is **surfaced to the user** wherever the skill already reports
+progress, so the effort decision is transparent and reviewable — never a hidden
+downgrade:
+
+- On the pipeline **tracker line** for the step where it is decided (e.g. the
+  resolver's `[0/5] Preflight` line names `effort: light` or `effort: full`).
+- In the **run log** (`.gitissue/runs.jsonl`) as the optional `profile` field, so
+  `/idd-doctor` and audits can see how often the fast path fired (see
+  `references/docs/config-schema.md`).
+
+### Opting out
+
+Each consuming skill exposes an explicit off-switch so a maintainer can force the
+full pipeline on every issue regardless of band: `resolve.adaptive_effort`
+(default `true`) for `/issue-resolver` and `review.adaptive_depth` (default
+`true`) for `/issue-pr-review`. When the switch is `false`, the skill behaves
+exactly as it did before this mechanism existed — the profile is pinned to
+`full`. Defaults are **on** so zero-config users get the fast path for trivial
+work automatically; the switch exists for maintainers who prefer uniform
+full-treatment (see `references/docs/config-schema.md`).

--- a/skills/issue-resolver/references/docs/config-schema.md
+++ b/skills/issue-resolver/references/docs/config-schema.md
@@ -123,6 +123,23 @@ resolve:
   # Maximum: 10
   qa_max_cycles: 5
 
+  # Scale the resolve pipeline to each issue's complexity (adaptive effort).
+  # Type: boolean
+  # Default: true
+  # When true, trivial issues (pre-work Effort band XS/S, asserted) take a
+  # lighter, faster, lower-token path: a lighter Research step (the
+  # already-resolved safety check still runs), the 3-option synthesis in Plan is
+  # skipped for a direct minimal plan, the propose-relevant-skills sub-step is
+  # skipped, and QA is capped at 1 cycle. The Decision Record and Acceptance
+  # Criteria Verification table are always emitted regardless. Complex or
+  # ambiguous issues (M/L/XL, low-confidence, or no band) keep the full pipeline.
+  # When false, every issue gets the full pipeline as before — the profile is
+  # pinned to "full". The chosen profile is surfaced on the [0/5] tracker line
+  # and in the run log's `profile` field. See
+  # https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md
+  # (Complexity → pipeline profile).
+  adaptive_effort: true
+
   # UI/UX review settings (Step 4 — QA)
   # Code-level UI review is auto-detected per issue and always runs when UI
   # work is present; it needs no flag and runs in any environment (including
@@ -145,6 +162,21 @@ review:
   # Minimum: 1
   # Maximum: 10
   max_cycles: 3
+
+  # Scale review depth to each PR's complexity (adaptive depth).
+  # Type: boolean
+  # Default: true
+  # When true, /issue-pr-review derives a pre-work complexity signal from the PR
+  # (diff size, files-changed, labels, and the linked issue's Effort band — the
+  # fuller of any that disagree) and, for a trivial PR, caps the review-fix loop
+  # at 1 cycle and skips optional passes. The acceptance-criteria and
+  # traceability hard-blocks always run at full strength. Complex or ambiguous
+  # PRs keep the full max_cycles depth. When false, every PR gets full review
+  # depth as before — the profile is pinned to "full". The chosen depth is
+  # surfaced on the [1/7] tracker line. See
+  # https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md
+  # (Complexity → pipeline profile).
+  adaptive_depth: true
 
   # Auto-merge PR when clean (overridden to true in --auto mode)
   # Type: boolean
@@ -464,8 +496,10 @@ graph TD
     RS --> R5["pr_auto_link"]
     RS --> R6["max_commits"]
     RS --> R7["qa_max_cycles"]
+    RS --> R8["adaptive_effort"]
 
     RV --> RV1["max_cycles"]
+    RV --> RV14["adaptive_depth"]
     RV --> RV2["auto_merge"]
     RV --> RV3["confidence_threshold"]
     RV --> RV4["run_tests"]
@@ -540,6 +574,7 @@ Each line carries at minimum a **timestamp, issue number, mode, outcome**, and t
 | `outcome` | string | yes | Terminal outcome. Resolver: `success`, `already_resolved`, `failed`. Auto-pilot: one of its six categorical outcomes (`merged`, `left_open`, `partial_followup`, `blocked_by_dependency`, `failed`, `skipped`). |
 | `pr` | integer or null | yes | PR number when a PR was created, else `null` |
 | `complexity` | string | no | Research complexity on the **3-value** run-log scale (`low` / `medium` / `high`) when known. Collapse the researcher's 5-value estimate before writing: `trivial` or `low` → `low`; `medium` → `medium`; `high` or `complex` → `high`. Never emit `trivial` or `complex` in runs.jsonl. |
+| `profile` | string | no | The adaptive-effort pipeline profile the run selected: `light` (trivial fast path) or `full`. Omitted when `resolve.adaptive_effort` is `false` or the signal was unavailable. Lets `/idd-doctor` and audits see how often the fast path fired. See [agent-model-effort.md](https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md) (Complexity → pipeline profile). |
 | `qa_cycles` | integer | no | Number of QA review-fix cycles run (resolver) |
 | `duration_s` | integer | no | Wall-clock duration of the run in seconds, when measurable |
 | `skipped_reason` | string | no | Why the issue was skipped (auto-pilot skips, and any `skipped`/`already_resolved` outcome), e.g. `already_resolved`, `blocked_label`, `blocked_by_dependency`, `in_skip_list`, `assigned_to_other` |
@@ -547,7 +582,8 @@ Each line carries at minimum a **timestamp, issue number, mode, outcome**, and t
 Example lines:
 
 ```jsonl
-{"ts":"2026-06-26T14:31:07Z","issue":141,"mode":"auto","skill":"issue-resolver","complexity":"medium","qa_cycles":2,"outcome":"success","pr":150,"duration_s":372}
+{"ts":"2026-06-26T14:31:07Z","issue":141,"mode":"auto","skill":"issue-resolver","complexity":"medium","profile":"full","qa_cycles":2,"outcome":"success","pr":150,"duration_s":372}
+{"ts":"2026-06-26T15:02:41Z","issue":152,"mode":"auto","skill":"issue-resolver","complexity":"low","profile":"light","qa_cycles":1,"outcome":"success","pr":161,"duration_s":94}
 {"ts":"2026-06-26T14:48:12Z","issue":118,"mode":"balanced","skill":"auto-pilot","outcome":"skipped","pr":null,"skipped_reason":"blocked_by_dependency"}
 ```
 
@@ -649,8 +685,11 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `resolve.test_timeout` | `300` | 5 minute test timeout |
 | *(removed)* `resolve.pr_auto_link` | — | Deprecated; `Closes #N` is unconditional per SPEC §5.1 |
 | `resolve.max_commits` | `10` | Max commits warning |
+| `resolve.qa_max_cycles` | `5` | Max QA review-fix cycles during resolve Step 4 |
+| `resolve.adaptive_effort` | `true` | Scale the resolve pipeline to issue complexity — trivial issues (Effort XS/S) take a lighter path (lighter Research, skip 3-option Plan, skip propose-skills, QA capped at 1 cycle); `false` pins every issue to the full pipeline ([agent-model-effort.md](https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md)) |
 | `resolve.ui_review.browser_review` | `"ask"` | Browser (screenshot) UI review mode; code UI review is auto-detected and always runs |
 | `review.max_cycles` | `3` | Max review-fix cycles |
+| `review.adaptive_depth` | `true` | Scale review depth to PR complexity — a trivial PR caps the review-fix loop at 1 cycle and skips optional passes (AC + traceability hard-blocks still run); `false` pins every PR to full depth ([agent-model-effort.md](https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md)) |
 | `review.auto_merge` | `false` | Auto-merge PR when clean |
 | `review.confidence_threshold` | `80` | Min confidence level for issues |
 | `review.run_tests` | `true` | Run tests during review |

--- a/skills/issue-resolver/references/docs/config-schema.md
+++ b/skills/issue-resolver/references/docs/config-schema.md
@@ -84,6 +84,10 @@ resolve:
   # Default: "auto"
   # "auto": proceed immediately after planning
   # "comment-and-wait": show plan and wait for user approval
+  # Note: with resolve.adaptive_effort: true (default), a light-profile (trivial
+  #   XS/S) issue proceeds on a direct minimal plan without the option prompt —
+  #   it produces no 3-option comparison to wait on. Set adaptive_effort: false
+  #   to force the approval wait on every issue regardless of complexity.
   approval_gate: auto
 
   # Branch naming prefix

--- a/skills/issue-resolver/references/pipeline-steps.md
+++ b/skills/issue-resolver/references/pipeline-steps.md
@@ -206,6 +206,33 @@ If the researcher returns `already_resolved: true` or `pr_in_progress: true`:
 - Auto mode: close the issue with a comment and move on.
 - Interactive mode: inform the user and stop.
 
+### `light` profile — lighter research
+
+When *Step 0g* selected `profile = light` (`resolve.adaptive_effort` on, pre-work
+`Effort` band `XS`/`S` asserted), run a reduced research pass keyed to a trivial
+change:
+
+1. **Keep** the *Verify not already resolved* phase in full — this is
+   safety-critical and runs on every profile (a fast path must never skip the
+   already-fixed check).
+2. **Keep** a focused scan of the file(s) the issue obviously names or points at,
+   enough to write the change and its evidence.
+3. **Skip** the broad dependency trace (`trace_depth`), the git-history
+   domain-expert scan, and external solution research — a single-word/single-file
+   edit does not need them. Lowering this work is the token saving the profile
+   exists for.
+
+**Upgrade, never downgrade.** If the lighter pass still surfaces `high`/`complex`
+signals (the change touches far more than the band implied), revise the profile
+**upward** to `full` for the remaining steps and run Step 2's synthesizer and
+Step 4's full QA loop as usual. Never move a run from `full` down to `light` on a
+mid-pipeline signal — the pre-work gate is the only place `light` is chosen, and
+downgrading could truncate work already underway. Record the upgrade so the
+surfaced profile and the run-log `profile` reflect the final value.
+
+The delegation payload is otherwise unchanged; pass the researcher a note that a
+lighter, targeted scan is expected (mirroring the model/effort tier intent).
+
 ### Inline fallback
 
 If no Agent tool, execute research inline following the same phases described in `references/agents/codebase-researcher.md`.
@@ -229,6 +256,36 @@ The synthesizer returns 3 options differing in scope:
 1. **Minimal fix** — smallest change
 2. **Balanced approach** — proper fix, reasonable scope (usually recommended)
 3. **Comprehensive refactor** — addresses root cause and technical debt
+
+### `light` profile — skip the synthesis
+
+When *Step 0g* selected `profile = light`, do **not** spawn the synthesizer at
+all — the 3-option comparison is overkill for a trivial change, and skipping the
+spawn is a direct token saving. Instead, derive a **direct minimal plan** inline
+from the Step 1 research:
+
+- The plan is the single obvious change that satisfies the acceptance criteria
+  (e.g. "update the copy string in `X`", "bump the timeout constant in `Y`").
+- Record it as the **selected option** with a one-line name and summary, so
+  Step 5's Decision Record has a real `Selected option` to lift and
+  `Options rejected` is simply "n/a — trivial change, direct plan (light profile)".
+- The **design-confirm checkpoint does not apply** — it fires only on
+  `overall_complexity: L`/`XL` or `overall_risk: High`, which the `light` path
+  (band `XS`/`S`) is by definition not.
+- **`approval_gate: comment-and-wait` does not present options on the `light`
+  path.** That gate exists to show the 3 synthesized options and wait for a pick,
+  but the `light` path produces none — so it proceeds with the direct minimal
+  plan **without** an option prompt (the same way the `light` path skips the
+  *Propose relevant skills* prompt). A maintainer who wants to approve every plan
+  regardless of size sets `resolve.adaptive_effort: false`, which pins the full
+  pipeline and restores the `comment-and-wait` option prompt.
+
+If Step 1 upgraded the profile to `full` (a `high`/`complex` signal), run the
+normal synthesizer spawn below instead — the `light` skip is only for runs that
+stayed `light` through research.
+
+The tracker line is unchanged (`[2/5] Plan  ✓ approach: {selected option name}`);
+`{selected option name}` is the direct minimal plan's name.
 
 ### Plan selection
 
@@ -476,7 +533,12 @@ Each cycle:
 
 ### Loop controls
 
-- **Max cycles:** `resolve.qa_max_cycles` (default: 5)
+- **Max cycles:** `resolve.qa_max_cycles` (default: 5). **`light` profile caps
+  this at 1** — a single review pass, one fix if blocking issues are found, then
+  proceed to Deliver. The reviewer spawn still runs on the `light` path (review is
+  reduced in depth, never skipped); only the *number* of review-fix iterations is
+  capped. (A profile upgraded to `full` in Step 1 uses the normal
+  `resolve.qa_max_cycles` cap.)
 - **Exit on clean:** stop as soon as review passes AND tests pass
 - **Exit on stagnation:** if the same issues appear in 2 consecutive cycles, stop and report
 

--- a/skills/issue-resolver/references/report-templates.md
+++ b/skills/issue-resolver/references/report-templates.md
@@ -24,6 +24,7 @@ Closes #{issue_number}
 - **Options rejected:** Option 1 — {one-line reason}; Option 3 — {reason}
 - **Selected option:** Option {N} — {name}
 - **Residual risk:** {what remains uncertain or accepted as known limitation, or "none identified"}
+- **Effort profile:** {"light — fast path (pre-work Effort {band}); synthesis skipped, QA capped at 1 cycle" when the run used the light profile; omit this line entirely on the full profile — the default — so it appears only when the fast path actually fired}
 - **Design-confirm:** {high-complexity issues only — "confirmed Option {N} at design-confirm checkpoint (complexity: {level})" in interactive mode, or "auto-selected Option {N} (complexity: {level})" in auto mode; omit this line for trivial/low/medium complexity}
 - **Reproduction:** {bug issues only — success: `<command>` confirmed red for the stated reason → regression test `<path>` (or "manual — no seam"); degraded: `not reproduced — <one-line reason> (fix applied without confirmed red; criterion marked unverified)`; omit for non-bug issues}
 
@@ -129,7 +130,7 @@ in the closing block:
 ```
   ◆ Resolve Pipeline
   ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
-  [0/5] Preflight    ✓ issue #42 open, not yet resolved
+  [0/5] Preflight    ✓ issue #42 open, not yet resolved, effort: full
   [1/5] Research     ✓ read 12 files, complexity: medium
   [2/5] Plan         ✓ option 2 selected: balanced refactor
   [3/5] Implement    ✓ 3 files changed, 8 unit tests, 2 e2e tests

--- a/skills/issue-triage/references/docs/agent-model-effort.md
+++ b/skills/issue-triage/references/docs/agent-model-effort.md
@@ -70,3 +70,97 @@ For each spawned step the orchestrator should:
 
 Selection is bounded by the same cost-awareness as model suggestion: prefer the
 lowest tier that can do the step correctly.
+
+## Complexity → pipeline profile
+
+Model/effort selection above is **advisory** — it tunes *how hard* each agent
+thinks but never changes *which* steps run. The **pipeline profile** is a
+distinct, second mechanism layered on the **same `XS … XL` scale**: it scales
+*how much pipeline runs* — which optional steps fire, how many QA/review cycles
+are allowed — so a trivial one-character edit does not pay the full
+orchestration cost of a multi-subsystem change. Unlike model/effort, the profile
+**does** change control flow (it can collapse a step or cap a loop), so it is a
+**gated** control, not advisory. The two are independent: model/effort sizes the
+agents a step spawns; the profile decides whether the lighter-weight step runs at
+all. They share the scale and nothing else — do **not** invent a second
+classifier for the profile.
+
+### The two profiles
+
+| Profile | Effort band | Intent |
+|---------|-------------|--------|
+| **light** | XS, S | Trivial/small work — collapse optional phases, cap the review-fix loop to one cycle. |
+| **full**  | M, L, XL | Everything today runs unchanged — the current pipeline in full. |
+
+The profile is a **coarse** switch (two states), deliberately not one profile per
+band: the goal is a fast path for the long tail of trivial work, not five
+gradations. Model/effort selection already provides the fine-grained,
+per-agent scaling within either profile.
+
+### Selecting the profile (pre-work signal)
+
+The profile is chosen from a **pre-work** signal — before the first expensive
+subagent spawn — so the saving is real. If the profile were derived from an
+agent's *output* (e.g. the researcher's `complexity`), the dominant cost would
+already be paid before the decision, and the fast path would save almost nothing.
+The pre-work signal is the issue's **`Effort` band** in its `## Metadata` section
+(the `XS … XL` value written by `/issue-creator`, the same scale this whole
+document uses).
+
+Resolve the profile from that band, **erring toward `full` whenever the signal
+is weak**:
+
+| Condition on the pre-work signal | Profile |
+|----------------------------------|---------|
+| `Effort` is `M`, `L`, or `XL` | **full** |
+| `Effort` is `XS` or `S` **and** asserted (not low-confidence) | **light** |
+| `Effort` is `XS`/`S` but marked `(needs review)` / low-confidence | **full** (ambiguous → fuller) |
+| `Effort` is absent / unparseable | **full** (safe default) |
+
+The low-confidence and absent rows are the safety contract: an uncertain estimate
+must never under-serve a task that turns out to be hard. A skill **may** refine
+the profile *upward* once a stronger signal arrives (e.g. the researcher reports
+`high`/`complex` on what the band called `S`) — never downward. Downgrading on a
+mid-pipeline signal would defeat the pre-work guarantee and risk truncating work
+already deep in the full path.
+
+### What each consuming skill does with the profile
+
+This document defines the *scale → profile* mapping and the pre-work-signal rule;
+each skill owns exactly *which* of its steps the `light` profile collapses (its
+pipeline reference spells out the per-step mechanics):
+
+- **`/issue-resolver`** — `light` keeps a **lighter** Research step (the
+  already-resolved safety check still runs), skips the 3-option synthesis in Plan
+  (a direct minimal plan is used), skips the interactive propose-relevant-skills
+  sub-step, and caps QA at **one** cycle. Implement and Deliver are unchanged, and
+  the durable PR artifacts (Decision Record + Acceptance Criteria Verification
+  table) are **always** emitted — the profile never removes durable memory.
+- **`/issue-pr-review`** — has no researcher, so it derives its own pre-work
+  signal (diff size / files-changed / labels / linked-issue `Effort`, taking the
+  **fuller** of any that disagree) and scales review **depth** — the `light`
+  profile caps the review-fix loop to one cycle and skips optional passes, while
+  the acceptance-criteria and traceability hard-blocks still run at full strength.
+
+### Surfacing the profile (transparency)
+
+The chosen profile is **surfaced to the user** wherever the skill already reports
+progress, so the effort decision is transparent and reviewable — never a hidden
+downgrade:
+
+- On the pipeline **tracker line** for the step where it is decided (e.g. the
+  resolver's `[0/5] Preflight` line names `effort: light` or `effort: full`).
+- In the **run log** (`.gitissue/runs.jsonl`) as the optional `profile` field, so
+  `/idd-doctor` and audits can see how often the fast path fired (see
+  `references/docs/config-schema.md`).
+
+### Opting out
+
+Each consuming skill exposes an explicit off-switch so a maintainer can force the
+full pipeline on every issue regardless of band: `resolve.adaptive_effort`
+(default `true`) for `/issue-resolver` and `review.adaptive_depth` (default
+`true`) for `/issue-pr-review`. When the switch is `false`, the skill behaves
+exactly as it did before this mechanism existed — the profile is pinned to
+`full`. Defaults are **on** so zero-config users get the fast path for trivial
+work automatically; the switch exists for maintainers who prefer uniform
+full-treatment (see `references/docs/config-schema.md`).

--- a/skills/issue-triage/references/docs/config-schema.md
+++ b/skills/issue-triage/references/docs/config-schema.md
@@ -123,6 +123,23 @@ resolve:
   # Maximum: 10
   qa_max_cycles: 5
 
+  # Scale the resolve pipeline to each issue's complexity (adaptive effort).
+  # Type: boolean
+  # Default: true
+  # When true, trivial issues (pre-work Effort band XS/S, asserted) take a
+  # lighter, faster, lower-token path: a lighter Research step (the
+  # already-resolved safety check still runs), the 3-option synthesis in Plan is
+  # skipped for a direct minimal plan, the propose-relevant-skills sub-step is
+  # skipped, and QA is capped at 1 cycle. The Decision Record and Acceptance
+  # Criteria Verification table are always emitted regardless. Complex or
+  # ambiguous issues (M/L/XL, low-confidence, or no band) keep the full pipeline.
+  # When false, every issue gets the full pipeline as before — the profile is
+  # pinned to "full". The chosen profile is surfaced on the [0/5] tracker line
+  # and in the run log's `profile` field. See
+  # https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md
+  # (Complexity → pipeline profile).
+  adaptive_effort: true
+
   # UI/UX review settings (Step 4 — QA)
   # Code-level UI review is auto-detected per issue and always runs when UI
   # work is present; it needs no flag and runs in any environment (including
@@ -145,6 +162,21 @@ review:
   # Minimum: 1
   # Maximum: 10
   max_cycles: 3
+
+  # Scale review depth to each PR's complexity (adaptive depth).
+  # Type: boolean
+  # Default: true
+  # When true, /issue-pr-review derives a pre-work complexity signal from the PR
+  # (diff size, files-changed, labels, and the linked issue's Effort band — the
+  # fuller of any that disagree) and, for a trivial PR, caps the review-fix loop
+  # at 1 cycle and skips optional passes. The acceptance-criteria and
+  # traceability hard-blocks always run at full strength. Complex or ambiguous
+  # PRs keep the full max_cycles depth. When false, every PR gets full review
+  # depth as before — the profile is pinned to "full". The chosen depth is
+  # surfaced on the [1/7] tracker line. See
+  # https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md
+  # (Complexity → pipeline profile).
+  adaptive_depth: true
 
   # Auto-merge PR when clean (overridden to true in --auto mode)
   # Type: boolean
@@ -464,8 +496,10 @@ graph TD
     RS --> R5["pr_auto_link"]
     RS --> R6["max_commits"]
     RS --> R7["qa_max_cycles"]
+    RS --> R8["adaptive_effort"]
 
     RV --> RV1["max_cycles"]
+    RV --> RV14["adaptive_depth"]
     RV --> RV2["auto_merge"]
     RV --> RV3["confidence_threshold"]
     RV --> RV4["run_tests"]
@@ -540,6 +574,7 @@ Each line carries at minimum a **timestamp, issue number, mode, outcome**, and t
 | `outcome` | string | yes | Terminal outcome. Resolver: `success`, `already_resolved`, `failed`. Auto-pilot: one of its six categorical outcomes (`merged`, `left_open`, `partial_followup`, `blocked_by_dependency`, `failed`, `skipped`). |
 | `pr` | integer or null | yes | PR number when a PR was created, else `null` |
 | `complexity` | string | no | Research complexity on the **3-value** run-log scale (`low` / `medium` / `high`) when known. Collapse the researcher's 5-value estimate before writing: `trivial` or `low` → `low`; `medium` → `medium`; `high` or `complex` → `high`. Never emit `trivial` or `complex` in runs.jsonl. |
+| `profile` | string | no | The adaptive-effort pipeline profile the run selected: `light` (trivial fast path) or `full`. Omitted when `resolve.adaptive_effort` is `false` or the signal was unavailable. Lets `/idd-doctor` and audits see how often the fast path fired. See [agent-model-effort.md](https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md) (Complexity → pipeline profile). |
 | `qa_cycles` | integer | no | Number of QA review-fix cycles run (resolver) |
 | `duration_s` | integer | no | Wall-clock duration of the run in seconds, when measurable |
 | `skipped_reason` | string | no | Why the issue was skipped (auto-pilot skips, and any `skipped`/`already_resolved` outcome), e.g. `already_resolved`, `blocked_label`, `blocked_by_dependency`, `in_skip_list`, `assigned_to_other` |
@@ -547,7 +582,8 @@ Each line carries at minimum a **timestamp, issue number, mode, outcome**, and t
 Example lines:
 
 ```jsonl
-{"ts":"2026-06-26T14:31:07Z","issue":141,"mode":"auto","skill":"issue-resolver","complexity":"medium","qa_cycles":2,"outcome":"success","pr":150,"duration_s":372}
+{"ts":"2026-06-26T14:31:07Z","issue":141,"mode":"auto","skill":"issue-resolver","complexity":"medium","profile":"full","qa_cycles":2,"outcome":"success","pr":150,"duration_s":372}
+{"ts":"2026-06-26T15:02:41Z","issue":152,"mode":"auto","skill":"issue-resolver","complexity":"low","profile":"light","qa_cycles":1,"outcome":"success","pr":161,"duration_s":94}
 {"ts":"2026-06-26T14:48:12Z","issue":118,"mode":"balanced","skill":"auto-pilot","outcome":"skipped","pr":null,"skipped_reason":"blocked_by_dependency"}
 ```
 
@@ -649,8 +685,11 @@ Config is validated on load at the start of every skill invocation. Errors inclu
 | `resolve.test_timeout` | `300` | 5 minute test timeout |
 | *(removed)* `resolve.pr_auto_link` | — | Deprecated; `Closes #N` is unconditional per SPEC §5.1 |
 | `resolve.max_commits` | `10` | Max commits warning |
+| `resolve.qa_max_cycles` | `5` | Max QA review-fix cycles during resolve Step 4 |
+| `resolve.adaptive_effort` | `true` | Scale the resolve pipeline to issue complexity — trivial issues (Effort XS/S) take a lighter path (lighter Research, skip 3-option Plan, skip propose-skills, QA capped at 1 cycle); `false` pins every issue to the full pipeline ([agent-model-effort.md](https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md)) |
 | `resolve.ui_review.browser_review` | `"ask"` | Browser (screenshot) UI review mode; code UI review is auto-detected and always runs |
 | `review.max_cycles` | `3` | Max review-fix cycles |
+| `review.adaptive_depth` | `true` | Scale review depth to PR complexity — a trivial PR caps the review-fix loop at 1 cycle and skips optional passes (AC + traceability hard-blocks still run); `false` pins every PR to full depth ([agent-model-effort.md](https://github.com/luongnv89/idd/blob/main/docs/agent-model-effort.md)) |
 | `review.auto_merge` | `false` | Auto-merge PR when clean |
 | `review.confidence_threshold` | `80` | Min confidence level for issues |
 | `review.run_tests` | `true` | Run tests during review |

--- a/skills/issue-triage/references/docs/config-schema.md
+++ b/skills/issue-triage/references/docs/config-schema.md
@@ -84,6 +84,10 @@ resolve:
   # Default: "auto"
   # "auto": proceed immediately after planning
   # "comment-and-wait": show plan and wait for user approval
+  # Note: with resolve.adaptive_effort: true (default), a light-profile (trivial
+  #   XS/S) issue proceeds on a direct minimal plan without the option prompt —
+  #   it produces no 3-option comparison to wait on. Set adaptive_effort: false
+  #   to force the approval wait on every issue regardless of complexity.
   approval_gate: auto
 
   # Branch naming prefix

--- a/src/skills/auto-pilot/SKILL.source.md
+++ b/src/skills/auto-pilot/SKILL.source.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Requires git and GitHub CLI (gh) with auth and push access. Requires merge permission for auto-merge. Requires issue-triage, issue-resolver, issue-analysis, and issue-pr-review to be installed from the same distribution. Optional: issue-creator for normalizing unstructured issues mid-loop."
 effort: max
 metadata:
-  version: 2.4.0
+  version: 2.4.1
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -173,7 +173,7 @@ The auto-pilot processes multiple issues in a single session. Without careful co
 
 The solution: the main agent acts as a **lightweight orchestrator** that delegates heavy work to subagents via the Agent tool. Each subagent gets a fresh context window, does its work, and returns a concise result. The main agent never reads code, diffs, or test output directly.
 
-Auto-pilot delegates to the resolver/reviewer **skills**, which spawn the shared agents (researcher, synthesizer, implementer, code reviewer, UI reviewer, fixer) under their role identities. Those skills size each agent's model/effort per `docs/agent-model-effort.md` and follow the shared conventions in `docs/shared-agent-conventions.md`; auto-pilot folds the telemetry they return (`complexity`, `qa_cycles`, `duration_s`) into its single run-log line per issue (see the run-log note below).
+Auto-pilot delegates to the resolver/reviewer **skills**, which spawn the shared agents (researcher, synthesizer, implementer, code reviewer, UI reviewer, fixer) under their role identities. Those skills size each agent's model/effort per `docs/agent-model-effort.md` and follow the shared conventions in `docs/shared-agent-conventions.md`; auto-pilot folds the telemetry they return (`complexity`, `profile`, `qa_cycles`, `duration_s`) into its single run-log line per issue (see the run-log note below).
 
 ### Subagent Architecture
 
@@ -263,8 +263,8 @@ the log accurate: the single-writer rule and the batch fan-out. Both live in
 
 Populate from the iteration's known values plus the resolver's returned telemetry
 (`ts`, `issue`, `mode`, `skill`, `outcome`, `pr`, and `qa_cycles` / `complexity` /
-`duration_s` when present). **When the outcome is `skipped`, always include
-`skipped_reason`** — a skip never ran the resolver, so it carries no telemetry.
+`profile` / `duration_s` when present). **When the outcome is `skipped`, always
+include `skipped_reason`** — a skip never ran the resolver, so it carries no telemetry.
 The full field list lives in `references/run-log.md` → *Fields to populate*.
 
 ```bash

--- a/src/skills/auto-pilot/references/run-log.md
+++ b/src/skills/auto-pilot/references/run-log.md
@@ -14,10 +14,10 @@ is invoked with `--no-run-log` (see *Resolver Subagent* in
 `references/subagent-prompts.md`), so it **does not** append its own line — only
 auto-pilot writes here. Writing in both places would double-write one line per
 issue and skew `/idd-doctor`'s resolve-rate and median-QA metrics. The resolver
-**returns** its telemetry (`qa_cycles`, `complexity`, `duration_s`) in its
-result; fold those into the **single line** auto-pilot writes (enriched with that
-telemetry) so the per-issue QA signal survives even though the resolver stayed
-silent. The resolver's run `status` informs auto-pilot's decision but is **not**
+**returns** its telemetry (`qa_cycles`, `complexity`, `profile`, `duration_s`) in
+its result; fold those into the **single line** auto-pilot writes (enriched with
+that telemetry) so the per-issue QA signal survives even though the resolver
+stayed silent. The resolver's run `status` informs auto-pilot's decision but is **not**
 copied into the row's `outcome` — that field stays auto-pilot's own six
 categorical label (set from the merge result).
 
@@ -41,7 +41,9 @@ telemetry: `ts` (current UTC, ISO 8601), `issue` (the number), `mode` (the
 auto-pilot merge mode — `conservative` / `balanced` / `aggressive`), `skill`
 (`auto-pilot`), `outcome` (one of the six categorical labels), `pr` (the PR
 number when one was created, else `null`), and — from the resolver's report-back
-— `qa_cycles`, `complexity`, and `duration_s` when present. **When the outcome is
-`skipped`, always include `skipped_reason`** (e.g. `already_resolved`,
+— `qa_cycles`, `complexity`, `profile`, and `duration_s` when present (`profile`
+is the adaptive-effort profile the resolve chose, `light` or `full`; omit it when
+the resolver returned none). **When the outcome is `skipped`, always include
+`skipped_reason`** (e.g. `already_resolved`,
 `blocked_label`, `blocked_by_dependency`, `in_skip_list`, `assigned_to_other`); a
 skip never ran the resolver, so it carries no resolver telemetry.

--- a/src/skills/auto-pilot/references/subagent-prompts.md
+++ b/src/skills/auto-pilot/references/subagent-prompts.md
@@ -41,6 +41,7 @@ When done, report back ONLY these fields:
 - tests_passed: count of tests passed
 - qa_cycles: number of QA cycles run
 - complexity: Research complexity collapsed to the runs.jsonl 3-value scale (see docs/config-schema.md — trivial/low→low, medium→medium, high/complex→high)
+- profile: the adaptive-effort pipeline profile the resolve selected ("light" or "full"), for the run-log `profile` field; omit/null when resolve.adaptive_effort is false or no profile was selected
 - duration_s: wall-clock seconds for the resolve, when measurable, for the run-log line
 - failure_step: which step failed (if status is failure)
 - failure_reason: short error description (if status is failure)
@@ -204,6 +205,10 @@ When done, report back ONLY these fields:
   primary issue's run-log line only, so a batch is not weighted N-fold)
 - complexity: the complexity assessed in Research (e.g. low/medium/high), shared on
   every fanned-out run-log line
+- profile: the adaptive-effort pipeline profile the batch resolve selected ("light"
+  or "full"), shared on every fanned-out run-log line like complexity; omit/null
+  when resolve.adaptive_effort is false. (A batch of several issues is rarely
+  trivial, so this is usually "full".)
 - duration_s: wall-clock seconds for the batch resolve, when measurable; like
   qa_cycles it is attributed to the primary issue's line only
 - failure_step: which step failed (if status is failure)

--- a/src/skills/init-gitissue/SKILL.source.md
+++ b/src/skills/init-gitissue/SKILL.source.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Requires git. No GitHub CLI or authentication needed — generates a local config file only."
 effort: low
 metadata:
-  version: 0.3.5
+  version: 0.3.6
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 

--- a/src/skills/init-gitissue/templates/gitissue-template.yml
+++ b/src/skills/init-gitissue/templates/gitissue-template.yml
@@ -47,6 +47,11 @@ resolve:
   # Max QA review-fix cycles during resolve Step 4
   qa_max_cycles: 5
 
+  # Scale the resolve pipeline to issue complexity (adaptive effort).
+  # true: trivial issues (Effort XS/S) take a lighter, faster path; complex or
+  # ambiguous issues keep the full pipeline. false: full pipeline for every issue.
+  adaptive_effort: true
+
   ui_review:
     browser_review: ask
 
@@ -67,6 +72,10 @@ triage:
 # PR review settings (used by /issue-pr-review and /auto-pilot)
 review:
   max_cycles: 3
+  # Scale review depth to PR complexity (adaptive depth).
+  # true: a trivial PR caps the review-fix loop at 1 cycle and skips optional
+  # passes; complex or ambiguous PRs keep full depth. false: full depth always.
+  adaptive_depth: true
   auto_merge: false
   confidence_threshold: 80
   run_tests: true

--- a/src/skills/issue-pr-review/SKILL.source.md
+++ b/src/skills/issue-pr-review/SKILL.source.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Requires git and GitHub CLI (gh) with authentication. Self-contained — uses shared agents from shared/agents/."
 effort: high
 metadata:
-  version: 2.4.1
+  version: 2.5.0
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -79,6 +79,7 @@ If `origin` is missing or rebase conflicts occur, stop and ask (interactive) or 
 
 Load `.gitissue.yml` once. Defaults (full semantics in `docs/config-schema.md`):
 - `review.max_cycles: 3` — 3 LLM cycles suffice once the script pre-pass handles mechanical issues
+- `review.adaptive_depth: true` — scale review depth to the PR's complexity (see *Step 1 — Depth gate*). When `false`, every PR gets full-depth review (profile pinned to `full`).
 - `review.auto_merge: false` (overridden to `true` in auto mode)
 - `review.confidence_threshold: 80`
 - `review.run_tests: true`, `review.check_ci: true`
@@ -99,7 +100,7 @@ UI/UX **code** review needs no config flag — it is auto-detected per PR (*Step
 ```
   ◆ PR Review Pipeline
   ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
-  [1/7] PR Info      ✓ PR #87: fix(auth): resolve redirect (#42)
+  [1/7] PR Info      ✓ PR #87: fix(auth): resolve redirect (#42), depth: full
   [2/7] Pre-pass     ✓ lint clean, format clean, 17 tests passed
   [3/7] Review       ● analyzing changes...
   [4/7] Test         ✓ 17 tests passed, build ok
@@ -158,6 +159,43 @@ gh pr checkout {N}
 ```
 
 Use `{headRefName}` from Step 1 as `{branch_name}` for sync, commit, and push. Canonical command: `docs/platform-github.md` (*Pull requests* → Checkout PR head branch).
+
+### Depth gate (select the review profile)
+
+Decide **how deep** this review goes, so a one-line copy fix is not put through
+the same full-weight review as a multi-subsystem PR. The mechanism and the shared
+`XS … XL` scale it reuses are defined once in `docs/agent-model-effort.md`
+(*Complexity → pipeline profile*); this skill has no researcher, so it derives its
+own **pre-work** complexity signal from data already fetched in Step 1.
+
+When `review.adaptive_depth` is `false`, skip the gate: set `profile = full` and
+review at full depth as before. Otherwise compute the signal from the PR itself
+and take the **fuller** of any inputs that disagree (a "trivial" issue whose diff
+ballooned still earns full review):
+
+- **Diff size / files-changed** — from `statusCheckRollup`/`files` in Step 1
+  (`gh pr view {N} --json files`). Small (e.g. ≤ ~15 changed lines across 1 file)
+  leans `light`; larger leans `full`.
+- **Linked-issue `Effort` band** — when the PR links an issue (`Closes #N`), fetch
+  its `## Metadata` `Effort` (`gh issue view {N} --json body`). `XS`/`S` asserted
+  leans `light`; `M`/`L`/`XL`, or low-confidence, leans `full`.
+- **Labels** — a `security`/`CVE`/`vulnerability` label (case-insensitive) forces
+  `full` regardless of size (security-sensitive changes always get full review).
+
+Resolve to `profile = light` only when **every** available signal agrees on
+trivial; if any signal says `full`, or a signal is missing/ambiguous, use `full`
+(ambiguous → fuller). Surface the decision on the `[1/7]` tracker line:
+
+```
+[1/7] PR Info      ✓ PR #{N}: {title}
+                     {files_count} files changed, base: {base_branch}, depth: {profile}
+```
+
+`{profile}` is `light` or `full`. When `review.adaptive_depth` is `false`, still
+print `depth: full` so the line is uniform. The `light` profile scales the Review
+Loop only — see *Review Loop* (`light` caps cycles at 1 and skips optional passes;
+the acceptance-criteria and traceability hard-blocks always run at full strength).
+Full mechanics in `references/review-loop-mechanics.md` (*Depth gate*).
 
 ---
 
@@ -328,7 +366,16 @@ Cycle {N}:
 After Step 6, go back to Step 3 — but reuse the same reviewer agent via `SendMessage` (not a fresh spawn). Only spawn fresh for the confirmation pass.
 
 **Loop controls:**
-- **Max cycles:** `review.max_cycles` (default: 3)
+- **Max cycles:** `review.max_cycles` (default: 3). **`light` profile (Step 1
+  Depth gate) caps this at 1** — one review pass, one fix cycle if `action: "fix"`
+  issues are found, then the confirmation pass and exit. The reviewer still runs
+  on the `light` path (depth reduced, review never skipped); only the number of
+  review-fix iterations is capped. `full` uses `review.max_cycles` as before.
+- **`light` profile — optional passes:** the `light` depth skips the optional
+  browser UI review (the code UI review still auto-detects and runs when UI work
+  is present) and does not spin extra confirmation cycles. The two #36
+  hard-blocks — `acceptance_criteria: fail` and missing `Closes #N` — **still run
+  at full strength** on every profile; the fast path never relaxes them.
 - **Agent reuse:** Cycles 2+ reuse the existing reviewer and fixer agents. Fresh spawn only for the confirmation pass after fixer reports zero issues.
 - **Soft pass (when `review.soft_pass: true`, default):** Stop when ALL hold: zero `action: "fix"` issues remain AND (tests pass or `review.run_tests: false`) AND (CI passes, no CI configured, or `review.check_ci: false`) AND traceability is not `fail`. Medium `note` issues and `partial` dimensions are report-only — they do not block.
 - **Strict pass (when `review.soft_pass: false`):** Apply the same tests/CI gates, then require zero `action: "fix"` findings, zero remaining `action: "note"` findings, and `pass` for every enabled dimension. A `partial` dimension or any note is a strict blocker: exit the fix loop, report it under Remaining, and do not report clean or merge. Notes never become fixer inputs — Step 6 still fixes only `action: "fix"` — so strict mode surfaces these for manual remediation rather than looping without a fixable action.

--- a/src/skills/issue-pr-review/references/report-templates.md
+++ b/src/skills/issue-pr-review/references/report-templates.md
@@ -175,7 +175,7 @@ In interactive mode: never auto-merge — just report status.
 A clean review prints the 7-step tracker and a summary:
 
 ```
-  [1/7] PR Info       ✓ #87 fix(auth): resolve redirect (#42)
+  [1/7] PR Info       ✓ #87 fix(auth): resolve redirect (#42), depth: full
   [2/7] Script Pre    ✓ 3 lint fixes applied
   [3/7] Review        ✓ spec[ac:pass correctness:pass safety:pass]
                         standards[trace:pass maint:pass]

--- a/src/skills/issue-pr-review/references/review-loop-mechanics.md
+++ b/src/skills/issue-pr-review/references/review-loop-mechanics.md
@@ -2,6 +2,50 @@
 
 Exact spawn calls and the token-trade rationale for the reviewer/fixer agents used in Step 3 and the Review Loop of `/issue-pr-review`. SKILL.md keeps the summary (cold start → SendMessage re-review → fresh confirmation); this file holds the detail.
 
+## Depth gate (adaptive review depth)
+
+The Step 1 *Depth gate* selects a review `profile` — `light` or `full` — from a
+pre-work complexity signal, so a trivial PR is not reviewed as deeply as a
+multi-subsystem one. The mechanism and the shared `XS … XL` scale live in
+`docs/agent-model-effort.md` (*Complexity → pipeline profile*); this section is
+only how the review loop consumes the result.
+
+**Selecting the signal (no researcher here).** Unlike `/issue-resolver`,
+`/issue-pr-review` has no research subagent, so it derives the signal from data
+already fetched in Step 1 and takes the **fuller** of any inputs that disagree:
+
+- **Diff size / files-changed** (`gh pr view {N} --json files`) — small change
+  (≈ ≤ 15 changed lines in 1 file) leans `light`.
+- **Linked-issue `Effort` band** — when the PR body has `Closes #N`, read that
+  issue's `## Metadata` `Effort` (`gh issue view {N} --json body`); `XS`/`S`
+  asserted leans `light`, `M`/`L`/`XL` or low-confidence leans `full`.
+- **Security label** — any `security`/`CVE`/`vulnerability` label forces `full`.
+
+Resolve to `light` **only when every available signal agrees on trivial**; any
+`full` vote, or a missing/ambiguous signal, wins → `full`. When
+`review.adaptive_depth` is `false`, the gate is skipped and `profile = full`.
+
+**What `light` changes in the loop:**
+
+| Aspect | `full` (default) | `light` |
+|--------|------------------|---------|
+| Review-fix cycle cap | `review.max_cycles` (3) | **1** |
+| Optional browser UI review | runs when opted in + reachable | skipped |
+| Code UI review (auto-detected) | runs when UI work present | runs when UI work present (unchanged) |
+| AC + traceability hard-blocks | full strength | **full strength (unchanged)** |
+| Reviewer spawn | yes | yes (depth reduced, never skipped) |
+
+The `light` cap of 1 is a **ceiling that wins** — it is the effective cycle limit
+regardless of the configured value, i.e. `min(1, configured_cap)`. This matters
+under `/auto-pilot`, which overrides `review.max_cycles` with its `review_cycles`
+value (default 3): on the `light` path the effective cap is still **1**, never the
+overridden 3. The cap governs **only** the loop iteration count; the cold-start
+reviewer, the fixer, and the fresh confirmation pass below all still apply — a
+`light` review is one review pass + at most one fix + confirmation, not a skipped
+review. The two #36 hard-blocks (`acceptance_criteria: fail`, missing
+`Closes #N`) are never relaxed by the profile — a trivial PR that fails them still
+blocks soft-pass and does not merge.
+
 ## Why reuse the reviewer
 
 To minimize token usage, the review loop **reuses the same reviewer agent** across fix cycles instead of spawning a fresh one each time. The reviewer already has the codebase context loaded, so subsequent reviews are cheaper.

--- a/src/skills/issue-resolver/SKILL.source.md
+++ b/src/skills/issue-resolver/SKILL.source.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Requires git and GitHub CLI (gh) with authentication and push access. Self-contained — uses shared agents from shared/agents/."
 effort: max
 metadata:
-  version: 0.16.1
+  version: 0.17.0
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -73,6 +73,7 @@ Defaults (full field reference in `docs/config-schema.md`):
 - `resolve.test_timeout: 300`
 - `resolve.max_commits: 10`
 - `resolve.qa_max_cycles: 5`
+- `resolve.adaptive_effort: true` — scale the pipeline to the issue's complexity (see *Step 0g — Complexity gate*). When `false`, every issue runs the full pipeline (profile pinned to `full`).
 - `resolve.ui_review.browser_review: "ask"` — gates only the optional browser/screenshot review; the code-level UI review (*Step 4 — UI/UX review*) is auto-detected and always runs.
 
 ---
@@ -162,7 +163,7 @@ The resolve pipeline has 6 steps (0-5). Display progress using the `[N/5]` step 
 ```
   ◆ Resolve Pipeline
   ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
-  [0/5] Preflight    ✓ issue #42 open, not yet resolved
+  [0/5] Preflight    ✓ issue #42 open, not yet resolved, effort: full
   [1/5] Research     ✓ read 12 files, complexity: medium
   [2/5] Plan         ✓ option 2 selected: balanced refactor
   [3/5] Implement    ✓ 3 files changed, 8 unit tests, 2 e2e tests
@@ -295,18 +296,61 @@ a custom prefix is used verbatim as `{configured-prefix}{N}-{short-description}`
 - Interactive mode: ask `continue` or `fresh`
 - Auto mode: `continue` (checkout existing branch)
 
-After preflight:
+### 0g — Complexity gate (select the pipeline profile)
+
+Decide **before Step 1** how much pipeline this issue earns, so a trivial edit
+does not pay the full orchestration cost. The mechanism, the shared `XS … XL`
+scale it reuses, and the safety rules are defined once in
+`docs/agent-model-effort.md` (*Complexity → pipeline profile*) — apply that
+document here; this sub-step is only the resolver's entry point into it.
+
+When `resolve.adaptive_effort` is `false`, skip the gate entirely: set
+`profile = full` and continue exactly as before. Otherwise select the profile
+from the issue's **pre-work `Effort` band** (the `XS … XL` value in the issue's
+`## Metadata`, written by `/issue-creator`) — never from a later agent output, so
+the saving is real:
+
+- `Effort` `XS`/`S`, asserted (not `(needs review)`/low-confidence) → `profile = light`
+- `Effort` `M`/`L`/`XL` → `profile = full`
+- `Effort` `XS`/`S` but low-confidence, **or** absent/unparseable → `profile = full` (ambiguous → fuller)
+
+The `light` profile changes later steps as follows (each step restates its own
+behavior; the full per-step mechanics are in `references/pipeline-steps.md`):
+
+- **Step 1 Research** — lighter scan, but the already-resolved safety check still runs.
+- **Step 2 Plan** — skip the 3-option synthesis; use a direct minimal plan.
+- **Step 3** — skip the interactive *Propose relevant skills* sub-step.
+- **Step 4 QA** — cap the review-fix loop at **1** cycle (overrides `resolve.qa_max_cycles`).
+
+`full` leaves every step exactly as it is today. Either way, **Deliver (Step 5)
+always emits the Decision Record and Acceptance Criteria Verification table** —
+the profile never removes durable memory.
+
+The profile may only be **revised upward** later (e.g. Step 1 research reports
+`high`/`complex` on what the band called `S` → switch to `full` for the remaining
+steps); never downgrade a `full` run to `light` mid-pipeline.
+
+After preflight (surface the chosen profile so the effort decision is transparent):
 ```
-[0/5] Preflight    ✓ issue #N open, branch: {branch_name}{workspace_note}
+[0/5] Preflight    ✓ issue #N open, branch: {branch_name}{workspace_note}, effort: {profile}
 ```
 
-`{workspace_note}` is ` (worktree)` in a worktree, empty otherwise.
+`{workspace_note}` is ` (worktree)` in a worktree, empty otherwise. `{profile}`
+is `light` or `full`. When `resolve.adaptive_effort` is `false`, still print
+`effort: full` (the pinned profile) so the line is uniform.
 
 ---
 
 ## Step 1 — Research
 
 Deeply understand the issue, affected codebase, and possible solutions; also verifies the issue hasn't already been fixed (early-exit path closes it in auto mode). Spawn the researcher (`shared/agents/codebase-researcher.md`) with the canonical pattern — full delegation payload, phases, early-exit behavior, and inline fallback are in `references/pipeline-steps.md` (*Step 1 — Research*).
+
+**`light` profile:** run a **lighter** research pass — the already-resolved
+safety check and a focused scan of the obviously-affected file(s) still run, but
+skip the broad dependency trace and external solution research (a trivial edit
+does not need them). If this lighter pass nonetheless surfaces `high`/`complex`
+signals, revise the profile **upward** to `full` for the remaining steps (never
+downward) — see *Step 0g* and `references/pipeline-steps.md` (*Step 1 — Research*).
 
 After research:
 ```
@@ -322,6 +366,14 @@ Generate implementation options and select one. Spawn the synthesizer (`shared/a
 It returns 3 options — minimal / balanced / comprehensive — with the balanced option usually recommended.
 
 Selection behavior (interactive auto, interactive comment-and-wait, auto-pilot) and inline fallback are in `references/pipeline-steps.md` (*Step 2 — Plan*).
+
+**`light` profile:** skip the 3-option synthesis entirely — do **not** spawn the
+synthesizer. Derive a **direct minimal plan** inline (the single obvious change
+that satisfies the acceptance criteria) and record it as the selected option, so
+the Decision Record still has a real `Selected option` to lift in Step 5. The
+design-confirm checkpoint does not apply (it is high-complexity only, which the
+`light` path is not). Full procedure in `references/pipeline-steps.md`
+(*Step 2 — Plan → `light` profile*).
 
 After plan selection:
 ```
@@ -355,6 +407,11 @@ relevant subset, let the user accept all/some/none into `selected_skills` — th
 implementer always falls back to internal agents, so selecting none is unchanged
 behavior. Full procedure in `references/pipeline-steps.md` (*Step 3 — Propose relevant skills*).
 
+**`light` profile:** skip this sub-step — set `selected_skills = []` and proceed
+straight to the implementer (a trivial edit does not warrant the extra prompt).
+This mirrors the auto-mode behavior; the implementer's internal-agent fallback is
+unchanged.
+
 Write code and tests based on the selected plan. Spawn the implementer (`shared/agents/implementer.md`) with the canonical pattern, passing the plan, branch name, naming conventions, and `selected_skills`.
 
 For **bug** issues, the implementer first runs the red-capable reproduction checkpoint — reproduce the symptom, confirm it fails red, fix, then convert to a regression test. Surfaced as evidence in the PR Decision Record and acceptance table. Non-bug issues skip it; auto mode never blocks. See `references/bug-verification.md`.
@@ -386,6 +443,11 @@ UI review is **auto-detected per issue** — no config flag enables it. Scan the
 - **Browser UI review** — optional screenshots from a running app; runs only when reachable *and* opted in, else **skips with a warning, code UI review still runs** — fail-soft.
 
 Detection rules, `ui-reviewer` spawns, the `resolve.ui_review.browser_review` gate, and skip/success messages are in `references/pipeline-steps.md` (*Step 4 — UI/UX review*). Cycle mechanics and loop controls (`resolve.qa_max_cycles`, exit-on-clean, exit-on-stagnation) are in the same file (*Step 4 — QA*).
+
+**`light` profile:** cap the review-fix loop at **1** cycle (a single review pass;
+fix once if blocking issues are found, then deliver) instead of
+`resolve.qa_max_cycles`. One reviewer spawn still runs — the fast path reduces
+depth, it does not skip review. UI review remains auto-detected as usual.
 
 ---
 
@@ -445,18 +507,20 @@ already fixed (`already_resolved`), or a failed step (`failed`) — append exact
 (see *Suppression rule*), in which case append **nothing** and return the
 telemetry to the caller instead. Build the object from values already known
 (`ts`, `issue`, `mode`, `skill`, `outcome`, `pr`, plus optional `complexity`,
-`qa_cycles`, `duration_s`, `skipped_reason`) per the schema in
+`profile`, `qa_cycles`, `duration_s`, `skipped_reason`) per the schema in
 `docs/config-schema.md` (*`.gitissue/runs.jsonl` — run log*). Collapse researcher
 complexity to the 3-value run-log scale before writing (`trivial`/`low`→`low`,
-`medium`→`medium`, `high`/`complex`→`high`).
+`medium`→`medium`, `high`/`complex`→`high`). Set `profile` to the pipeline profile
+chosen in *Step 0g* (`light` or `full`); omit it only when `resolve.adaptive_effort`
+is `false` or no profile was selected (e.g. an early failure before Step 0g).
 
 > **Suppression rule (single writer under `/auto-pilot`).** `--no-run-log` is
 > passed only by `/auto-pilot`, which runs this resolver as a subagent and writes
 > the **single** run-log line per issue itself — appending here too would
 > double-write and skew `/idd-doctor`'s metrics. Instead **return** the telemetry
-> (`outcome`, `qa_cycles`, `complexity`, `duration_s`) in the subagent result so
-> the orchestrator folds it into its own line. Independent of `--auto`: a
-> standalone `/issue-resolver <N> --auto` is *not* suppressed and still writes.
+> (`outcome`, `qa_cycles`, `complexity`, `profile`, `duration_s`) in the subagent
+> result so the orchestrator folds it into its own line. Independent of `--auto`:
+> a standalone `/issue-resolver <N> --auto` is *not* suppressed and still writes.
 
 ```bash
 # Only when --no-run-log is NOT set:
@@ -493,6 +557,7 @@ When invoked with `--auto` (or by `/auto-pilot`), the entire pipeline runs witho
 
 - **Environment:** Export `IDD_AUTO_MODE=1` before any shell snippet that consults it (`docs/pre-commit-security.md`).
 - **Workspace:** Always in-place. Skip Step 0e entirely — no `git worktree add` on the default resolution path. Run mandatory Repo Sync, then *0f — Create branch*.
+- **Complexity gate:** *Step 0g* runs in auto mode too — it reads the pre-work `Effort` band (no prompt) and selects `light`/`full` the same way, so trivial issues resolve on the fast path autonomously. Under `/auto-pilot` the selected `profile` is **returned** in the telemetry (with `--no-run-log`) and folded into auto-pilot's single run-log line; a standalone `--auto` run writes `profile` itself.
 - **Preflight:** Skip assignment guard. Log blocking labels as warnings, don't stop.
 - **Research:** If already resolved, close the issue with a comment and exit cleanly.
 - **Plan:** Auto-select the recommended option; design-confirm never appears — log the selection and proceed.

--- a/src/skills/issue-resolver/references/pipeline-steps.md
+++ b/src/skills/issue-resolver/references/pipeline-steps.md
@@ -206,6 +206,33 @@ If the researcher returns `already_resolved: true` or `pr_in_progress: true`:
 - Auto mode: close the issue with a comment and move on.
 - Interactive mode: inform the user and stop.
 
+### `light` profile — lighter research
+
+When *Step 0g* selected `profile = light` (`resolve.adaptive_effort` on, pre-work
+`Effort` band `XS`/`S` asserted), run a reduced research pass keyed to a trivial
+change:
+
+1. **Keep** the *Verify not already resolved* phase in full — this is
+   safety-critical and runs on every profile (a fast path must never skip the
+   already-fixed check).
+2. **Keep** a focused scan of the file(s) the issue obviously names or points at,
+   enough to write the change and its evidence.
+3. **Skip** the broad dependency trace (`trace_depth`), the git-history
+   domain-expert scan, and external solution research — a single-word/single-file
+   edit does not need them. Lowering this work is the token saving the profile
+   exists for.
+
+**Upgrade, never downgrade.** If the lighter pass still surfaces `high`/`complex`
+signals (the change touches far more than the band implied), revise the profile
+**upward** to `full` for the remaining steps and run Step 2's synthesizer and
+Step 4's full QA loop as usual. Never move a run from `full` down to `light` on a
+mid-pipeline signal — the pre-work gate is the only place `light` is chosen, and
+downgrading could truncate work already underway. Record the upgrade so the
+surfaced profile and the run-log `profile` reflect the final value.
+
+The delegation payload is otherwise unchanged; pass the researcher a note that a
+lighter, targeted scan is expected (mirroring the model/effort tier intent).
+
 ### Inline fallback
 
 If no Agent tool, execute research inline following the same phases described in `shared/agents/codebase-researcher.md`.
@@ -229,6 +256,36 @@ The synthesizer returns 3 options differing in scope:
 1. **Minimal fix** — smallest change
 2. **Balanced approach** — proper fix, reasonable scope (usually recommended)
 3. **Comprehensive refactor** — addresses root cause and technical debt
+
+### `light` profile — skip the synthesis
+
+When *Step 0g* selected `profile = light`, do **not** spawn the synthesizer at
+all — the 3-option comparison is overkill for a trivial change, and skipping the
+spawn is a direct token saving. Instead, derive a **direct minimal plan** inline
+from the Step 1 research:
+
+- The plan is the single obvious change that satisfies the acceptance criteria
+  (e.g. "update the copy string in `X`", "bump the timeout constant in `Y`").
+- Record it as the **selected option** with a one-line name and summary, so
+  Step 5's Decision Record has a real `Selected option` to lift and
+  `Options rejected` is simply "n/a — trivial change, direct plan (light profile)".
+- The **design-confirm checkpoint does not apply** — it fires only on
+  `overall_complexity: L`/`XL` or `overall_risk: High`, which the `light` path
+  (band `XS`/`S`) is by definition not.
+- **`approval_gate: comment-and-wait` does not present options on the `light`
+  path.** That gate exists to show the 3 synthesized options and wait for a pick,
+  but the `light` path produces none — so it proceeds with the direct minimal
+  plan **without** an option prompt (the same way the `light` path skips the
+  *Propose relevant skills* prompt). A maintainer who wants to approve every plan
+  regardless of size sets `resolve.adaptive_effort: false`, which pins the full
+  pipeline and restores the `comment-and-wait` option prompt.
+
+If Step 1 upgraded the profile to `full` (a `high`/`complex` signal), run the
+normal synthesizer spawn below instead — the `light` skip is only for runs that
+stayed `light` through research.
+
+The tracker line is unchanged (`[2/5] Plan  ✓ approach: {selected option name}`);
+`{selected option name}` is the direct minimal plan's name.
 
 ### Plan selection
 
@@ -476,7 +533,12 @@ Each cycle:
 
 ### Loop controls
 
-- **Max cycles:** `resolve.qa_max_cycles` (default: 5)
+- **Max cycles:** `resolve.qa_max_cycles` (default: 5). **`light` profile caps
+  this at 1** — a single review pass, one fix if blocking issues are found, then
+  proceed to Deliver. The reviewer spawn still runs on the `light` path (review is
+  reduced in depth, never skipped); only the *number* of review-fix iterations is
+  capped. (A profile upgraded to `full` in Step 1 uses the normal
+  `resolve.qa_max_cycles` cap.)
 - **Exit on clean:** stop as soon as review passes AND tests pass
 - **Exit on stagnation:** if the same issues appear in 2 consecutive cycles, stop and report
 

--- a/src/skills/issue-resolver/references/report-templates.md
+++ b/src/skills/issue-resolver/references/report-templates.md
@@ -24,6 +24,7 @@ Closes #{issue_number}
 - **Options rejected:** Option 1 — {one-line reason}; Option 3 — {reason}
 - **Selected option:** Option {N} — {name}
 - **Residual risk:** {what remains uncertain or accepted as known limitation, or "none identified"}
+- **Effort profile:** {"light — fast path (pre-work Effort {band}); synthesis skipped, QA capped at 1 cycle" when the run used the light profile; omit this line entirely on the full profile — the default — so it appears only when the fast path actually fired}
 - **Design-confirm:** {high-complexity issues only — "confirmed Option {N} at design-confirm checkpoint (complexity: {level})" in interactive mode, or "auto-selected Option {N} (complexity: {level})" in auto mode; omit this line for trivial/low/medium complexity}
 - **Reproduction:** {bug issues only — success: `<command>` confirmed red for the stated reason → regression test `<path>` (or "manual — no seam"); degraded: `not reproduced — <one-line reason> (fix applied without confirmed red; criterion marked unverified)`; omit for non-bug issues}
 
@@ -129,7 +130,7 @@ in the closing block:
 ```
   ◆ Resolve Pipeline
   ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
-  [0/5] Preflight    ✓ issue #42 open, not yet resolved
+  [0/5] Preflight    ✓ issue #42 open, not yet resolved, effort: full
   [1/5] Research     ✓ read 12 files, complexity: medium
   [2/5] Plan         ✓ option 2 selected: balanced refactor
   [3/5] Implement    ✓ 3 files changed, 8 unit tests, 2 e2e tests


### PR DESCRIPTION
Closes #240

## Summary

`/issue-resolver` and `/issue-pr-review` previously ran their full pipelines uniformly for every issue — a one-character copy tweak paid the same orchestration cost as a multi-subsystem change. This PR adds a **complexity-adaptive pipeline profile** so effort scales to the task: trivial work takes a fast path, complex or ambiguous work keeps the full treatment, and the mechanism degrades toward the fuller path whenever the signal is weak.

## Approach

**Reuse the existing `XS … XL` scale, add a second mechanism on top of it.** `docs/agent-model-effort.md` already tuned each spawned agent's *model/effort* (advisory, never changes control flow). This PR adds a distinct **pipeline profile** (`light` / `full`) to the same doc — it changes *which* steps run and *how many* cycles, keyed off a **pre-work** signal so the saving is real (deciding from a subagent's output would pay the dominant cost before choosing to go light).

- **Resolver** (Step 0g — Complexity gate): reads the issue's pre-work `Effort` band *before* any spawn. `light` (XS/S, asserted) runs a lighter Research pass (the already-resolved safety check still runs), skips the 3-option Plan synthesis for a direct minimal plan, skips propose-relevant-skills, and caps QA at 1 cycle. `full` is today's pipeline unchanged.
- **PR-review** (Step 1 — Depth gate): has no researcher, so it derives its own signal from the PR — diff size / files-changed / labels / the **linked issue's `Effort` band (same `XS … XL` scale)** — taking the *fuller* of any that disagree. `light` caps the review-fix loop at 1 and skips optional passes.
- **Safety floor:** the Decision Record + Acceptance Criteria Verification table always emit (durable memory is never dropped), and the AC + traceability hard-blocks always run at full strength. Ambiguous / low-confidence / missing signal → `full`. The profile may be revised *upward* mid-pipeline (research surfaces `high`/`complex`) but never downward.
- **Transparency:** the chosen profile is surfaced on the tracker line (`effort:` / `depth:`) and in `runs.jsonl` as an optional `profile` field, threaded through `/auto-pilot`'s single-writer run-log path.
- **Opt-out:** `resolve.adaptive_effort` and `review.adaptive_depth` (both default `true`) pin the full pipeline when set to `false`.

## Decision Record

- **Root cause:** the resolve and PR-review pipelines applied full-weight orchestration to every issue regardless of size — a typo fix spent the same time/tokens (research spawn, 3-option synthesis, up to 5 QA cycles) as a multi-subsystem change. No pre-work signal gated a lighter path.
- **Options considered:** Option 1 — gate a fast path on the *researcher's* complexity output; Option 2 — pre-work gate on the issue `Effort` band + a coarse two-state profile reusing the `XS … XL` scale, with an opt-out key; Option 3 — per-band fine-grained profiles (five gradations) with a new config surface.
- **Options rejected:** Option 1 — the researcher spawn is the dominant cost, so deciding from its output saves almost nothing (fails the "measurably reduces token cost" criterion). Option 3 — five gradations add config/branching surface for little gain over model/effort's existing per-agent scaling; a coarse switch is enough for the long tail of trivial work.
- **Selected option:** Option 2 — pre-work `Effort`-band gate, two profiles (`light`/`full`) on the shared scale, surfaced to the user, opt-out via two `*.adaptive_*` keys (default on).
- **Residual risk:** the fast path relies on the `Effort` band being reasonably accurate; a mis-estimated `XS`/`S` on a genuinely hard issue would take the light path — mitigated by (a) low-confidence/ambiguous bands falling to `full`, (b) the upgrade-never-downgrade rule when research surfaces `high`/`complex`, and (c) QA still running one real review pass with the hard-blocks intact. This is a docs/skills change with no runtime code; behavior is verified by the build gates and the shell test suite, not a program.

Analyzed at: `refactor/240-adaptive-effort-complexity @ dacbba4` (2026-07-13)

## Changes

| File | Change |
|------|--------|
| `docs/agent-model-effort.md` | New "Complexity → pipeline profile" section — light/full profiles on the shared XS…XL scale, pre-work-signal selection, ambiguous/low-confidence → full, upgrade-never-downgrade, surfacing, opt-out |
| `docs/config-schema.md` | Add `resolve.adaptive_effort` / `review.adaptive_depth` (Full Schema + Section Map + Defaults Table); add optional `runs.jsonl` `profile` field; reference agent-model-effort.md via full URL (avoids a doc→doc bundling cycle) |
| `src/skills/init-gitissue/templates/gitissue-template.yml` | Mirror both keys (build parity gate) |
| `src/skills/issue-resolver/SKILL.source.md` | Step 0g complexity gate + config default + per-step light-profile wiring (Steps 1–4) + auto-pilot note + `profile` in run-log/telemetry; version 0.16.1 → 0.17.0 |
| `src/skills/issue-resolver/references/pipeline-steps.md` | Full light-path mechanics (lighter Research, skip synthesis + comment-and-wait interaction, QA cap 1) |
| `src/skills/issue-resolver/references/report-templates.md` | `effort:` on the tracker line + conditional Decision-Record profile line |
| `src/skills/issue-pr-review/SKILL.source.md` | Step 1 depth gate + config default + review-loop wiring; version 2.4.1 → 2.5.0 |
| `src/skills/issue-pr-review/references/review-loop-mechanics.md` | Depth-gate mechanics + `light`-cap-wins-as-ceiling (min with auto-pilot's `review_cycles` override) |
| `src/skills/issue-pr-review/references/report-templates.md` | `depth:` on the tracker line |
| `src/skills/auto-pilot/SKILL.source.md` + `references/{subagent-prompts,run-log}.md` | Thread `profile` through the resolver/batch report-back and the single run-log line; version 2.4.0 → 2.4.1 |
| `src/skills/init-gitissue/SKILL.source.md` | Version 0.3.5 → 0.3.6 (template gained two keys) |
| `skills/**` | Rebuilt distribution (byte-deterministic) — bundled `docs/` copies + SKILL.md + references regenerated for every affected skill |
| `CHANGELOG.md` | Unreleased entry |

## Test Results

- Unit tests: n/a (skills-only project — no runtime code)
- Integration tests: **33 / 33** shell tests passed (`tests/test-*.sh`), including `test-config-schema-38`, `test-init-template-schema-parity`, `test-runs-jsonl`, `test-dependency-closure`, `test-build-determinism`
- Build: passed — `scripts/build.py` clean (parity, precheck-drift, closure, sanity gates all green; no cycle warnings); rebuild is byte-deterministic and leaves the tree clean (CI drift check will pass)
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| The resolve workflow classifies each issue's complexity and selects a proportionate level of effort **before doing the work** | pass | `issue-resolver` Step 0g reads the pre-work `Effort` band and selects `light`/`full` before any subagent spawn (`SKILL.source.md` *Step 0g — Complexity gate*; mechanism in `docs/agent-model-effort.md` → *Selecting the profile (pre-work signal)*) |
| Trivial tasks complete through a lighter path that **measurably reduces** time and token cost vs the full pipeline | pass | By construction: on `light`, the synthesizer spawn is skipped entirely (Step 2), the propose-skills sub-step is skipped (Step 3), and QA is capped 5→1 cycle (Step 4) — a strict subset of the full pipeline with fewer subagent spawns and cycles. Enumerated in `references/pipeline-steps.md`; no runtime exists in a skills repo to emit a token count, so the reduction is asserted by the removed work, not a measured figure |
| The PR-review workflow scales its review depth to **the same complexity signal** rather than full review for every change | pass | `issue-pr-review` Step 1 Depth gate consumes the **linked-issue `Effort` band (same `XS … XL` scale)** plus diff-size/files/labels, fuller-of-disagreeing, then caps the review-fix loop and skips optional passes on `light` (`SKILL.source.md` *Depth gate*; `references/review-loop-mechanics.md`) |
| Complex / multi-subsystem tasks keep the full process; mechanism **defaults to the fuller path when ambiguous** | pass | `M`/`L`/`XL` → `full`; `XS`/`S` low-confidence or absent band → `full`; any `full` vote wins in pr-review's fuller-of-disagreeing; upgrade-never-downgrade on mid-pipeline `high`/`complex` (`docs/agent-model-effort.md` → *Selecting the profile*, resolver Step 0g, pr-review Depth gate). This PR (Effort L) itself takes the `full` path |
| The complexity level chosen is **surfaced to the user** so the decision is transparent and reviewable | pass | Resolver `[0/5]` tracker line shows `effort: {light\|full}`; pr-review `[1/7]` shows `depth: {light\|full}`; both recorded in `runs.jsonl` `profile` (`docs/agent-model-effort.md` → *Surfacing the profile*; `docs/config-schema.md` runs.jsonl schema) |
